### PR TITLE
feat: [Backend] Implement coordinator deliverable weight, rubric, and sprint-deliverable mapping endpoints

### DIFF
--- a/backend/src/main/java/com/senior/spm/config/SecurityConfig.java
+++ b/backend/src/main/java/com/senior/spm/config/SecurityConfig.java
@@ -33,6 +33,7 @@ public class SecurityConfig {
                 .requestMatchers("/api/test/**").permitAll()
                 .requestMatchers(HttpMethod.PATCH, "/api/coordinator/deliverables/*/weight").hasRole("Coordinator")
                 .requestMatchers(HttpMethod.POST, "/api/coordinator/deliverables/*/rubric").hasRole("Coordinator")
+                .requestMatchers(HttpMethod.POST, "/api/coordinator/sprints/*/deliverable-mapping").hasRole("Coordinator")
                 .anyRequest().authenticated()
             )
             .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);

--- a/backend/src/main/java/com/senior/spm/config/SecurityConfig.java
+++ b/backend/src/main/java/com/senior/spm/config/SecurityConfig.java
@@ -2,19 +2,18 @@ package com.senior.spm.config;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
+import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
-import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
-import org.springframework.web.cors.CorsConfigurationSource;
 
 import com.senior.spm.filter.JwtAuthenticationFilter;
 
 @Configuration
-@EnableWebSecurity
 public class SecurityConfig {
 
     private final JwtAuthenticationFilter jwtAuthenticationFilter;
@@ -24,21 +23,24 @@ public class SecurityConfig {
     }
 
     @Bean
-    public PasswordEncoder passwordEncoder() {
-        return new BCryptPasswordEncoder();
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        http
+            .csrf(csrf -> csrf.disable())
+            .cors(Customizer.withDefaults())
+            .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+            .authorizeHttpRequests(auth -> auth
+                .requestMatchers("/api/auth/**").permitAll()
+                .requestMatchers("/api/test/**").permitAll()
+                .requestMatchers(HttpMethod.PATCH, "/api/coordinator/deliverables/*/weight").hasRole("Coordinator")
+                .anyRequest().authenticated()
+            )
+            .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
+
+        return http.build();
     }
 
     @Bean
-    public SecurityFilterChain filterChain(HttpSecurity http, CorsConfigurationSource corsConfigurationSource) throws Exception {
-        return http
-                .cors(cors -> cors.configurationSource(corsConfigurationSource))
-                .csrf(csrf -> csrf.disable())
-                .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
-                .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
-                .authorizeHttpRequests(
-                        auth -> auth
-                                .requestMatchers("/api/auth/**").permitAll()
-                                .anyRequest().authenticated())
-                .build();
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
     }
 }

--- a/backend/src/main/java/com/senior/spm/config/SecurityConfig.java
+++ b/backend/src/main/java/com/senior/spm/config/SecurityConfig.java
@@ -32,6 +32,7 @@ public class SecurityConfig {
                 .requestMatchers("/api/auth/**").permitAll()
                 .requestMatchers("/api/test/**").permitAll()
                 .requestMatchers(HttpMethod.PATCH, "/api/coordinator/deliverables/*/weight").hasRole("Coordinator")
+                .requestMatchers(HttpMethod.POST, "/api/coordinator/deliverables/*/rubric").hasRole("Coordinator")
                 .anyRequest().authenticated()
             )
             .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);

--- a/backend/src/main/java/com/senior/spm/controller/CoordinatorDeliverableController.java
+++ b/backend/src/main/java/com/senior/spm/controller/CoordinatorDeliverableController.java
@@ -1,0 +1,35 @@
+package com.senior.spm.controller;
+
+import java.util.UUID;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.senior.spm.controller.request.UpdateDeliverableWeightRequest;
+import com.senior.spm.service.DeliverableService;
+
+import jakarta.validation.Valid;
+
+@RestController
+@RequestMapping("/api/coordinator/deliverables")
+public class CoordinatorDeliverableController {
+
+    private final DeliverableService deliverableService;
+
+    public CoordinatorDeliverableController(DeliverableService deliverableService) {
+        this.deliverableService = deliverableService;
+    }
+
+    @PatchMapping("/{id}/weight")
+    public ResponseEntity<Void> updateDeliverableWeight(
+            @PathVariable UUID id,
+            @Valid @RequestBody UpdateDeliverableWeightRequest request) {
+
+        deliverableService.updateWeight(id, request.getWeightPercentage());
+        return ResponseEntity.ok().build();
+    }
+}

--- a/backend/src/main/java/com/senior/spm/controller/CoordinatorDeliverableController.java
+++ b/backend/src/main/java/com/senior/spm/controller/CoordinatorDeliverableController.java
@@ -1,14 +1,19 @@
 package com.senior.spm.controller;
 
+import java.util.List;
 import java.util.UUID;
 
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.validation.annotation.Validated;
 
+import com.senior.spm.controller.request.CreateRubricCriterionRequest;
 import com.senior.spm.controller.request.UpdateDeliverableWeightRequest;
 import com.senior.spm.service.DeliverableService;
 
@@ -16,6 +21,7 @@ import jakarta.validation.Valid;
 
 @RestController
 @RequestMapping("/api/coordinator/deliverables")
+@Validated
 public class CoordinatorDeliverableController {
 
     private final DeliverableService deliverableService;
@@ -31,5 +37,15 @@ public class CoordinatorDeliverableController {
 
         deliverableService.updateWeight(id, request.getWeightPercentage());
         return ResponseEntity.ok().build();
+    }
+
+    @PostMapping("/{id}/rubric")
+    public ResponseEntity<Void> createRubric(
+            @PathVariable UUID id,
+            @Valid @RequestBody List<@Valid CreateRubricCriterionRequest> request) {
+        System.out.println("RUBRIC endpoint hit");        
+
+        deliverableService.createRubric(id, request);
+        return ResponseEntity.status(HttpStatus.CREATED).build();
     }
 }

--- a/backend/src/main/java/com/senior/spm/controller/CoordinatorSprintController.java
+++ b/backend/src/main/java/com/senior/spm/controller/CoordinatorSprintController.java
@@ -1,0 +1,38 @@
+package com.senior.spm.controller;
+
+import java.util.UUID;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.senior.spm.controller.request.CreateSprintDeliverableMappingRequest;
+import com.senior.spm.service.SprintService;
+
+import jakarta.validation.Valid;
+
+@RestController
+@RequestMapping("/api/coordinator/sprints")
+@Validated
+public class CoordinatorSprintController {
+
+    private final SprintService sprintService;
+
+    public CoordinatorSprintController(SprintService sprintService) {
+        this.sprintService = sprintService;
+    }
+
+    @PostMapping("/{id}/deliverable-mapping")
+    public ResponseEntity<Void> createDeliverableMapping(
+            @PathVariable UUID id,
+            @Valid @RequestBody CreateSprintDeliverableMappingRequest request) {
+
+        sprintService.createDeliverableMapping(id, request);
+        return ResponseEntity.status(HttpStatus.CREATED).build();
+    }
+}

--- a/backend/src/main/java/com/senior/spm/controller/request/CreateRubricCriterionRequest.java
+++ b/backend/src/main/java/com/senior/spm/controller/request/CreateRubricCriterionRequest.java
@@ -1,0 +1,26 @@
+package com.senior.spm.controller.request;
+
+import java.math.BigDecimal;
+
+import jakarta.validation.constraints.DecimalMin;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class CreateRubricCriterionRequest {
+
+    @NotBlank(message = "criterionName is required.")
+    private String criterionName;
+
+    @NotBlank(message = "gradingType is required.")
+    private String gradingType;
+
+    @NotNull(message = "weight is required.")
+    @DecimalMin(value = "0.00", inclusive = false, message = "weight must be greater than 0.")
+    private BigDecimal weight;
+}

--- a/backend/src/main/java/com/senior/spm/controller/request/CreateSprintDeliverableMappingRequest.java
+++ b/backend/src/main/java/com/senior/spm/controller/request/CreateSprintDeliverableMappingRequest.java
@@ -1,0 +1,25 @@
+package com.senior.spm.controller.request;
+
+import java.math.BigDecimal;
+import java.util.UUID;
+
+import jakarta.validation.constraints.DecimalMax;
+import jakarta.validation.constraints.DecimalMin;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class CreateSprintDeliverableMappingRequest {
+
+    @NotNull(message = "deliverableId is required.")
+    private UUID deliverableId;
+
+    @NotNull(message = "contributionPercentage is required.")
+    @DecimalMin(value = "0.00", inclusive = false, message = "contributionPercentage must be greater than 0.")
+    @DecimalMax(value = "100.00", inclusive = true, message = "contributionPercentage cannot be greater than 100.")
+    private BigDecimal contributionPercentage;
+}

--- a/backend/src/main/java/com/senior/spm/controller/request/UpdateDeliverableWeightRequest.java
+++ b/backend/src/main/java/com/senior/spm/controller/request/UpdateDeliverableWeightRequest.java
@@ -1,0 +1,21 @@
+package com.senior.spm.controller.request;
+
+import java.math.BigDecimal;
+
+import jakarta.validation.constraints.DecimalMax;
+import jakarta.validation.constraints.DecimalMin;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class UpdateDeliverableWeightRequest {
+
+    @NotNull(message = "weightPercentage is required.")
+    @DecimalMin(value = "0.00", inclusive = false, message = "weightPercentage must be greater than 0.")
+    @DecimalMax(value = "100.00", inclusive = true, message = "weightPercentage cannot exceed 100.")
+    private BigDecimal weightPercentage;
+}

--- a/backend/src/main/java/com/senior/spm/entity/Deliverable.java
+++ b/backend/src/main/java/com/senior/spm/entity/Deliverable.java
@@ -43,6 +43,9 @@ public class Deliverable {
     @Column(precision = 5, scale = 2)
     private BigDecimal weight;
 
+    @Column(nullable = false)
+    private UUID termId;
+
     public enum DeliverableType {
         Proposal, SoW, Demonstration
     }

--- a/backend/src/main/java/com/senior/spm/filter/JwtAuthenticationFilter.java
+++ b/backend/src/main/java/com/senior/spm/filter/JwtAuthenticationFilter.java
@@ -1,10 +1,12 @@
 package com.senior.spm.filter;
 
 import java.io.IOException;
-import java.util.Collections;
+import java.util.ArrayList;
+import java.util.List;
 
 import org.springframework.lang.NonNull;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
@@ -21,10 +23,11 @@ import jakarta.servlet.http.HttpServletResponse;
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
     private final HandlerExceptionResolver handlerExceptionResolver;
-
     private final JWTService jwtService;
 
-    public JwtAuthenticationFilter(HandlerExceptionResolver handlerExceptionResolver, JWTService jwtService) {
+    public JwtAuthenticationFilter(
+            HandlerExceptionResolver handlerExceptionResolver,
+            JWTService jwtService) {
         this.handlerExceptionResolver = handlerExceptionResolver;
         this.jwtService = jwtService;
     }
@@ -34,23 +37,42 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             @NonNull HttpServletRequest request,
             @NonNull HttpServletResponse response,
             @NonNull FilterChain filterChain) throws ServletException, IOException {
-        var authHeader = request.getHeader("Authorization");
+
+        String authHeader = request.getHeader("Authorization");
+
         if (authHeader == null || !authHeader.startsWith("Bearer ")) {
             filterChain.doFilter(request, response);
             return;
         }
 
         try {
-            var token = authHeader.substring(7);
+            String token = authHeader.substring(7);
+
             if (!jwtService.validateToken(token)) {
                 response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
                 return;
             }
+
             var claims = jwtService.getClaims(token);
-            SecurityContextHolder.getContext().setAuthentication(
-                    new UsernamePasswordAuthenticationToken(claims.get("mail", String.class), null, Collections.emptyList()));
+
+            String mail = claims.get("mail", String.class);
+
+            Object roleObj = claims.get("role");
+            String role = roleObj != null ? roleObj.toString() : null;
+
+            List<SimpleGrantedAuthority> authorities = new ArrayList<>();
+
+            if (role != null && !role.isBlank()) {
+                authorities.add(new SimpleGrantedAuthority("ROLE_" + role));
+            }
+
+            UsernamePasswordAuthenticationToken authentication =
+                    new UsernamePasswordAuthenticationToken(mail, null, authorities);
+
+            SecurityContextHolder.getContext().setAuthentication(authentication);
             filterChain.doFilter(request, response);
-        } catch (ServletException | IOException e) {
+
+        } catch (Exception e) {
             handlerExceptionResolver.resolveException(request, response, null, e);
         }
     }

--- a/backend/src/main/java/com/senior/spm/repository/DeliverableRepository.java
+++ b/backend/src/main/java/com/senior/spm/repository/DeliverableRepository.java
@@ -1,0 +1,25 @@
+package com.senior.spm.repository;
+
+import java.math.BigDecimal;
+import java.util.UUID;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import com.senior.spm.entity.Deliverable;
+
+@Repository
+public interface DeliverableRepository extends JpaRepository<Deliverable, UUID> {
+
+    @Query("""
+           SELECT COALESCE(SUM(d.weight), 0)
+           FROM Deliverable d
+           WHERE d.termId = :termId
+             AND d.id <> :deliverableId
+           """)
+    BigDecimal sumWeightsExcludingDeliverableInTerm(
+            @Param("termId") UUID termId,
+            @Param("deliverableId") UUID deliverableId);
+}

--- a/backend/src/main/java/com/senior/spm/repository/RubricCriterionRepository.java
+++ b/backend/src/main/java/com/senior/spm/repository/RubricCriterionRepository.java
@@ -1,0 +1,12 @@
+package com.senior.spm.repository;
+
+import java.util.UUID;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import com.senior.spm.entity.RubricCriterion;
+
+@Repository
+public interface RubricCriterionRepository extends JpaRepository<RubricCriterion, UUID> {
+}

--- a/backend/src/main/java/com/senior/spm/repository/SprintDeliverableMappingRepository.java
+++ b/backend/src/main/java/com/senior/spm/repository/SprintDeliverableMappingRepository.java
@@ -1,0 +1,24 @@
+package com.senior.spm.repository;
+
+import java.math.BigDecimal;
+import java.util.UUID;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import com.senior.spm.entity.SprintDeliverableMapping;
+
+@Repository
+public interface SprintDeliverableMappingRepository extends JpaRepository<SprintDeliverableMapping, UUID> {
+
+    boolean existsBySprint_IdAndDeliverable_Id(UUID sprintId, UUID deliverableId);
+
+    @Query("""
+           SELECT COALESCE(SUM(m.contributionPercentage), 0)
+           FROM SprintDeliverableMapping m
+           WHERE m.deliverable.id = :deliverableId
+           """)
+    BigDecimal sumContributionPercentageByDeliverableId(@Param("deliverableId") UUID deliverableId);
+}

--- a/backend/src/main/java/com/senior/spm/repository/SprintRepository.java
+++ b/backend/src/main/java/com/senior/spm/repository/SprintRepository.java
@@ -1,0 +1,12 @@
+package com.senior.spm.repository;
+
+import java.util.UUID;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import com.senior.spm.entity.Sprint;
+
+@Repository
+public interface SprintRepository extends JpaRepository<Sprint, UUID> {
+}

--- a/backend/src/main/java/com/senior/spm/service/DeliverableService.java
+++ b/backend/src/main/java/com/senior/spm/service/DeliverableService.java
@@ -1,0 +1,58 @@
+package com.senior.spm.service;
+
+import java.math.BigDecimal;
+import java.util.UUID;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.server.ResponseStatusException;
+
+import com.senior.spm.entity.Deliverable;
+import com.senior.spm.repository.DeliverableRepository;
+
+@Service
+public class DeliverableService {
+
+    private static final BigDecimal MAX_TOTAL_WEIGHT = new BigDecimal("100");
+
+    private final DeliverableRepository deliverableRepository;
+
+    public DeliverableService(DeliverableRepository deliverableRepository) {
+        this.deliverableRepository = deliverableRepository;
+    }
+
+    @Transactional
+    public void updateWeight(UUID deliverableId, BigDecimal newWeight) {
+        if (newWeight == null || newWeight.compareTo(BigDecimal.ZERO) <= 0) {
+            throw new ResponseStatusException(
+                    HttpStatus.BAD_REQUEST,
+                    "Weight percentage must be greater than 0.");
+        }
+
+        Deliverable deliverable = deliverableRepository.findById(deliverableId)
+                .orElseThrow(() -> new ResponseStatusException(
+                        HttpStatus.NOT_FOUND,
+                        "Deliverable not found with id: " + deliverableId));
+
+        BigDecimal assignedWeight = deliverableRepository.sumWeightsExcludingDeliverableInTerm(
+                deliverable.getTermId(),
+                deliverableId);
+
+        if (assignedWeight == null) {
+            assignedWeight = BigDecimal.ZERO;
+        }
+
+        BigDecimal newTotal = assignedWeight.add(newWeight);
+
+        if (newTotal.compareTo(MAX_TOTAL_WEIGHT) > 0) {
+            throw new ResponseStatusException(
+                    HttpStatus.BAD_REQUEST,
+                    "Total deliverable weight cannot exceed 100%. Currently assigned: "
+                            + assignedWeight.stripTrailingZeros().toPlainString() + "%.");
+        }
+
+        deliverable.setWeight(newWeight);
+        deliverableRepository.save(deliverable);
+    }
+}

--- a/backend/src/main/java/com/senior/spm/service/DeliverableService.java
+++ b/backend/src/main/java/com/senior/spm/service/DeliverableService.java
@@ -1,6 +1,8 @@
 package com.senior.spm.service;
 
 import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.UUID;
 
 import org.springframework.http.HttpStatus;
@@ -8,8 +10,11 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.server.ResponseStatusException;
 
+import com.senior.spm.controller.request.CreateRubricCriterionRequest;
 import com.senior.spm.entity.Deliverable;
+import com.senior.spm.entity.RubricCriterion;
 import com.senior.spm.repository.DeliverableRepository;
+import com.senior.spm.repository.RubricCriterionRepository;
 
 @Service
 public class DeliverableService {
@@ -17,9 +22,13 @@ public class DeliverableService {
     private static final BigDecimal MAX_TOTAL_WEIGHT = new BigDecimal("100");
 
     private final DeliverableRepository deliverableRepository;
+    private final RubricCriterionRepository rubricCriterionRepository;
 
-    public DeliverableService(DeliverableRepository deliverableRepository) {
+    public DeliverableService(
+            DeliverableRepository deliverableRepository,
+            RubricCriterionRepository rubricCriterionRepository) {
         this.deliverableRepository = deliverableRepository;
+        this.rubricCriterionRepository = rubricCriterionRepository;
     }
 
     @Transactional
@@ -54,5 +63,48 @@ public class DeliverableService {
 
         deliverable.setWeight(newWeight);
         deliverableRepository.save(deliverable);
+    }
+
+    @Transactional
+    public void createRubric(UUID deliverableId, List<CreateRubricCriterionRequest> requests) {
+        if (requests == null || requests.isEmpty()) {
+            throw new ResponseStatusException(
+                    HttpStatus.BAD_REQUEST,
+                    "At least one rubric criterion is required.");
+        }
+
+        Deliverable deliverable = deliverableRepository.findById(deliverableId)
+                .orElseThrow(() -> new ResponseStatusException(
+                        HttpStatus.NOT_FOUND,
+                        "Deliverable not found with id: " + deliverableId));
+
+        List<RubricCriterion> rubricCriteria = new ArrayList<>();
+
+        for (CreateRubricCriterionRequest request : requests) {
+            if (request == null) {
+                throw new ResponseStatusException(
+                        HttpStatus.BAD_REQUEST,
+                        "Each rubric criterion must be a valid object.");
+            }
+
+            RubricCriterion.GradingType gradingType;
+            try {
+                gradingType = RubricCriterion.GradingType.valueOf(request.getGradingType());
+            } catch (IllegalArgumentException ex) {
+                throw new ResponseStatusException(
+                        HttpStatus.BAD_REQUEST,
+                        "gradingType must be either 'Binary' or 'Soft'.");
+            }
+
+            RubricCriterion rubricCriterion = new RubricCriterion();
+            rubricCriterion.setDeliverable(deliverable);
+            rubricCriterion.setCriterionName(request.getCriterionName().trim());
+            rubricCriterion.setGradingType(gradingType);
+            rubricCriterion.setWeight(request.getWeight());
+
+            rubricCriteria.add(rubricCriterion);
+        }
+
+        rubricCriterionRepository.saveAll(rubricCriteria);
     }
 }

--- a/backend/src/main/java/com/senior/spm/service/SprintService.java
+++ b/backend/src/main/java/com/senior/spm/service/SprintService.java
@@ -1,0 +1,81 @@
+package com.senior.spm.service;
+
+import java.math.BigDecimal;
+import java.util.UUID;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.server.ResponseStatusException;
+
+import com.senior.spm.controller.request.CreateSprintDeliverableMappingRequest;
+import com.senior.spm.entity.Deliverable;
+import com.senior.spm.entity.Sprint;
+import com.senior.spm.entity.SprintDeliverableMapping;
+import com.senior.spm.repository.DeliverableRepository;
+import com.senior.spm.repository.SprintDeliverableMappingRepository;
+import com.senior.spm.repository.SprintRepository;
+
+@Service
+public class SprintService {
+
+    private static final BigDecimal MAX_TOTAL_CONTRIBUTION = new BigDecimal("100");
+
+    private final SprintRepository sprintRepository;
+    private final DeliverableRepository deliverableRepository;
+    private final SprintDeliverableMappingRepository sprintDeliverableMappingRepository;
+
+    public SprintService(
+            SprintRepository sprintRepository,
+            DeliverableRepository deliverableRepository,
+            SprintDeliverableMappingRepository sprintDeliverableMappingRepository) {
+        this.sprintRepository = sprintRepository;
+        this.deliverableRepository = deliverableRepository;
+        this.sprintDeliverableMappingRepository = sprintDeliverableMappingRepository;
+    }
+
+    @Transactional
+    public void createDeliverableMapping(UUID sprintId, CreateSprintDeliverableMappingRequest request) {
+        Sprint sprint = sprintRepository.findById(sprintId)
+                .orElseThrow(() -> new ResponseStatusException(
+                        HttpStatus.NOT_FOUND,
+                        "Sprint not found with id: " + sprintId));
+
+        Deliverable deliverable = deliverableRepository.findById(request.getDeliverableId())
+                .orElseThrow(() -> new ResponseStatusException(
+                        HttpStatus.NOT_FOUND,
+                        "Deliverable not found with id: " + request.getDeliverableId()));
+
+        boolean alreadyExists = sprintDeliverableMappingRepository
+                .existsBySprint_IdAndDeliverable_Id(sprintId, request.getDeliverableId());
+
+        if (alreadyExists) {
+            throw new ResponseStatusException(
+                    HttpStatus.BAD_REQUEST,
+                    "This sprint is already linked to the specified deliverable.");
+        }
+
+        BigDecimal assignedContribution = sprintDeliverableMappingRepository
+                .sumContributionPercentageByDeliverableId(request.getDeliverableId());
+
+        if (assignedContribution == null) {
+            assignedContribution = BigDecimal.ZERO;
+        }
+
+        BigDecimal newTotal = assignedContribution.add(request.getContributionPercentage());
+
+        if (newTotal.compareTo(MAX_TOTAL_CONTRIBUTION) > 0) {
+            throw new ResponseStatusException(
+                    HttpStatus.BAD_REQUEST,
+                    "Total contribution percentage for this deliverable cannot exceed 100%. Currently assigned: "
+                            + assignedContribution.stripTrailingZeros().toPlainString() + "%.");
+        }
+
+        SprintDeliverableMapping mapping = new SprintDeliverableMapping();
+        mapping.setSprint(sprint);
+        mapping.setDeliverable(deliverable);
+        mapping.setContributionPercentage(request.getContributionPercentage());
+
+        sprintDeliverableMappingRepository.save(mapping);
+    }
+}

--- a/backend/src/main/resources/application.properties.example
+++ b/backend/src/main/resources/application.properties.example
@@ -1,9 +1,9 @@
 spring.application.name=spm
 spring.datasource.url=jdbc:mysql://localhost:3306/spm
-spring.datasource.username=
-spring.datasource.password=
+spring.datasource.username=spm
+spring.datasource.password=1234
 spring.jpa.hibernate.ddl-auto=update
 spring.jpa.defer-datasource-initialization=true
 spring.sql.init.mode=always
-jwt.secret=
+jwt.secret=myVerySecretKey123456789
 jwt.expiration=604800000

--- a/backend/src/main/resources/data.sql
+++ b/backend/src/main/resources/data.sql
@@ -20,3 +20,12 @@ VALUES
 		UUID_TO_BIN ("00000000-0000-0000-0000-000000000002"),
 		"23070006018"
 	);
+
+INSERT IGNORE INTO staff_user (id, is_first_login, mail, password_hash, role)
+VALUES (
+    UUID_TO_BIN("00000000-0000-0000-0000-000000000001"),
+    FALSE,
+    "coordinator@test.com",
+    "bcrypt_hash_buraya",
+    "Coordinator"
+);


### PR DESCRIPTION
## Summary
This PR adds backend support for coordinator deliverable management, including deliverable weight updates, rubric creation, and sprint-deliverable mapping.

## Implemented
- Implemented `PATCH /api/coordinator/deliverables/{id}/weight`
- Implemented `POST /api/coordinator/deliverables/{id}/rubric`
- Implemented `POST /api/coordinator/sprints/{id}/deliverable-mapping`

## What was added
- Added controller logic for coordinator endpoints
- Added request DTOs for rubric creation and sprint-deliverable mapping
- Added validation for:
  - deliverable weight updates
  - rubric request payload
  - contribution percentage totals
- Added backend/service logic for saving rubric criteria
- Added backend/service logic for linking sprints and deliverables
- Updated security configuration for coordinator-only access where required

## Validation rules covered
- Deliverable weight cannot cause total weight to exceed 100%
- Rubric `gradingType` must be valid
- Sprint-deliverable contribution percentages cannot exceed 100%

## Why
These changes complete the core backend coordinator flows for:
- setting deliverable weights
- defining deliverable rubric criteria
- mapping sprint contributions to deliverables

Closes #13
Closes #14
Closes #17