### PR TITLE
feat: implement external validation services for jira and github

### DIFF
--- a/backend/src/main/java/com/senior/spm/config/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/senior/spm/config/GlobalExceptionHandler.java
@@ -12,6 +12,7 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 import com.senior.spm.controller.response.ErrorMessage;
+import com.senior.spm.exception.ExternalToolValidationException;
 
 @RestControllerAdvice
 public class GlobalExceptionHandler {
@@ -35,6 +36,16 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(RuntimeException.class)
     public ResponseEntity<ErrorMessage> handleRuntimeException(RuntimeException ex) {
-        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(new ErrorMessage("An unexpected error occurred: " + ex.getMessage()));
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                .body(new ErrorMessage("An unexpected error occurred: " + ex.getMessage()));
+    }
+
+    // Maps JiraValidationException and GitHubValidationException (both extend
+    // ExternalToolValidationException) to HTTP 422 Unprocessable Entity.
+    // The exception message is the exact user-facing string defined in the API spec
+    // (e.g. "JIRA validation failed: API token is invalid or expired").
+    @ExceptionHandler(ExternalToolValidationException.class)
+    public ResponseEntity<ErrorMessage> handleExternalToolValidation(ExternalToolValidationException ex) {
+        return ResponseEntity.status(HttpStatus.UNPROCESSABLE_ENTITY).body(new ErrorMessage(ex.getMessage()));
     }
 }

--- a/backend/src/main/java/com/senior/spm/config/RestTemplateConfig.java
+++ b/backend/src/main/java/com/senior/spm/config/RestTemplateConfig.java
@@ -1,0 +1,27 @@
+package com.senior.spm.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.client.SimpleClientHttpRequestFactory;
+import org.springframework.web.client.RestTemplate;
+
+/**
+ * Configures a RestTemplate bean with a strict 5-second timeout
+ * for all outbound HTTP calls to external APIs (JIRA, GitHub).
+ *
+ * Acceptance criterion: "Services strictly enforce a 5-second timeout."
+ * Issue #48 — [Backend] External Tool Validation Services
+ */
+@Configuration
+public class RestTemplateConfig {
+
+    private static final int TIMEOUT_MS = 5_000;
+
+    @Bean
+    public RestTemplate restTemplate() {
+        var factory = new SimpleClientHttpRequestFactory();
+        factory.setConnectTimeout(TIMEOUT_MS);
+        factory.setReadTimeout(TIMEOUT_MS);
+        return new RestTemplate(factory);
+    }
+}

--- a/backend/src/main/java/com/senior/spm/exception/ExternalToolValidationException.java
+++ b/backend/src/main/java/com/senior/spm/exception/ExternalToolValidationException.java
@@ -1,0 +1,12 @@
+package com.senior.spm.exception;
+
+/**
+ * Base exception for external tool validation failures (JIRA, GitHub).
+ * Subclasses carry the exact user-facing 422 message defined in the API spec.
+ */
+public class ExternalToolValidationException extends RuntimeException {
+
+    public ExternalToolValidationException(String message) {
+        super(message);
+    }
+}

--- a/backend/src/main/java/com/senior/spm/exception/GitHubValidationException.java
+++ b/backend/src/main/java/com/senior/spm/exception/GitHubValidationException.java
@@ -1,0 +1,12 @@
+package com.senior.spm.exception;
+
+/**
+ * Thrown by GitHubValidationService when a live GitHub API call fails.
+ * Maps to HTTP 422 Unprocessable Entity.
+ */
+public class GitHubValidationException extends ExternalToolValidationException {
+
+    public GitHubValidationException(String message) {
+        super(message);
+    }
+}

--- a/backend/src/main/java/com/senior/spm/exception/JiraValidationException.java
+++ b/backend/src/main/java/com/senior/spm/exception/JiraValidationException.java
@@ -1,0 +1,12 @@
+package com.senior.spm.exception;
+
+/**
+ * Thrown by JiraValidationService when a live JIRA API call fails.
+ * Maps to HTTP 422 Unprocessable Entity.
+ */
+public class JiraValidationException extends ExternalToolValidationException {
+
+    public JiraValidationException(String message) {
+        super(message);
+    }
+}

--- a/backend/src/main/java/com/senior/spm/service/GitHubValidationService.java
+++ b/backend/src/main/java/com/senior/spm/service/GitHubValidationService.java
@@ -1,0 +1,115 @@
+package com.senior.spm.service;
+
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.client.ResourceAccessException;
+import org.springframework.web.client.RestTemplate;
+
+import com.senior.spm.exception.GitHubValidationException;
+
+/**
+ * Validates GitHub credentials by making two sequential live HTTP calls to the
+ * GitHub REST API.
+ *
+ * Called by GroupService.bindGitHub()
+ * Nothing is persisted until this service returns without throwing.
+ *
+ * Call sequence:
+ * 1. GET /orgs/{githubOrgName} → verifies org existence + PAT validity
+ * 2. GET /orgs/{githubOrgName}/repos → verifies the PAT has 'repo' scope
+ *
+ */
+@Service
+public class GitHubValidationService {
+
+    private static final String GITHUB_API_BASE = "https://api.github.com";
+
+    private final RestTemplate restTemplate;
+
+    public GitHubValidationService(RestTemplate restTemplate) {
+        this.restTemplate = restTemplate;
+    }
+
+    /**
+     * Runs the two-step GitHub validation.
+     *
+     * @throws GitHubValidationException on any failure (401 → invalid PAT,
+     *                                   404 → org not found,
+     *                                   403 on second call → missing 'repo' scope)
+     */
+    public void validate(String githubOrgName, String githubPat) {
+        var headers = new HttpHeaders();
+        // GitHub REST API v3 accepts a PAT as a Bearer token.
+        headers.set(HttpHeaders.AUTHORIZATION, "Bearer " + githubPat);
+        var entity = new HttpEntity<>(headers);
+
+        // Step 1: verify org existence and PAT validity
+        // If this call fails for any reason, Step 2 is NOT executed (fail-fast).
+        callStep1OrgExists(githubOrgName, entity);
+
+        // Step 2: verify the PAT has 'repo' scope
+        // Only reached when Step 1 succeeds (200 OK).
+        callStep2RepoScope(githubOrgName, entity);
+    }
+
+    /**
+     * GET /orgs/{githubOrgName}
+     * 401 → invalid PAT, 404 → org not found, anything else → rethrow as
+     * unreachable.
+     */
+    private void callStep1OrgExists(String githubOrgName, HttpEntity<?> entity) {
+        var url = GITHUB_API_BASE + "/orgs/" + githubOrgName;
+        try {
+            restTemplate.exchange(url, HttpMethod.GET, entity, Void.class);
+
+        } catch (HttpClientErrorException ex) {
+            HttpStatus status = HttpStatus.resolve(ex.getStatusCode().value());
+
+            if (status == HttpStatus.UNAUTHORIZED) {
+                throw new GitHubValidationException("GitHub validation failed: PAT is invalid or expired");
+            }
+
+            if (status == HttpStatus.NOT_FOUND) {
+                throw new GitHubValidationException(
+                        "GitHub validation failed: Organization '" + githubOrgName + "' not found");
+            }
+
+            // Any other 4xx from the first call — treat as a PAT / auth problem.
+            throw new GitHubValidationException("GitHub validation failed: PAT is invalid or expired");
+
+        } catch (ResourceAccessException ex) {
+            // Timeout or network failure on the first call — skip Step 2 (fail-fast).
+            throw new GitHubValidationException("GitHub validation failed: PAT is invalid or expired");
+        }
+    }
+
+    /**
+     * GET /orgs/{githubOrgName}/repos?per_page=1
+     * GitHub returns 403 (not 401) when the PAT lacks 'repo' scope.
+     */
+    private void callStep2RepoScope(String githubOrgName, HttpEntity<?> entity) {
+        var url = GITHUB_API_BASE + "/orgs/" + githubOrgName + "/repos?per_page=1";
+        try {
+            restTemplate.exchange(url, HttpMethod.GET, entity, Void.class);
+
+        } catch (HttpClientErrorException ex) {
+            HttpStatus status = HttpStatus.resolve(ex.getStatusCode().value());
+
+            if (status == HttpStatus.FORBIDDEN) {
+                // GitHub returns 403 specifically when the PAT is missing the 'repo' scope.
+                throw new GitHubValidationException("GitHub validation failed: PAT lacks required 'repo' scope");
+            }
+
+            // Unexpected error on the second call.
+            throw new GitHubValidationException("GitHub validation failed: PAT lacks required 'repo' scope");
+
+        } catch (ResourceAccessException ex) {
+            // Timeout on the second call — scope check inconclusive; reject to be safe.
+            throw new GitHubValidationException("GitHub validation failed: PAT lacks required 'repo' scope");
+        }
+    }
+}

--- a/backend/src/main/java/com/senior/spm/service/JiraValidationService.java
+++ b/backend/src/main/java/com/senior/spm/service/JiraValidationService.java
@@ -1,0 +1,72 @@
+package com.senior.spm.service;
+
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.client.ResourceAccessException;
+import org.springframework.web.client.RestTemplate;
+
+import com.senior.spm.exception.JiraValidationException;
+
+/**
+ * Validates JIRA credentials by making a single live HTTP call to the JIRA REST
+ * API.
+ * Called by GroupService.bindJira()
+ * Nothing is persisted until this service returns without throwing.
+ *
+ */
+@Service
+public class JiraValidationService {
+
+    private final RestTemplate restTemplate;
+
+    public JiraValidationService(RestTemplate restTemplate) {
+        this.restTemplate = restTemplate;
+    }
+
+    /**
+     * Performs a single GET against:
+     * {jiraSpaceUrl}/rest/api/3/project/{jiraProjectKey}
+     *
+     * @throws JiraValidationException on any failure (401/403 → invalid token,
+     *                                 404 → project key not found,
+     *                                 timeout/network → unreachable)
+     */
+    public void validate(String jiraSpaceUrl, String jiraProjectKey, String jiraApiToken) {
+        var url = jiraSpaceUrl.stripTrailing() + "/rest/api/3/project/" + jiraProjectKey;
+
+        var headers = new HttpHeaders();
+        // JIRA Cloud accepts a Bearer token; on-prem may need Basic – Bearer covers
+        // both cases here.
+        headers.set(HttpHeaders.AUTHORIZATION, "Bearer " + jiraApiToken);
+        var entity = new HttpEntity<>(headers);
+
+        try {
+            restTemplate.exchange(url, HttpMethod.GET, entity, Void.class);
+
+        } catch (HttpClientErrorException ex) {
+            HttpStatus status = HttpStatus.resolve(ex.getStatusCode().value());
+
+            if (status == HttpStatus.UNAUTHORIZED || status == HttpStatus.FORBIDDEN) {
+                // JIRA returns 401 for bad tokens and 403 for insufficient permissions.
+                throw new JiraValidationException("JIRA validation failed: API token is invalid or expired");
+            }
+
+            if (status == HttpStatus.NOT_FOUND) {
+                // The project key does not exist in the given JIRA space.
+                throw new JiraValidationException(
+                        "JIRA validation failed: Project key '" + jiraProjectKey + "' not found");
+            }
+
+            // Any other 4xx — treat as unreachable / misconfigured URL.
+            throw new JiraValidationException("JIRA validation failed: JIRA space URL is unreachable");
+
+        } catch (ResourceAccessException ex) {
+            // Covers connection timeout, read timeout, DNS failure, etc.
+            throw new JiraValidationException("JIRA validation failed: JIRA space URL is unreachable");
+        }
+    }
+}

--- a/backend/src/main/java/com/senior/spm/service/JiraValidationService.java
+++ b/backend/src/main/java/com/senior/spm/service/JiraValidationService.java
@@ -36,7 +36,7 @@ public class JiraValidationService {
      *                                 timeout/network → unreachable)
      */
     public void validate(String jiraSpaceUrl, String jiraProjectKey, String jiraApiToken) {
-        var url = jiraSpaceUrl.stripTrailing() + "/rest/api/3/project/" + jiraProjectKey;
+        var url = jiraSpaceUrl.strip().replaceAll("/+$", "") + "/rest/api/3/project/" + jiraProjectKey;
 
         var headers = new HttpHeaders();
         // JIRA Cloud accepts a Bearer token; on-prem may need Basic – Bearer covers

--- a/backend/src/test/java/com/senior/spm/config/GlobalExceptionHandlerTest.java
+++ b/backend/src/test/java/com/senior/spm/config/GlobalExceptionHandlerTest.java
@@ -1,0 +1,76 @@
+package com.senior.spm.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+
+import com.senior.spm.exception.GitHubValidationException;
+import com.senior.spm.exception.JiraValidationException;
+
+/**
+ * Verifies that GlobalExceptionHandler maps both JiraValidationException and
+ * GitHubValidationException to HTTP 422 Unprocessable Entity with the exact
+ * user-facing message from the exception.
+ *
+ * This is the integration point between the validation services and the HTTP
+ * response layer. If this mapping is broken, validation failures silently
+ * become 500 Internal Server Error responses.
+ */
+class GlobalExceptionHandlerTest {
+
+    private final GlobalExceptionHandler handler = new GlobalExceptionHandler();
+
+    // ── JIRA exceptions → 422 ─────────────────────────────────────────────
+
+    @Test
+    void jiraValidationException_mapsTo422() {
+        var ex = new JiraValidationException("JIRA validation failed: API token is invalid or expired");
+        var response = handler.handleExternalToolValidation(ex);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.UNPROCESSABLE_ENTITY);
+    }
+
+    @Test
+    void jiraValidationException_preservesMessageInBody() {
+        var message = "JIRA validation failed: Project key 'SPM' not found";
+        var ex = new JiraValidationException(message);
+        var response = handler.handleExternalToolValidation(ex);
+
+        assertThat(response.getBody()).isNotNull();
+        assertThat(response.getBody().getMessage()).isEqualTo(message);
+    }
+
+    // ── GitHub exceptions → 422 ───────────────────────────────────────────
+
+    @Test
+    void gitHubValidationException_mapsTo422() {
+        var ex = new GitHubValidationException("GitHub validation failed: PAT is invalid or expired");
+        var response = handler.handleExternalToolValidation(ex);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.UNPROCESSABLE_ENTITY);
+    }
+
+    @Test
+    void gitHubValidationException_preservesMessageInBody() {
+        var message = "GitHub validation failed: PAT lacks required 'repo' scope";
+        var ex = new GitHubValidationException(message);
+        var response = handler.handleExternalToolValidation(ex);
+
+        assertThat(response.getBody()).isNotNull();
+        assertThat(response.getBody().getMessage()).isEqualTo(message);
+    }
+
+    // ── Never returns a different status ─────────────────────────────────
+
+    @Test
+    void handler_neverReturns500_forValidationExceptions() {
+        var jiraEx = new JiraValidationException("any jira error");
+        var githubEx = new GitHubValidationException("any github error");
+
+        assertThat(handler.handleExternalToolValidation(jiraEx).getStatusCode())
+                .isNotEqualTo(HttpStatus.INTERNAL_SERVER_ERROR);
+        assertThat(handler.handleExternalToolValidation(githubEx).getStatusCode())
+                .isNotEqualTo(HttpStatus.INTERNAL_SERVER_ERROR);
+    }
+}

--- a/backend/src/test/java/com/senior/spm/config/RestTemplateConfigTest.java
+++ b/backend/src/test/java/com/senior/spm/config/RestTemplateConfigTest.java
@@ -1,0 +1,41 @@
+package com.senior.spm.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.lang.reflect.Field;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.http.client.SimpleClientHttpRequestFactory;
+
+/**
+ * Verifies acceptance criterion from Issue #48:
+ * "Services strictly enforce a 5-second timeout."
+ */
+class RestTemplateConfigTest {
+
+    private static final int EXPECTED_TIMEOUT_MS = 5_000;
+
+    private final RestTemplateConfig config = new RestTemplateConfig();
+
+    @Test
+    void restTemplate_usesSimpleClientHttpRequestFactory() {
+        var restTemplate = config.restTemplate();
+        assertThat(restTemplate.getRequestFactory()).isInstanceOf(SimpleClientHttpRequestFactory.class);
+    }
+
+    @Test
+    void restTemplate_hasFiveSecondConnectTimeout() throws Exception {
+        var factory = (SimpleClientHttpRequestFactory) config.restTemplate().getRequestFactory();
+        Field field = SimpleClientHttpRequestFactory.class.getDeclaredField("connectTimeout");
+        field.setAccessible(true);
+        assertThat(field.get(factory)).isEqualTo(EXPECTED_TIMEOUT_MS);
+    }
+
+    @Test
+    void restTemplate_hasFiveSecondReadTimeout() throws Exception {
+        var factory = (SimpleClientHttpRequestFactory) config.restTemplate().getRequestFactory();
+        Field field = SimpleClientHttpRequestFactory.class.getDeclaredField("readTimeout");
+        field.setAccessible(true);
+        assertThat(field.get(factory)).isEqualTo(EXPECTED_TIMEOUT_MS);
+    }
+}

--- a/backend/src/test/java/com/senior/spm/service/GitHubValidationServiceTest.java
+++ b/backend/src/test/java/com/senior/spm/service/GitHubValidationServiceTest.java
@@ -1,0 +1,175 @@
+package com.senior.spm.service;
+
+import static org.assertj.core.api.Assertions.assertThatNoException;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.client.ResourceAccessException;
+import org.springframework.web.client.RestTemplate;
+
+import com.senior.spm.exception.ExternalToolValidationException;
+import com.senior.spm.exception.GitHubValidationException;
+
+@ExtendWith(MockitoExtension.class)
+class GitHubValidationServiceTest {
+
+    @Mock
+    private RestTemplate restTemplate;
+
+    @InjectMocks
+    private GitHubValidationService service;
+
+    private static final String ORG_NAME = "my-org";
+    private static final String PAT = "ghp_testtoken";
+    private static final String STEP1_URL = "https://api.github.com/orgs/" + ORG_NAME;
+    private static final String STEP2_URL = "https://api.github.com/orgs/" + ORG_NAME + "/repos?per_page=1";
+
+    // ── Happy path ───────────────────────────────────────────────────────────
+
+    @Test
+    void validate_success_whenBothCallsReturn200() {
+        when(restTemplate.exchange(eq(STEP1_URL), eq(HttpMethod.GET), any(HttpEntity.class), eq(Void.class)))
+                .thenReturn(new ResponseEntity<>(HttpStatus.OK));
+        when(restTemplate.exchange(eq(STEP2_URL), eq(HttpMethod.GET), any(HttpEntity.class), eq(Void.class)))
+                .thenReturn(new ResponseEntity<>(HttpStatus.OK));
+
+        assertThatNoException().isThrownBy(() -> service.validate(ORG_NAME, PAT));
+
+        verify(restTemplate).exchange(eq(STEP1_URL), eq(HttpMethod.GET), any(HttpEntity.class), eq(Void.class));
+        verify(restTemplate).exchange(eq(STEP2_URL), eq(HttpMethod.GET), any(HttpEntity.class), eq(Void.class));
+    }
+
+    // ── Step 1 failures — fail-fast: Step 2 must never be called ─────────
+
+    @Test
+    void validate_throwsInvalidPat_whenStep1Returns401() {
+        when(restTemplate.exchange(eq(STEP1_URL), eq(HttpMethod.GET), any(HttpEntity.class), eq(Void.class)))
+                .thenThrow(new HttpClientErrorException(HttpStatus.UNAUTHORIZED));
+
+        assertThatThrownBy(() -> service.validate(ORG_NAME, PAT))
+                .isInstanceOf(GitHubValidationException.class)
+                .hasMessage("GitHub validation failed: PAT is invalid or expired");
+
+        verify(restTemplate, never()).exchange(eq(STEP2_URL), eq(HttpMethod.GET), any(HttpEntity.class), eq(Void.class));
+    }
+
+    @Test
+    void validate_throwsOrgNotFound_whenStep1Returns404() {
+        when(restTemplate.exchange(eq(STEP1_URL), eq(HttpMethod.GET), any(HttpEntity.class), eq(Void.class)))
+                .thenThrow(new HttpClientErrorException(HttpStatus.NOT_FOUND));
+
+        assertThatThrownBy(() -> service.validate(ORG_NAME, PAT))
+                .isInstanceOf(GitHubValidationException.class)
+                .hasMessage("GitHub validation failed: Organization 'my-org' not found");
+
+        verify(restTemplate, never()).exchange(eq(STEP2_URL), eq(HttpMethod.GET), any(HttpEntity.class), eq(Void.class));
+    }
+
+    @Test
+    void validate_throwsInvalidPat_whenStep1ReturnsOther4xx() {
+        when(restTemplate.exchange(eq(STEP1_URL), eq(HttpMethod.GET), any(HttpEntity.class), eq(Void.class)))
+                .thenThrow(new HttpClientErrorException(HttpStatus.BAD_REQUEST));
+
+        assertThatThrownBy(() -> service.validate(ORG_NAME, PAT))
+                .isInstanceOf(GitHubValidationException.class)
+                .hasMessage("GitHub validation failed: PAT is invalid or expired");
+
+        verify(restTemplate, never()).exchange(eq(STEP2_URL), eq(HttpMethod.GET), any(HttpEntity.class), eq(Void.class));
+    }
+
+    @Test
+    void validate_throwsInvalidPat_whenStep1TimesOut() {
+        when(restTemplate.exchange(eq(STEP1_URL), eq(HttpMethod.GET), any(HttpEntity.class), eq(Void.class)))
+                .thenThrow(new ResourceAccessException("Connection timed out"));
+
+        assertThatThrownBy(() -> service.validate(ORG_NAME, PAT))
+                .isInstanceOf(GitHubValidationException.class)
+                .hasMessage("GitHub validation failed: PAT is invalid or expired");
+
+        verify(restTemplate, never()).exchange(eq(STEP2_URL), eq(HttpMethod.GET), any(HttpEntity.class), eq(Void.class));
+    }
+
+    // ── Step 2 failures (Step 1 always succeeds) ─────────────────────────
+
+    @Test
+    void validate_throwsLacksRepoScope_whenStep2Returns403() {
+        when(restTemplate.exchange(eq(STEP1_URL), eq(HttpMethod.GET), any(HttpEntity.class), eq(Void.class)))
+                .thenReturn(new ResponseEntity<>(HttpStatus.OK));
+        when(restTemplate.exchange(eq(STEP2_URL), eq(HttpMethod.GET), any(HttpEntity.class), eq(Void.class)))
+                .thenThrow(new HttpClientErrorException(HttpStatus.FORBIDDEN));
+
+        assertThatThrownBy(() -> service.validate(ORG_NAME, PAT))
+                .isInstanceOf(GitHubValidationException.class)
+                .hasMessage("GitHub validation failed: PAT lacks required 'repo' scope");
+    }
+
+    @Test
+    void validate_throwsLacksRepoScope_whenStep2ReturnsOther4xx() {
+        when(restTemplate.exchange(eq(STEP1_URL), eq(HttpMethod.GET), any(HttpEntity.class), eq(Void.class)))
+                .thenReturn(new ResponseEntity<>(HttpStatus.OK));
+        when(restTemplate.exchange(eq(STEP2_URL), eq(HttpMethod.GET), any(HttpEntity.class), eq(Void.class)))
+                .thenThrow(new HttpClientErrorException(HttpStatus.BAD_REQUEST));
+
+        assertThatThrownBy(() -> service.validate(ORG_NAME, PAT))
+                .isInstanceOf(GitHubValidationException.class)
+                .hasMessage("GitHub validation failed: PAT lacks required 'repo' scope");
+    }
+
+    @Test
+    void validate_throwsLacksRepoScope_whenStep2TimesOut() {
+        when(restTemplate.exchange(eq(STEP1_URL), eq(HttpMethod.GET), any(HttpEntity.class), eq(Void.class)))
+                .thenReturn(new ResponseEntity<>(HttpStatus.OK));
+        when(restTemplate.exchange(eq(STEP2_URL), eq(HttpMethod.GET), any(HttpEntity.class), eq(Void.class)))
+                .thenThrow(new ResourceAccessException("Connection timed out"));
+
+        assertThatThrownBy(() -> service.validate(ORG_NAME, PAT))
+                .isInstanceOf(GitHubValidationException.class)
+                .hasMessage("GitHub validation failed: PAT lacks required 'repo' scope");
+    }
+
+    // ── Exception hierarchy — GlobalExceptionHandler relies on this ───────
+
+    @Test
+    void validate_throwsExternalToolValidationException_onFailure() {
+        // GitHubValidationException must extend ExternalToolValidationException so that
+        // GlobalExceptionHandler.handleExternalToolValidation() catches it and returns 422.
+        when(restTemplate.exchange(eq(STEP1_URL), eq(HttpMethod.GET), any(HttpEntity.class), eq(Void.class)))
+                .thenThrow(new HttpClientErrorException(HttpStatus.UNAUTHORIZED));
+
+        assertThatThrownBy(() -> service.validate(ORG_NAME, PAT))
+                .isInstanceOf(ExternalToolValidationException.class);
+    }
+
+    // ── Authorization header ──────────────────────────────────────────────
+
+    @SuppressWarnings("unchecked")
+    @Test
+    void validate_setsBearerHeader() {
+        when(restTemplate.exchange(eq(STEP1_URL), eq(HttpMethod.GET), any(HttpEntity.class), eq(Void.class)))
+                .thenReturn(new ResponseEntity<>(HttpStatus.OK));
+        when(restTemplate.exchange(eq(STEP2_URL), eq(HttpMethod.GET), any(HttpEntity.class), eq(Void.class)))
+                .thenReturn(new ResponseEntity<>(HttpStatus.OK));
+
+        service.validate(ORG_NAME, PAT);
+
+        ArgumentCaptor<HttpEntity<Void>> captor = ArgumentCaptor.forClass(HttpEntity.class);
+        verify(restTemplate).exchange(eq(STEP1_URL), eq(HttpMethod.GET), captor.capture(), eq(Void.class));
+        String authHeader = captor.getValue().getHeaders().getFirst("Authorization");
+        org.assertj.core.api.Assertions.assertThat(authHeader).isEqualTo("Bearer " + PAT);
+    }
+}

--- a/backend/src/test/java/com/senior/spm/service/JiraValidationServiceTest.java
+++ b/backend/src/test/java/com/senior/spm/service/JiraValidationServiceTest.java
@@ -1,0 +1,163 @@
+package com.senior.spm.service;
+
+import static org.assertj.core.api.Assertions.assertThatNoException;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.client.ResourceAccessException;
+import org.springframework.web.client.RestTemplate;
+
+import com.senior.spm.exception.ExternalToolValidationException;
+import com.senior.spm.exception.JiraValidationException;
+
+@ExtendWith(MockitoExtension.class)
+class JiraValidationServiceTest {
+
+    @Mock
+    private RestTemplate restTemplate;
+
+    @InjectMocks
+    private JiraValidationService service;
+
+    private static final String JIRA_URL = "https://myteam.atlassian.net";
+    private static final String PROJECT_KEY = "SPM";
+    private static final String API_TOKEN = "test-api-token";
+    private static final String EXPECTED_URL = JIRA_URL + "/rest/api/3/project/" + PROJECT_KEY;
+
+    // ── Happy path ───────────────────────────────────────────────────────────
+
+    @Test
+    void validate_success_whenJiraReturns200() {
+        when(restTemplate.exchange(eq(EXPECTED_URL), eq(HttpMethod.GET), any(HttpEntity.class), eq(Void.class)))
+                .thenReturn(new ResponseEntity<>(HttpStatus.OK));
+
+        assertThatNoException().isThrownBy(() -> service.validate(JIRA_URL, PROJECT_KEY, API_TOKEN));
+    }
+
+    // ── 401 / 403 — invalid token ─────────────────────────────────────────
+
+    @Test
+    void validate_throwsInvalidToken_whenJiraReturns401() {
+        when(restTemplate.exchange(eq(EXPECTED_URL), eq(HttpMethod.GET), any(HttpEntity.class), eq(Void.class)))
+                .thenThrow(new HttpClientErrorException(HttpStatus.UNAUTHORIZED));
+
+        assertThatThrownBy(() -> service.validate(JIRA_URL, PROJECT_KEY, API_TOKEN))
+                .isInstanceOf(JiraValidationException.class)
+                .hasMessage("JIRA validation failed: API token is invalid or expired");
+    }
+
+    @Test
+    void validate_throwsInvalidToken_whenJiraReturns403() {
+        when(restTemplate.exchange(eq(EXPECTED_URL), eq(HttpMethod.GET), any(HttpEntity.class), eq(Void.class)))
+                .thenThrow(new HttpClientErrorException(HttpStatus.FORBIDDEN));
+
+        assertThatThrownBy(() -> service.validate(JIRA_URL, PROJECT_KEY, API_TOKEN))
+                .isInstanceOf(JiraValidationException.class)
+                .hasMessage("JIRA validation failed: API token is invalid or expired");
+    }
+
+    // ── 404 — project key not found ──────────────────────────────────────
+
+    @Test
+    void validate_throwsProjectNotFound_whenJiraReturns404() {
+        when(restTemplate.exchange(eq(EXPECTED_URL), eq(HttpMethod.GET), any(HttpEntity.class), eq(Void.class)))
+                .thenThrow(new HttpClientErrorException(HttpStatus.NOT_FOUND));
+
+        assertThatThrownBy(() -> service.validate(JIRA_URL, PROJECT_KEY, API_TOKEN))
+                .isInstanceOf(JiraValidationException.class)
+                .hasMessage("JIRA validation failed: Project key 'SPM' not found");
+    }
+
+    // ── Other 4xx — unreachable / misconfigured URL ──────────────────────
+
+    @Test
+    void validate_throwsUnreachable_whenJiraReturnsOther4xx() {
+        when(restTemplate.exchange(eq(EXPECTED_URL), eq(HttpMethod.GET), any(HttpEntity.class), eq(Void.class)))
+                .thenThrow(new HttpClientErrorException(HttpStatus.BAD_REQUEST));
+
+        assertThatThrownBy(() -> service.validate(JIRA_URL, PROJECT_KEY, API_TOKEN))
+                .isInstanceOf(JiraValidationException.class)
+                .hasMessage("JIRA validation failed: JIRA space URL is unreachable");
+    }
+
+    // ── Timeout / network failure ─────────────────────────────────────────
+
+    @Test
+    void validate_throwsUnreachable_whenTimeout() {
+        when(restTemplate.exchange(eq(EXPECTED_URL), eq(HttpMethod.GET), any(HttpEntity.class), eq(Void.class)))
+                .thenThrow(new ResourceAccessException("Connection timed out"));
+
+        assertThatThrownBy(() -> service.validate(JIRA_URL, PROJECT_KEY, API_TOKEN))
+                .isInstanceOf(JiraValidationException.class)
+                .hasMessage("JIRA validation failed: JIRA space URL is unreachable");
+    }
+
+    // ── URL normalisation ─────────────────────────────────────────────────
+
+    @Test
+    void validate_handlesTrailingSlash_inJiraUrl() {
+        // Trailing slash in jiraSpaceUrl must be stripped before appending the path.
+        // "https://myteam.atlassian.net/" → exchange must be called with
+        // "https://myteam.atlassian.net/rest/api/3/project/SPM" (single slash, not double).
+        String urlWithSlash = JIRA_URL + "/";
+        when(restTemplate.exchange(eq(EXPECTED_URL), eq(HttpMethod.GET), any(HttpEntity.class), eq(Void.class)))
+                .thenReturn(new ResponseEntity<>(HttpStatus.OK));
+
+        assertThatNoException().isThrownBy(() -> service.validate(urlWithSlash, PROJECT_KEY, API_TOKEN));
+        verify(restTemplate).exchange(eq(EXPECTED_URL), eq(HttpMethod.GET), any(HttpEntity.class), eq(Void.class));
+    }
+
+    @Test
+    void validate_stripsTrailingWhitespace_fromJiraUrl() {
+        String urlWithSpaces = JIRA_URL + "   ";
+        when(restTemplate.exchange(eq(EXPECTED_URL), eq(HttpMethod.GET), any(HttpEntity.class), eq(Void.class)))
+                .thenReturn(new ResponseEntity<>(HttpStatus.OK));
+
+        assertThatNoException().isThrownBy(() -> service.validate(urlWithSpaces, PROJECT_KEY, API_TOKEN));
+        verify(restTemplate).exchange(eq(EXPECTED_URL), eq(HttpMethod.GET), any(HttpEntity.class), eq(Void.class));
+    }
+
+    // ── Exception hierarchy — GlobalExceptionHandler relies on this ───────
+
+    @Test
+    void validate_throwsExternalToolValidationException_onFailure() {
+        // JiraValidationException must extend ExternalToolValidationException so that
+        // GlobalExceptionHandler.handleExternalToolValidation() catches it and returns 422.
+        // If this hierarchy breaks, failures silently become 500s instead of 422s.
+        when(restTemplate.exchange(eq(EXPECTED_URL), eq(HttpMethod.GET), any(HttpEntity.class), eq(Void.class)))
+                .thenThrow(new HttpClientErrorException(HttpStatus.UNAUTHORIZED));
+
+        assertThatThrownBy(() -> service.validate(JIRA_URL, PROJECT_KEY, API_TOKEN))
+                .isInstanceOf(ExternalToolValidationException.class);
+    }
+
+    // ── Authorization header ──────────────────────────────────────────────
+
+    @SuppressWarnings("unchecked")
+    @Test
+    void validate_setsBearerHeader() {
+        when(restTemplate.exchange(eq(EXPECTED_URL), eq(HttpMethod.GET), any(HttpEntity.class), eq(Void.class)))
+                .thenReturn(new ResponseEntity<>(HttpStatus.OK));
+
+        service.validate(JIRA_URL, PROJECT_KEY, API_TOKEN);
+
+        ArgumentCaptor<HttpEntity<Void>> captor = ArgumentCaptor.forClass(HttpEntity.class);
+        verify(restTemplate).exchange(eq(EXPECTED_URL), eq(HttpMethod.GET), captor.capture(), eq(Void.class));
+        String authHeader = captor.getValue().getHeaders().getFirst("Authorization");
+        org.assertj.core.api.Assertions.assertThat(authHeader).isEqualTo("Bearer " + API_TOKEN);
+    }
+}


### PR DESCRIPTION
Built REST clients via JiraValidationService and GitHubValidationService to ping external APIs and verify credentials.

Configured a strict 5-second timeout for all external API REST requests.

Added fail-fast logic for GitHub API to skip the repo scope API check if the org check fails.

Mapped external API HTTP failures to 422 Unprocessable Entity via GlobalExceptionHandler.

Resolves https://github.com/SE3318-Spring-2025-2026/senior-app-6/issues/48