### PR TITLE
test: add Postman tests for coordinator setup flow

### DIFF
--- a/backend/tests/postman/Coordinator QA Tests.postman_collection.json
+++ b/backend/tests/postman/Coordinator QA Tests.postman_collection.json
@@ -1,0 +1,586 @@
+{
+  "info": {
+    "_postman_id": "99b11afc-9b9a-478a-8c5f-f6b42b8dc225",
+    "name": "Coordinator QA Tests",
+    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
+    "_exporter_id": "52978385",
+    "_collection_link": "https://go.postman.co/collection/52978385-99b11afc-9b9a-478a-8c5f-f6b42b8dc225?source=collection_link"
+  },
+  "item": [
+    {
+      "name": "Student Upload - Unauthorized (403)",
+      "event": [
+        {
+          "listen": "test",
+          "script": {
+            "exec": [
+              "pm.test(\"Unauthorized request should return 403\", function () {\r",
+              "    pm.response.to.have.status(403);\r",
+              "});"
+            ],
+            "type": "text/javascript",
+            "packages": {},
+            "requests": {}
+          }
+        }
+      ],
+      "request": {
+        "method": "POST",
+        "header": [],
+        "body": {
+          "mode": "raw",
+          "raw": "{\r\n  \"studentIds\": [\"12345678901\", \"12345678902\"]\r\n}",
+          "options": {
+            "raw": {
+              "language": "json"
+            }
+          }
+        },
+        "url": {
+          "raw": "http://localhost:8080/api/coordinator/students/upload",
+          "protocol": "http",
+          "host": [
+            "localhost"
+          ],
+          "port": "8080",
+          "path": [
+            "api",
+            "coordinator",
+            "students",
+            "upload"
+          ]
+        }
+      },
+      "response": []
+    },
+    {
+      "name": "Student Upload - Success (201)",
+      "event": [
+        {
+          "listen": "test",
+          "script": {
+            "exec": [
+              "pm.test(\"Authorized coordinator request should return 201\", function () {\r",
+              "    pm.response.to.have.status(201);\r",
+              "});"
+            ],
+            "type": "text/javascript",
+            "packages": {},
+            "requests": {}
+          }
+        }
+      ],
+      "request": {
+        "auth": {
+          "type": "bearer",
+          "bearer": [
+            {
+              "key": "token",
+              "value": "{{token}}",
+              "type": "string"
+            }
+          ]
+        },
+        "method": "POST",
+        "header": [],
+        "body": {
+          "mode": "raw",
+          "raw": "{\r\n  \"studentIds\": [\"12345678905\", \"12345678906\"]\r\n}",
+          "options": {
+            "raw": {
+              "language": "json"
+            }
+          }
+        },
+        "url": {
+          "raw": "http://localhost:8080/api/coordinator/students/upload",
+          "protocol": "http",
+          "host": [
+            "localhost"
+          ],
+          "port": "8080",
+          "path": [
+            "api",
+            "coordinator",
+            "students",
+            "upload"
+          ]
+        }
+      },
+      "response": []
+    },
+    {
+      "name": "Login - Coordinator",
+      "event": [
+        {
+          "listen": "test",
+          "script": {
+            "exec": [
+              "pm.test(\"Login should return 200\", function () {\r",
+              "    pm.response.to.have.status(200);\r",
+              "});\r",
+              "\r",
+              "const jsonData = pm.response.json();\r",
+              "\r",
+              "pm.test(\"Token should exist\", function () {\r",
+              "    pm.expect(jsonData.token).to.exist;\r",
+              "});\r",
+              "\r",
+              "pm.collectionVariables.set(\"token\", jsonData.token);"
+            ],
+            "type": "text/javascript",
+            "packages": {},
+            "requests": {}
+          }
+        }
+      ],
+      "request": {
+        "method": "POST",
+        "header": [],
+        "body": {
+          "mode": "raw",
+          "raw": "{\r\n  \"mail\": \"coordinator@test.com\",\r\n  \"password\": \"test\"\r\n}",
+          "options": {
+            "raw": {
+              "language": "json"
+            }
+          }
+        },
+        "url": {
+          "raw": "http://localhost:8080/api/auth/login",
+          "protocol": "http",
+          "host": [
+            "localhost"
+          ],
+          "port": "8080",
+          "path": [
+            "api",
+            "auth",
+            "login"
+          ]
+        }
+      },
+      "response": []
+    },
+    {
+      "name": "Student Upload - Duplicate IDs (400)",
+      "event": [
+        {
+          "listen": "test",
+          "script": {
+            "exec": [
+              "pm.test(\"Duplicate IDs should return 400\", function () {\r",
+              "    pm.response.to.have.status(400);\r",
+              "});"
+            ],
+            "type": "text/javascript",
+            "packages": {},
+            "requests": {}
+          }
+        }
+      ],
+      "request": {
+        "auth": {
+          "type": "bearer",
+          "bearer": [
+            {
+              "key": "token",
+              "value": "{{token}}",
+              "type": "string"
+            }
+          ]
+        },
+        "method": "POST",
+        "header": [],
+        "body": {
+          "mode": "raw",
+          "raw": "{\r\n  \"studentIds\": [\"12345678905\", \"12345678905\"]\r\n}",
+          "options": {
+            "raw": {
+              "language": "json"
+            }
+          }
+        },
+        "url": {
+          "raw": "http://localhost:8080/api/coordinator/students/upload",
+          "protocol": "http",
+          "host": [
+            "localhost"
+          ],
+          "port": "8080",
+          "path": [
+            "api",
+            "coordinator",
+            "students",
+            "upload"
+          ]
+        }
+      },
+      "response": []
+    },
+    {
+      "name": "Student Upload - Invalid Format (400)",
+      "event": [
+        {
+          "listen": "test",
+          "script": {
+            "exec": [
+              "pm.test(\"Invalid student ID format should return 400\", function () {\r",
+              "    pm.response.to.have.status(400);\r",
+              "});"
+            ],
+            "type": "text/javascript",
+            "packages": {},
+            "requests": {}
+          }
+        }
+      ],
+      "request": {
+        "method": "POST",
+        "header": [],
+        "body": {
+          "mode": "raw",
+          "raw": "{\r\n  \"studentIds\": [\"123\"]\r\n}",
+          "options": {
+            "raw": {
+              "language": "json"
+            }
+          }
+        },
+        "url": {
+          "raw": "http://localhost:8080/api/coordinator/students/upload",
+          "protocol": "http",
+          "host": [
+            "localhost"
+          ],
+          "port": "8080",
+          "path": [
+            "api",
+            "coordinator",
+            "students",
+            "upload"
+          ]
+        }
+      },
+      "response": []
+    },
+    {
+      "name": "Student Upload - Empty List (400)",
+      "event": [
+        {
+          "listen": "test",
+          "script": {
+            "exec": [
+              "pm.test(\"Empty student list should return 400\", function () {\r",
+              "    pm.response.to.have.status(400);\r",
+              "});"
+            ],
+            "type": "text/javascript",
+            "packages": {},
+            "requests": {}
+          }
+        }
+      ],
+      "request": {
+        "auth": {
+          "type": "bearer",
+          "bearer": [
+            {
+              "key": "token",
+              "value": "{{token}}",
+              "type": "string"
+            }
+          ]
+        },
+        "method": "POST",
+        "header": [],
+        "body": {
+          "mode": "raw",
+          "raw": "{\r\n  \"studentIds\": []\r\n}",
+          "options": {
+            "raw": {
+              "language": "json"
+            }
+          }
+        },
+        "url": {
+          "raw": "http://localhost:8080/api/coordinator/students/upload",
+          "protocol": "http",
+          "host": [
+            "localhost"
+          ],
+          "port": "8080",
+          "path": [
+            "api",
+            "coordinator",
+            "students",
+            "upload"
+          ]
+        }
+      },
+      "response": []
+    },
+    {
+      "name": "Student Upload - Existing ID (400)",
+      "event": [
+        {
+          "listen": "test",
+          "script": {
+            "exec": [
+              "pm.test(\"Existing student ID should return 400\", function () {\r",
+              "    pm.response.to.have.status(400);\r",
+              "});"
+            ],
+            "type": "text/javascript",
+            "packages": {},
+            "requests": {}
+          }
+        }
+      ],
+      "request": {
+        "auth": {
+          "type": "bearer",
+          "bearer": [
+            {
+              "key": "token",
+              "value": "{{token}}",
+              "type": "string"
+            }
+          ]
+        },
+        "method": "POST",
+        "header": [],
+        "body": {
+          "mode": "raw",
+          "raw": "{\r\n  \"studentIds\": [\"23070006018\"]\r\n}",
+          "options": {
+            "raw": {
+              "language": "json"
+            }
+          }
+        },
+        "url": {
+          "raw": "http://localhost:8080/api/coordinator/students/upload",
+          "protocol": "http",
+          "host": [
+            "localhost"
+          ],
+          "port": "8080",
+          "path": [
+            "api",
+            "coordinator",
+            "students",
+            "upload"
+          ]
+        }
+      },
+      "response": []
+    },
+    {
+      "name": "Create Deliverable - Unauthorized (403)",
+      "event": [
+        {
+          "listen": "test",
+          "script": {
+            "exec": [
+              "pm.test(\"Unauthorized deliverable creation should return 403\", function () {\r",
+              "    pm.response.to.have.status(403);\r",
+              "});"
+            ],
+            "type": "text/javascript",
+            "packages": {},
+            "requests": {}
+          }
+        }
+      ],
+      "request": {
+        "method": "POST",
+        "header": [],
+        "body": {
+          "mode": "raw",
+          "raw": "{\r\n  \"name\": \"Unauthorized Deliverable\",\r\n  \"type\": \"Proposal\",\r\n  \"submissionDeadline\": \"2026-05-01T10:00:00\",\r\n  \"reviewDeadline\": \"2026-05-02T10:00:00\"\r\n}",
+          "options": {
+            "raw": {
+              "language": "json"
+            }
+          }
+        },
+        "url": {
+          "raw": "http://localhost:8080/api/coordinator/deliverables",
+          "protocol": "http",
+          "host": [
+            "localhost"
+          ],
+          "port": "8080",
+          "path": [
+            "api",
+            "coordinator",
+            "deliverables"
+          ]
+        }
+      },
+      "response": []
+    },
+    {
+      "name": "Create Deliverable - Success (201)",
+      "event": [
+        {
+          "listen": "test",
+          "script": {
+            "exec": [
+              "pm.test(\"Valid deliverable should return 201\", function () {\r",
+              "    pm.response.to.have.status(201);\r",
+              "});"
+            ],
+            "type": "text/javascript",
+            "packages": {},
+            "requests": {}
+          }
+        }
+      ],
+      "request": {
+        "auth": {
+          "type": "bearer",
+          "bearer": [
+            {
+              "key": "token",
+              "value": "{{token}}",
+              "type": "string"
+            }
+          ]
+        },
+        "method": "POST",
+        "header": [],
+        "body": {
+          "mode": "raw",
+          "raw": "{\r\n  \"name\": \"Test Deliverable 1\",\r\n  \"type\": \"Proposal\",\r\n  \"submissionDeadline\": \"2026-05-01T10:00:00\",\r\n  \"reviewDeadline\": \"2026-05-02T10:00:00\"\r\n}",
+          "options": {
+            "raw": {
+              "language": "json"
+            }
+          }
+        },
+        "url": {
+          "raw": "http://localhost:8080/api/coordinator/deliverables",
+          "protocol": "http",
+          "host": [
+            "localhost"
+          ],
+          "port": "8080",
+          "path": [
+            "api",
+            "coordinator",
+            "deliverables"
+          ]
+        }
+      },
+      "response": []
+    },
+    {
+      "name": "Create Deliverable - Reversed Deadlines (400)",
+      "event": [
+        {
+          "listen": "test",
+          "script": {
+            "exec": [
+              "pm.test(\"Reversed deadlines should return 400\", function () {\r",
+              "    pm.response.to.have.status(400);\r",
+              "});"
+            ],
+            "type": "text/javascript",
+            "packages": {},
+            "requests": {}
+          }
+        }
+      ],
+      "request": {
+        "method": "POST",
+        "header": [],
+        "body": {
+          "mode": "raw",
+          "raw": "{\r\n  \"name\": \"Invalid Deliverable\",\r\n  \"type\": \"Proposal\",\r\n  \"submissionDeadline\": \"2026-05-03T10:00:00\",\r\n  \"reviewDeadline\": \"2026-05-01T10:00:00\"\r\n}",
+          "options": {
+            "raw": {
+              "language": "json"
+            }
+          }
+        },
+        "url": {
+          "raw": "http://localhost:8080/api/coordinator/deliverables",
+          "protocol": "http",
+          "host": [
+            "localhost"
+          ],
+          "port": "8080",
+          "path": [
+            "api",
+            "coordinator",
+            "deliverables"
+          ]
+        }
+      },
+      "response": []
+    },
+    {
+      "name": "Create Deliverable - Missing Field (400)",
+      "event": [
+        {
+          "listen": "test",
+          "script": {
+            "exec": [
+              "pm.test(\"Missing required field should return 400\", function () {\r",
+              "    pm.response.to.have.status(400);\r",
+              "});"
+            ],
+            "type": "text/javascript",
+            "packages": {},
+            "requests": {}
+          }
+        }
+      ],
+      "request": {
+        "auth": {
+          "type": "bearer",
+          "bearer": [
+            {
+              "key": "token",
+              "value": "{{token}}",
+              "type": "string"
+            }
+          ]
+        },
+        "method": "POST",
+        "header": [],
+        "body": {
+          "mode": "raw",
+          "raw": "{\r\n  \"type\": \"Proposal\",\r\n  \"submissionDeadline\": \"2026-05-01T10:00:00\",\r\n  \"reviewDeadline\": \"2026-05-02T10:00:00\"\r\n}",
+          "options": {
+            "raw": {
+              "language": "json"
+            }
+          }
+        },
+        "url": {
+          "raw": "http://localhost:8080/api/coordinator/deliverables",
+          "protocol": "http",
+          "host": [
+            "localhost"
+          ],
+          "port": "8080",
+          "path": [
+            "api",
+            "coordinator",
+            "deliverables"
+          ]
+        }
+      },
+      "response": []
+    }
+  ],
+  "variable": [
+    {
+      "key": "token",
+      "value": ""
+    }
+  ]
+}

--- a/backend/tests/postman/README.md
+++ b/backend/tests/postman/README.md
@@ -1,0 +1,23 @@
+# Coordinator QA Tests
+
+## Description
+Postman collection for testing Coordinator setup flow.
+
+## Covered Scenarios
+
+### Student Upload
+- Unauthorized (403)
+- Success (201)
+- Duplicate IDs (400)
+- Invalid Format (400)
+- Empty List (400)
+- Existing ID (400)
+
+### Deliverable
+- Unauthorized (403)
+- Success (201)
+- Reversed Deadlines (400)
+- Missing Field (400)
+
+## Limitations
+Rubric and deliverable weight endpoints were not available in the current backend implementation during testing, so they are not included in this collection.


### PR DESCRIPTION
Added Postman QA tests for Coordinator setup flow.

Covered:
- Student upload
- Deliverable creation

Tested cases include:
- Happy path
- Sad path
- 400 and 403 responses
- Business logic cases such as duplicate student IDs and reversed deadlines

Postman collection is located at:
backend/tests/postman/

Note:
Rubric and deliverable weight endpoints were referenced in the issue scope, but these endpoints were not available in the current backend implementation at the time of testing, so they could not be tested.