### PR TITLE
feat: implement github auth endpoint for students

### DIFF
--- a/backend/src/main/java/com/senior/spm/controller/AuthController.java
+++ b/backend/src/main/java/com/senior/spm/controller/AuthController.java
@@ -8,8 +8,12 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.server.ResponseStatusException;
 
+import com.senior.spm.controller.request.GithubLoginRequest;
 import com.senior.spm.controller.request.LoginRequest;
+import com.senior.spm.controller.response.GithubLoginResponse;
 import com.senior.spm.controller.response.LoginResponse;
+import com.senior.spm.entity.Student;
+import com.senior.spm.repository.StudentRepository;
 import com.senior.spm.repository.StaffUserRepository;
 import com.senior.spm.service.JWTService;
 
@@ -22,11 +26,14 @@ public class AuthController {
     private final JWTService jwtService;
     private final PasswordEncoder passwordEncoder;
     private final StaffUserRepository staffUserRepository;
+    private final StudentRepository studentRepository;
 
-    public AuthController(JWTService jwtService, PasswordEncoder passwordEncoder, StaffUserRepository staffUserRepository) {
+    public AuthController(JWTService jwtService, PasswordEncoder passwordEncoder, StaffUserRepository staffUserRepository,
+            StudentRepository studentRepository) {
         this.jwtService = jwtService;
         this.passwordEncoder = passwordEncoder;
         this.staffUserRepository = staffUserRepository;
+        this.studentRepository = studentRepository;
     }
 
     @PostMapping("/login")
@@ -48,5 +55,25 @@ public class AuthController {
         }
 
         throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "Invalid credentials");
+    }
+
+    @PostMapping("/github")
+    public GithubLoginResponse githubLogin(@Valid @RequestBody GithubLoginRequest request) {
+        var student = studentRepository.findByStudentId(request.getStudentId())
+                .or(() -> studentRepository.findByGithubUsername(request.getUsername()));
+
+        if (student.isEmpty()) {
+            throw new ResponseStatusException(HttpStatus.FORBIDDEN, "Student ID not recognized");
+        }
+
+        Student validStudent = student.get();
+        var token = jwtService.issueToken(validStudent);
+
+        var userInfo = new GithubLoginResponse.UserInfo(
+                validStudent.getId(),
+                validStudent.getGithubUsername(),
+                "Student");
+
+        return new GithubLoginResponse(token, userInfo);
     }
 }

--- a/backend/src/main/java/com/senior/spm/controller/request/GithubLoginRequest.java
+++ b/backend/src/main/java/com/senior/spm/controller/request/GithubLoginRequest.java
@@ -1,0 +1,20 @@
+package com.senior.spm.controller.request;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Data;
+
+@Data
+public class GithubLoginRequest {
+
+    @NotBlank
+    private String accessToken;
+
+    @NotBlank
+    private String username;
+
+    @NotBlank
+    private String email;
+
+    @NotBlank
+    private String studentId;
+}

--- a/backend/src/main/java/com/senior/spm/controller/response/GithubLoginResponse.java
+++ b/backend/src/main/java/com/senior/spm/controller/response/GithubLoginResponse.java
@@ -1,0 +1,23 @@
+package com.senior.spm.controller.response;
+
+import java.util.UUID;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class GithubLoginResponse {
+
+    private String token;
+    private UserInfo userInfo;
+
+    @Data
+    @AllArgsConstructor
+    public static class UserInfo {
+
+        private UUID id;
+        private String githubUsername;
+        private String role;
+    }
+}

--- a/backend/src/main/java/com/senior/spm/repository/StudentRepository.java
+++ b/backend/src/main/java/com/senior/spm/repository/StudentRepository.java
@@ -1,5 +1,6 @@
 package com.senior.spm.repository;
 
+import java.util.Optional;
 import java.util.UUID;
 
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -11,4 +12,8 @@ import com.senior.spm.entity.Student;
 public interface StudentRepository extends JpaRepository<Student, UUID> {
 
     boolean existsByStudentId(String studentId);
+
+    Optional<Student> findByStudentId(String studentId);
+
+    Optional<Student> findByGithubUsername(String githubUsername);
 }


### PR DESCRIPTION
Implemented POST /api/auth/github endpoint.

Added GithubLoginRequest to receive access token, username, email, and studentId.

Added eligibility check via StudentRepository (returns 403 if not found).

Generates and returns a JWT with the "Student" role for valid logins.