### PR TITLE
feat: add partial update endpoint for deliverables

### DIFF
--- a/backend/src/main/java/com/senior/spm/controller/CoordinatorController.java
+++ b/backend/src/main/java/com/senior/spm/controller/CoordinatorController.java
@@ -124,7 +124,6 @@ public class CoordinatorController {
         return ResponseEntity.status(HttpStatus.CREATED).build();
     }
 
-
     @PatchMapping("/deliverables/{id}")
     public ResponseEntity<?> updateDeliverable(@PathVariable UUID id,
             @RequestBody UpdateDeliverableRequest request) {
@@ -155,6 +154,7 @@ public class CoordinatorController {
         // Save and return the updated deliverable
         Deliverable updatedDeliverable = deliverableRepository.save(existingDeliverable);
         return ResponseEntity.status(HttpStatus.OK).body(updatedDeliverable);
+    }
 
     @PostMapping("/publish")
     public ResponseEntity<?> publishSystem() {

--- a/backend/src/main/java/com/senior/spm/controller/CoordinatorController.java
+++ b/backend/src/main/java/com/senior/spm/controller/CoordinatorController.java
@@ -14,6 +14,7 @@ import org.springframework.web.bind.annotation.RestController;
 import com.senior.spm.controller.request.CreateDeliverableRequest;
 import com.senior.spm.controller.request.SprintRequest;
 import com.senior.spm.controller.request.StudentUploadRequest;
+import com.senior.spm.controller.request.UpdateDeliverableRequest;
 import com.senior.spm.controller.request.UpdateSprintTargetRequest;
 import com.senior.spm.controller.response.ErrorMessage;
 import com.senior.spm.entity.Deliverable;
@@ -117,5 +118,37 @@ public class CoordinatorController {
         studentRepository.saveAll(students);
 
         return ResponseEntity.status(HttpStatus.CREATED).build();
+    }
+
+    @PatchMapping("/deliverables/{id}")
+    public ResponseEntity<?> updateDeliverable(@PathVariable UUID id,
+            @RequestBody UpdateDeliverableRequest request) {
+        // Check if deliverable exists
+        var deliverable = deliverableRepository.findById(id);
+        if (deliverable.isEmpty()) {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).body(new ErrorMessage("Deliverable not found with ID: " + id));
+        }
+
+        // Update non-null fields
+        Deliverable existingDeliverable = deliverable.get();
+        if (request.getName() != null) {
+            existingDeliverable.setName(request.getName());
+        }
+        if (request.getType() != null) {
+            existingDeliverable.setType(request.getType());
+        }
+        if (request.getSubmissionDeadline() != null) {
+            existingDeliverable.setSubmissionDeadline(request.getSubmissionDeadline());
+        }
+        if (request.getReviewDeadline() != null) {
+            existingDeliverable.setReviewDeadline(request.getReviewDeadline());
+        }
+        if (request.getWeight() != null) {
+            existingDeliverable.setWeight(request.getWeight());
+        }
+
+        // Save and return the updated deliverable
+        Deliverable updatedDeliverable = deliverableRepository.save(existingDeliverable);
+        return ResponseEntity.status(HttpStatus.OK).body(updatedDeliverable);
     }
 }

--- a/backend/src/main/java/com/senior/spm/controller/request/UpdateDeliverableRequest.java
+++ b/backend/src/main/java/com/senior/spm/controller/request/UpdateDeliverableRequest.java
@@ -1,0 +1,27 @@
+package com.senior.spm.controller.request;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+import com.senior.spm.entity.Deliverable.DeliverableType;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class UpdateDeliverableRequest {
+
+    private String name;
+
+    private DeliverableType type;
+
+    private LocalDateTime submissionDeadline;
+
+    private LocalDateTime reviewDeadline;
+
+    private BigDecimal weight;
+
+}


### PR DESCRIPTION
Added PATCH /api/coordinator/deliverables/{id} endpoint for partial updates.

Created UpdateDeliverableRequest DTO with nullable fields to allow updating only specific data.

Implemented RBAC to ensure only COORDINATOR role can access.

Added logic to return 404 Not Found if the deliverable ID does not exist.