### PR TITLE
feat: implement external validation services for jira and github

### DIFF
--- a/backend/src/main/java/com/senior/spm/config/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/senior/spm/config/GlobalExceptionHandler.java
@@ -12,6 +12,7 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 import com.senior.spm.controller.response.ErrorMessage;
+import com.senior.spm.exception.ExternalToolValidationException;
 
 @RestControllerAdvice
 public class GlobalExceptionHandler {
@@ -35,6 +36,16 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(RuntimeException.class)
     public ResponseEntity<ErrorMessage> handleRuntimeException(RuntimeException ex) {
-        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(new ErrorMessage("An unexpected error occurred: " + ex.getMessage()));
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                .body(new ErrorMessage("An unexpected error occurred: " + ex.getMessage()));
+    }
+
+    // Maps JiraValidationException and GitHubValidationException (both extend
+    // ExternalToolValidationException) to HTTP 422 Unprocessable Entity.
+    // The exception message is the exact user-facing string defined in the API spec
+    // (e.g. "JIRA validation failed: API token is invalid or expired").
+    @ExceptionHandler(ExternalToolValidationException.class)
+    public ResponseEntity<ErrorMessage> handleExternalToolValidation(ExternalToolValidationException ex) {
+        return ResponseEntity.status(HttpStatus.UNPROCESSABLE_ENTITY).body(new ErrorMessage(ex.getMessage()));
     }
 }

--- a/backend/src/main/java/com/senior/spm/config/RestTemplateConfig.java
+++ b/backend/src/main/java/com/senior/spm/config/RestTemplateConfig.java
@@ -1,0 +1,27 @@
+package com.senior.spm.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.client.SimpleClientHttpRequestFactory;
+import org.springframework.web.client.RestTemplate;
+
+/**
+ * Configures a RestTemplate bean with a strict 5-second timeout
+ * for all outbound HTTP calls to external APIs (JIRA, GitHub).
+ *
+ * Acceptance criterion: "Services strictly enforce a 5-second timeout."
+ * Issue #48 — [Backend] External Tool Validation Services
+ */
+@Configuration
+public class RestTemplateConfig {
+
+    private static final int TIMEOUT_MS = 5_000;
+
+    @Bean
+    public RestTemplate restTemplate() {
+        var factory = new SimpleClientHttpRequestFactory();
+        factory.setConnectTimeout(TIMEOUT_MS);
+        factory.setReadTimeout(TIMEOUT_MS);
+        return new RestTemplate(factory);
+    }
+}

--- a/backend/src/main/java/com/senior/spm/exception/ExternalToolValidationException.java
+++ b/backend/src/main/java/com/senior/spm/exception/ExternalToolValidationException.java
@@ -1,0 +1,12 @@
+package com.senior.spm.exception;
+
+/**
+ * Base exception for external tool validation failures (JIRA, GitHub).
+ * Subclasses carry the exact user-facing 422 message defined in the API spec.
+ */
+public class ExternalToolValidationException extends RuntimeException {
+
+    public ExternalToolValidationException(String message) {
+        super(message);
+    }
+}

--- a/backend/src/main/java/com/senior/spm/exception/GitHubValidationException.java
+++ b/backend/src/main/java/com/senior/spm/exception/GitHubValidationException.java
@@ -1,0 +1,12 @@
+package com.senior.spm.exception;
+
+/**
+ * Thrown by GitHubValidationService when a live GitHub API call fails.
+ * Maps to HTTP 422 Unprocessable Entity.
+ */
+public class GitHubValidationException extends ExternalToolValidationException {
+
+    public GitHubValidationException(String message) {
+        super(message);
+    }
+}

--- a/backend/src/main/java/com/senior/spm/exception/JiraValidationException.java
+++ b/backend/src/main/java/com/senior/spm/exception/JiraValidationException.java
@@ -1,0 +1,12 @@
+package com.senior.spm.exception;
+
+/**
+ * Thrown by JiraValidationService when a live JIRA API call fails.
+ * Maps to HTTP 422 Unprocessable Entity.
+ */
+public class JiraValidationException extends ExternalToolValidationException {
+
+    public JiraValidationException(String message) {
+        super(message);
+    }
+}

--- a/backend/src/main/java/com/senior/spm/service/GitHubValidationService.java
+++ b/backend/src/main/java/com/senior/spm/service/GitHubValidationService.java
@@ -1,0 +1,115 @@
+package com.senior.spm.service;
+
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.client.ResourceAccessException;
+import org.springframework.web.client.RestTemplate;
+
+import com.senior.spm.exception.GitHubValidationException;
+
+/**
+ * Validates GitHub credentials by making two sequential live HTTP calls to the
+ * GitHub REST API.
+ *
+ * Called by GroupService.bindGitHub()
+ * Nothing is persisted until this service returns without throwing.
+ *
+ * Call sequence:
+ * 1. GET /orgs/{githubOrgName} → verifies org existence + PAT validity
+ * 2. GET /orgs/{githubOrgName}/repos → verifies the PAT has 'repo' scope
+ *
+ */
+@Service
+public class GitHubValidationService {
+
+    private static final String GITHUB_API_BASE = "https://api.github.com";
+
+    private final RestTemplate restTemplate;
+
+    public GitHubValidationService(RestTemplate restTemplate) {
+        this.restTemplate = restTemplate;
+    }
+
+    /**
+     * Runs the two-step GitHub validation.
+     *
+     * @throws GitHubValidationException on any failure (401 → invalid PAT,
+     *                                   404 → org not found,
+     *                                   403 on second call → missing 'repo' scope)
+     */
+    public void validate(String githubOrgName, String githubPat) {
+        var headers = new HttpHeaders();
+        // GitHub REST API v3 accepts a PAT as a Bearer token.
+        headers.set(HttpHeaders.AUTHORIZATION, "Bearer " + githubPat);
+        var entity = new HttpEntity<>(headers);
+
+        // Step 1: verify org existence and PAT validity
+        // If this call fails for any reason, Step 2 is NOT executed (fail-fast).
+        callStep1OrgExists(githubOrgName, entity);
+
+        // Step 2: verify the PAT has 'repo' scope
+        // Only reached when Step 1 succeeds (200 OK).
+        callStep2RepoScope(githubOrgName, entity);
+    }
+
+    /**
+     * GET /orgs/{githubOrgName}
+     * 401 → invalid PAT, 404 → org not found, anything else → rethrow as
+     * unreachable.
+     */
+    private void callStep1OrgExists(String githubOrgName, HttpEntity<?> entity) {
+        var url = GITHUB_API_BASE + "/orgs/" + githubOrgName;
+        try {
+            restTemplate.exchange(url, HttpMethod.GET, entity, Void.class);
+
+        } catch (HttpClientErrorException ex) {
+            HttpStatus status = HttpStatus.resolve(ex.getStatusCode().value());
+
+            if (status == HttpStatus.UNAUTHORIZED) {
+                throw new GitHubValidationException("GitHub validation failed: PAT is invalid or expired");
+            }
+
+            if (status == HttpStatus.NOT_FOUND) {
+                throw new GitHubValidationException(
+                        "GitHub validation failed: Organization '" + githubOrgName + "' not found");
+            }
+
+            // Any other 4xx from the first call — treat as a PAT / auth problem.
+            throw new GitHubValidationException("GitHub validation failed: PAT is invalid or expired");
+
+        } catch (ResourceAccessException ex) {
+            // Timeout or network failure on the first call — skip Step 2 (fail-fast).
+            throw new GitHubValidationException("GitHub validation failed: PAT is invalid or expired");
+        }
+    }
+
+    /**
+     * GET /orgs/{githubOrgName}/repos?per_page=1
+     * GitHub returns 403 (not 401) when the PAT lacks 'repo' scope.
+     */
+    private void callStep2RepoScope(String githubOrgName, HttpEntity<?> entity) {
+        var url = GITHUB_API_BASE + "/orgs/" + githubOrgName + "/repos?per_page=1";
+        try {
+            restTemplate.exchange(url, HttpMethod.GET, entity, Void.class);
+
+        } catch (HttpClientErrorException ex) {
+            HttpStatus status = HttpStatus.resolve(ex.getStatusCode().value());
+
+            if (status == HttpStatus.FORBIDDEN) {
+                // GitHub returns 403 specifically when the PAT is missing the 'repo' scope.
+                throw new GitHubValidationException("GitHub validation failed: PAT lacks required 'repo' scope");
+            }
+
+            // Unexpected error on the second call.
+            throw new GitHubValidationException("GitHub validation failed: PAT lacks required 'repo' scope");
+
+        } catch (ResourceAccessException ex) {
+            // Timeout on the second call — scope check inconclusive; reject to be safe.
+            throw new GitHubValidationException("GitHub validation failed: PAT lacks required 'repo' scope");
+        }
+    }
+}

--- a/backend/src/main/java/com/senior/spm/service/JiraValidationService.java
+++ b/backend/src/main/java/com/senior/spm/service/JiraValidationService.java
@@ -1,0 +1,72 @@
+package com.senior.spm.service;
+
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.client.ResourceAccessException;
+import org.springframework.web.client.RestTemplate;
+
+import com.senior.spm.exception.JiraValidationException;
+
+/**
+ * Validates JIRA credentials by making a single live HTTP call to the JIRA REST
+ * API.
+ * Called by GroupService.bindJira()
+ * Nothing is persisted until this service returns without throwing.
+ *
+ */
+@Service
+public class JiraValidationService {
+
+    private final RestTemplate restTemplate;
+
+    public JiraValidationService(RestTemplate restTemplate) {
+        this.restTemplate = restTemplate;
+    }
+
+    /**
+     * Performs a single GET against:
+     * {jiraSpaceUrl}/rest/api/3/project/{jiraProjectKey}
+     *
+     * @throws JiraValidationException on any failure (401/403 → invalid token,
+     *                                 404 → project key not found,
+     *                                 timeout/network → unreachable)
+     */
+    public void validate(String jiraSpaceUrl, String jiraProjectKey, String jiraApiToken) {
+        var url = jiraSpaceUrl.stripTrailing() + "/rest/api/3/project/" + jiraProjectKey;
+
+        var headers = new HttpHeaders();
+        // JIRA Cloud accepts a Bearer token; on-prem may need Basic – Bearer covers
+        // both cases here.
+        headers.set(HttpHeaders.AUTHORIZATION, "Bearer " + jiraApiToken);
+        var entity = new HttpEntity<>(headers);
+
+        try {
+            restTemplate.exchange(url, HttpMethod.GET, entity, Void.class);
+
+        } catch (HttpClientErrorException ex) {
+            HttpStatus status = HttpStatus.resolve(ex.getStatusCode().value());
+
+            if (status == HttpStatus.UNAUTHORIZED || status == HttpStatus.FORBIDDEN) {
+                // JIRA returns 401 for bad tokens and 403 for insufficient permissions.
+                throw new JiraValidationException("JIRA validation failed: API token is invalid or expired");
+            }
+
+            if (status == HttpStatus.NOT_FOUND) {
+                // The project key does not exist in the given JIRA space.
+                throw new JiraValidationException(
+                        "JIRA validation failed: Project key '" + jiraProjectKey + "' not found");
+            }
+
+            // Any other 4xx — treat as unreachable / misconfigured URL.
+            throw new JiraValidationException("JIRA validation failed: JIRA space URL is unreachable");
+
+        } catch (ResourceAccessException ex) {
+            // Covers connection timeout, read timeout, DNS failure, etc.
+            throw new JiraValidationException("JIRA validation failed: JIRA space URL is unreachable");
+        }
+    }
+}


### PR DESCRIPTION
Built REST clients via JiraValidationService and GitHubValidationService to ping external APIs and verify credentials.

Configured a strict 5-second timeout for all external API REST requests.

Added fail-fast logic for GitHub API to skip the repo scope API check if the org check fails.

Mapped external API HTTP failures to 422 Unprocessable Entity via GlobalExceptionHandler.

Resolves #48
