### PR TITLE
Issue #39: Core domain entities and repositories for Process 2

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -85,6 +85,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.springframework.security</groupId>
             <artifactId>spring-security-test</artifactId>
             <scope>test</scope>

--- a/backend/src/main/java/com/senior/spm/entity/AdvisorRequest.java
+++ b/backend/src/main/java/com/senior/spm/entity/AdvisorRequest.java
@@ -1,0 +1,57 @@
+package com.senior.spm.entity;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.ForeignKey;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Table(name = "advisor_request")
+@Getter
+@Setter
+@NoArgsConstructor
+public class AdvisorRequest {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID id;
+
+    @ManyToOne
+    @JoinColumn(name = "group_id", nullable = false, foreignKey = @ForeignKey(name = "fk_advisor_request_group"))
+    private ProjectGroup group;
+
+    @ManyToOne
+    @JoinColumn(name = "advisor_id", nullable = false, foreignKey = @ForeignKey(name = "fk_advisor_request_advisor"))
+    private StaffUser advisor;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private RequestStatus status;
+
+    @Column(nullable = false)
+    private LocalDateTime sentAt;
+
+    @Column(nullable = true)
+    private LocalDateTime respondedAt;
+
+    public enum RequestStatus {
+        PENDING,
+        ACCEPTED,
+        REJECTED,
+        AUTO_REJECTED,
+        CANCELLED
+    }
+}

--- a/backend/src/main/java/com/senior/spm/entity/GroupInvitation.java
+++ b/backend/src/main/java/com/senior/spm/entity/GroupInvitation.java
@@ -1,0 +1,57 @@
+package com.senior.spm.entity;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.ForeignKey;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Table(name = "group_invitation")
+@Getter
+@Setter
+@NoArgsConstructor
+public class GroupInvitation {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID id;
+
+    @ManyToOne
+    @JoinColumn(name = "group_id", nullable = false, foreignKey = @ForeignKey(name = "fk_group_invitation_group"))
+    private ProjectGroup group;
+
+    @ManyToOne
+    @JoinColumn(name = "target_student_id", nullable = false, foreignKey = @ForeignKey(name = "fk_group_invitation_student"))
+    private Student targetStudent;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private InvitationStatus status;
+
+    @Column(nullable = false)
+    private LocalDateTime sentAt;
+
+    @Column(nullable = true)
+    private LocalDateTime respondedAt;
+
+    public enum InvitationStatus {
+        PENDING,
+        ACCEPTED,
+        DECLINED,
+        CANCELLED,
+        AUTO_DENIED
+    }
+}

--- a/backend/src/main/java/com/senior/spm/entity/GroupInvitation.java
+++ b/backend/src/main/java/com/senior/spm/entity/GroupInvitation.java
@@ -34,8 +34,8 @@ public class GroupInvitation {
     private ProjectGroup group;
 
     @ManyToOne
-    @JoinColumn(name = "target_student_id", nullable = false, foreignKey = @ForeignKey(name = "fk_group_invitation_student"))
-    private Student targetStudent;
+    @JoinColumn(name = "invitee_student_id", nullable = false, foreignKey = @ForeignKey(name = "fk_group_invitation_student"))
+    private Student invitee;
 
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)

--- a/backend/src/main/java/com/senior/spm/entity/GroupMembership.java
+++ b/backend/src/main/java/com/senior/spm/entity/GroupMembership.java
@@ -1,0 +1,54 @@
+package com.senior.spm.entity;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.ForeignKey;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Table(name = "group_membership", uniqueConstraints = {
+    @UniqueConstraint(name = "uq_gm_student", columnNames = {"group_id", "student_id"})
+})
+@Getter
+@Setter
+@NoArgsConstructor
+public class GroupMembership {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID id;
+
+    @ManyToOne
+    @JoinColumn(name = "group_id", nullable = false, foreignKey = @ForeignKey(name = "fk_group_membership_group"))
+    private ProjectGroup group;
+
+    @ManyToOne
+    @JoinColumn(name = "student_id", nullable = false, foreignKey = @ForeignKey(name = "fk_group_membership_student"))
+    private Student student;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private MemberRole role;
+
+    @Column(nullable = false)
+    private LocalDateTime joinedAt;
+
+    public enum MemberRole {
+        TEAM_LEADER,
+        MEMBER
+    }
+}

--- a/backend/src/main/java/com/senior/spm/entity/GroupMembership.java
+++ b/backend/src/main/java/com/senior/spm/entity/GroupMembership.java
@@ -21,7 +21,8 @@ import lombok.Setter;
 
 @Entity
 @Table(name = "group_membership", uniqueConstraints = {
-    @UniqueConstraint(name = "uq_gm_student", columnNames = {"group_id", "student_id"})
+    @UniqueConstraint(name = "uq_gm_group_student", columnNames = {"group_id", "student_id"}),
+    @UniqueConstraint(name = "uq_gm_student", columnNames = {"student_id"})
 })
 @Getter
 @Setter

--- a/backend/src/main/java/com/senior/spm/entity/ProjectGroup.java
+++ b/backend/src/main/java/com/senior/spm/entity/ProjectGroup.java
@@ -40,7 +40,7 @@ public class ProjectGroup {
     private GroupStatus status;
 
     @Column(nullable = false)
-    private UUID termId;
+    private String termId;
 
     @Column(nullable = false)
     private LocalDateTime createdAt;
@@ -51,23 +51,23 @@ public class ProjectGroup {
     @Column(length = 100, nullable = true)
     private String jiraProjectKey;
 
-    @Column(columnDefinition = "LONGTEXT", nullable = true)
+    @Column(length = 1024, nullable = true)
     private String encryptedJiraToken;
 
     @Column(length = 100, nullable = true)
     private String githubOrgName;
 
-    @Column(columnDefinition = "LONGTEXT", nullable = true)
+    @Column(length = 1024, nullable = true)
     private String encryptedGithubPat;
 
     @ManyToOne
     @JoinColumn(name = "advisor_id", nullable = true, foreignKey = @ForeignKey(name = "fk_project_group_advisor"))
     private StaffUser advisor;
 
-    @OneToMany(mappedBy = "groupId")
+    @OneToMany(mappedBy = "group")
     private List<GroupMembership> members;
 
-    @OneToMany(mappedBy = "groupId")
+    @OneToMany(mappedBy = "group")
     private List<GroupInvitation> invitations;
 
     @Version

--- a/backend/src/main/java/com/senior/spm/entity/ProjectGroup.java
+++ b/backend/src/main/java/com/senior/spm/entity/ProjectGroup.java
@@ -1,0 +1,84 @@
+package com.senior.spm.entity;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.ForeignKey;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
+import jakarta.persistence.Version;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Table(name = "project_group")
+@Getter
+@Setter
+@NoArgsConstructor
+public class ProjectGroup {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID id;
+
+    @Column(nullable = false)
+    private String groupName;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private GroupStatus status;
+
+    @Column(nullable = false)
+    private UUID termId;
+
+    @Column(nullable = false)
+    private LocalDateTime createdAt;
+
+    @Column(length = 500, nullable = true)
+    private String jiraSpaceUrl;
+
+    @Column(length = 100, nullable = true)
+    private String jiraProjectKey;
+
+    @Column(columnDefinition = "LONGTEXT", nullable = true)
+    private String encryptedJiraToken;
+
+    @Column(length = 100, nullable = true)
+    private String githubOrgName;
+
+    @Column(columnDefinition = "LONGTEXT", nullable = true)
+    private String encryptedGithubPat;
+
+    @ManyToOne
+    @JoinColumn(name = "advisor_id", nullable = true, foreignKey = @ForeignKey(name = "fk_project_group_advisor"))
+    private StaffUser advisor;
+
+    @OneToMany(mappedBy = "groupId")
+    private List<GroupMembership> members;
+
+    @OneToMany(mappedBy = "groupId")
+    private List<GroupInvitation> invitations;
+
+    @Version
+    @Column(nullable = false)
+    private Long version;
+
+    public enum GroupStatus {
+        FORMING,
+        TOOLS_PENDING,
+        TOOLS_BOUND,
+        ADVISOR_ASSIGNED,
+        DISBANDED
+    }
+}

--- a/backend/src/main/java/com/senior/spm/entity/ScheduleWindow.java
+++ b/backend/src/main/java/com/senior/spm/entity/ScheduleWindow.java
@@ -27,7 +27,7 @@ public class ScheduleWindow {
     private UUID id;
 
     @Column(nullable = false)
-    private UUID termId;
+    private String termId;
 
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)

--- a/backend/src/main/java/com/senior/spm/entity/ScheduleWindow.java
+++ b/backend/src/main/java/com/senior/spm/entity/ScheduleWindow.java
@@ -1,6 +1,6 @@
 package com.senior.spm.entity;
 
-import java.util.List;
+import java.time.LocalDateTime;
 import java.util.UUID;
 
 import jakarta.persistence.Column;
@@ -10,46 +10,37 @@ import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
-import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 @Entity
-@Table(name = "staffUser")
+@Table(name = "schedule_window")
 @Getter
 @Setter
 @NoArgsConstructor
-public class StaffUser {
+public class ScheduleWindow {
 
     @Id
     @GeneratedValue(strategy = GenerationType.UUID)
     private UUID id;
 
-    @Column(nullable = false, unique = true)
-    private String mail;
-
     @Column(nullable = false)
-    private String passwordHash;
+    private UUID termId;
 
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
-    private Role role;
+    private WindowType type;
 
     @Column(nullable = false)
-    private boolean firstLogin = true;
+    private LocalDateTime opensAt;
 
     @Column(nullable = false)
-    private int advisorCapacity = 5;
+    private LocalDateTime closesAt;
 
-    @OneToMany(mappedBy = "advisor")
-    private List<ProjectGroup> advisedGroups;
-
-    @OneToMany(mappedBy = "advisor")
-    private List<AdvisorRequest> receivedRequests;
-
-    public enum Role {
-        Admin, Coordinator, Professor
+    public enum WindowType {
+        GROUP_CREATION,
+        ADVISOR_ASSOCIATION
     }
 }

--- a/backend/src/main/java/com/senior/spm/entity/Student.java
+++ b/backend/src/main/java/com/senior/spm/entity/Student.java
@@ -1,5 +1,6 @@
 package com.senior.spm.entity;
 
+import java.util.List;
 import java.util.UUID;
 
 import jakarta.persistence.Column;
@@ -7,6 +8,7 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 import jakarta.validation.constraints.Pattern;
 import lombok.Getter;
@@ -30,4 +32,10 @@ public class Student {
 
     @Column(length = 255, nullable = true, unique = true)
     private String githubUsername;
+
+    @OneToMany(mappedBy = "student")
+    private List<GroupMembership> memberships;
+
+    @OneToMany(mappedBy = "targetStudent")
+    private List<GroupInvitation> invitations;
 }

--- a/backend/src/main/java/com/senior/spm/entity/Student.java
+++ b/backend/src/main/java/com/senior/spm/entity/Student.java
@@ -36,6 +36,6 @@ public class Student {
     @OneToMany(mappedBy = "student")
     private List<GroupMembership> memberships;
 
-    @OneToMany(mappedBy = "targetStudent")
+    @OneToMany(mappedBy = "invitee")
     private List<GroupInvitation> invitations;
 }

--- a/backend/src/main/java/com/senior/spm/repository/AdvisorRequestRepository.java
+++ b/backend/src/main/java/com/senior/spm/repository/AdvisorRequestRepository.java
@@ -23,9 +23,15 @@ public interface AdvisorRequestRepository extends JpaRepository<AdvisorRequest, 
 
     Optional<AdvisorRequest> findByGroupIdAndStatus(UUID groupId, RequestStatus status);
 
+    Optional<AdvisorRequest> findTopByGroupIdOrderBySentAtDesc(UUID groupId);
+
     long countByAdvisorIdAndStatus(UUID advisorId, RequestStatus status);
 
     @Modifying
     @Query("UPDATE AdvisorRequest ar SET ar.status = ?1 WHERE ar.status = 'PENDING' AND ar.group.id = ?2 AND ar.id != ?3")
     void bulkUpdateStatusForGroup(RequestStatus status, UUID groupId, UUID excludeId);
+
+    @Modifying
+    @Query("UPDATE AdvisorRequest ar SET ar.status = :status WHERE ar.status = 'PENDING' AND ar.group.id = :groupId")
+    void bulkUpdateStatusByGroupId(@org.springframework.data.repository.query.Param("status") RequestStatus status, @org.springframework.data.repository.query.Param("groupId") UUID groupId);
 }

--- a/backend/src/main/java/com/senior/spm/repository/AdvisorRequestRepository.java
+++ b/backend/src/main/java/com/senior/spm/repository/AdvisorRequestRepository.java
@@ -1,0 +1,31 @@
+package com.senior.spm.repository;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.stereotype.Repository;
+
+import com.senior.spm.entity.AdvisorRequest;
+import com.senior.spm.entity.AdvisorRequest.RequestStatus;
+
+@Repository
+public interface AdvisorRequestRepository extends JpaRepository<AdvisorRequest, UUID> {
+
+    List<AdvisorRequest> findByGroupId(UUID groupId);
+
+    List<AdvisorRequest> findByAdvisorId(UUID advisorId);
+
+    List<AdvisorRequest> findByAdvisorIdAndStatus(UUID advisorId, RequestStatus status);
+
+    Optional<AdvisorRequest> findByGroupIdAndStatus(UUID groupId, RequestStatus status);
+
+    long countByAdvisorIdAndStatus(UUID advisorId, RequestStatus status);
+
+    @Modifying
+    @Query("UPDATE AdvisorRequest ar SET ar.status = ?1 WHERE ar.status = 'PENDING' AND ar.group.id = ?2 AND ar.id != ?3")
+    void bulkUpdateStatusForGroup(RequestStatus status, UUID groupId, UUID excludeId);
+}

--- a/backend/src/main/java/com/senior/spm/repository/GroupInvitationRepository.java
+++ b/backend/src/main/java/com/senior/spm/repository/GroupInvitationRepository.java
@@ -16,13 +16,19 @@ public interface GroupInvitationRepository extends JpaRepository<GroupInvitation
 
     List<GroupInvitation> findByGroupId(UUID groupId);
 
-    List<GroupInvitation> findByTargetStudentId(UUID targetStudentId);
+    List<GroupInvitation> findByInviteeId(UUID inviteeId);
 
-    List<GroupInvitation> findByTargetStudentIdAndStatus(UUID targetStudentId, InvitationStatus status);
+    List<GroupInvitation> findByInviteeIdAndStatus(UUID inviteeId, InvitationStatus status);
 
-    boolean existsByGroupIdAndTargetStudentIdAndStatus(UUID groupId, UUID targetStudentId, InvitationStatus status);
+    boolean existsByGroupIdAndInviteeIdAndStatus(UUID groupId, UUID inviteeId, InvitationStatus status);
+
+    long countByGroupIdAndStatus(UUID groupId, InvitationStatus status);
 
     @Modifying
-    @Query("UPDATE GroupInvitation gi SET gi.status = 'AUTO_DENIED' WHERE gi.status = 'PENDING' AND gi.targetStudent.id = ?1 AND gi.group.id != ?2")
+    @Query("UPDATE GroupInvitation gi SET gi.status = 'AUTO_DENIED' WHERE gi.status = 'PENDING' AND gi.invitee.id = ?1 AND gi.group.id != ?2")
     void autoDenyOtherPendingInvitations(UUID studentId, UUID acceptedGroupId);
+
+    @Modifying
+    @Query("UPDATE GroupInvitation gi SET gi.status = 'AUTO_DENIED' WHERE gi.status = 'PENDING' AND gi.group.id = ?1")
+    void autoDenyAllPendingByGroupId(UUID groupId);
 }

--- a/backend/src/main/java/com/senior/spm/repository/GroupInvitationRepository.java
+++ b/backend/src/main/java/com/senior/spm/repository/GroupInvitationRepository.java
@@ -1,0 +1,28 @@
+package com.senior.spm.repository;
+
+import java.util.List;
+import java.util.UUID;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.stereotype.Repository;
+
+import com.senior.spm.entity.GroupInvitation;
+import com.senior.spm.entity.GroupInvitation.InvitationStatus;
+
+@Repository
+public interface GroupInvitationRepository extends JpaRepository<GroupInvitation, UUID> {
+
+    List<GroupInvitation> findByGroupId(UUID groupId);
+
+    List<GroupInvitation> findByTargetStudentId(UUID targetStudentId);
+
+    List<GroupInvitation> findByTargetStudentIdAndStatus(UUID targetStudentId, InvitationStatus status);
+
+    boolean existsByGroupIdAndTargetStudentIdAndStatus(UUID groupId, UUID targetStudentId, InvitationStatus status);
+
+    @Modifying
+    @Query("UPDATE GroupInvitation gi SET gi.status = 'AUTO_DENIED' WHERE gi.status = 'PENDING' AND gi.targetStudent.id = ?1 AND gi.group.id != ?2")
+    void autoDenyOtherPendingInvitations(UUID studentId, UUID acceptedGroupId);
+}

--- a/backend/src/main/java/com/senior/spm/repository/GroupMembershipRepository.java
+++ b/backend/src/main/java/com/senior/spm/repository/GroupMembershipRepository.java
@@ -1,0 +1,29 @@
+package com.senior.spm.repository;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import com.senior.spm.entity.GroupMembership;
+import com.senior.spm.entity.GroupMembership.MemberRole;
+
+@Repository
+public interface GroupMembershipRepository extends JpaRepository<GroupMembership, UUID> {
+
+    Optional<GroupMembership> findByStudentId(UUID studentId);
+
+    Optional<GroupMembership> findByGroupIdAndStudentId(UUID groupId, UUID studentId);
+
+    boolean existsByStudentId(UUID studentId);
+
+    List<GroupMembership> findByGroupId(UUID groupId);
+
+    Optional<GroupMembership> findByGroupIdAndRole(UUID groupId, MemberRole role);
+
+    long countByGroupId(UUID groupId);
+
+    void deleteByGroupId(UUID groupId);
+}

--- a/backend/src/main/java/com/senior/spm/repository/ProjectGroupRepository.java
+++ b/backend/src/main/java/com/senior/spm/repository/ProjectGroupRepository.java
@@ -13,13 +13,15 @@ import com.senior.spm.entity.ProjectGroup.GroupStatus;
 @Repository
 public interface ProjectGroupRepository extends JpaRepository<ProjectGroup, UUID> {
 
-    boolean existsByGroupNameAndTermId(String groupName, UUID termId);
+    boolean existsByGroupNameAndTermId(String groupName, String termId);
 
     Optional<ProjectGroup> findByIdAndStatus(UUID id, GroupStatus status);
 
-    List<ProjectGroup> findByTermId(UUID termId);
+    List<ProjectGroup> findByTermId(String termId);
 
-    List<ProjectGroup> findByTermIdAndStatus(UUID termId, GroupStatus status);
+    List<ProjectGroup> findByTermIdAndStatus(String termId, GroupStatus status);
 
-    long countByAdvisorIdAndTermId(UUID advisorId, UUID termId);
+    long countByAdvisorIdAndTermIdAndStatusNot(UUID advisorId, String termId, GroupStatus status);
+
+    List<ProjectGroup> findByTermIdAndStatusNotAndAdvisorIsNull(String termId, GroupStatus status);
 }

--- a/backend/src/main/java/com/senior/spm/repository/ProjectGroupRepository.java
+++ b/backend/src/main/java/com/senior/spm/repository/ProjectGroupRepository.java
@@ -1,0 +1,25 @@
+package com.senior.spm.repository;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import com.senior.spm.entity.ProjectGroup;
+import com.senior.spm.entity.ProjectGroup.GroupStatus;
+
+@Repository
+public interface ProjectGroupRepository extends JpaRepository<ProjectGroup, UUID> {
+
+    boolean existsByGroupNameAndTermId(String groupName, UUID termId);
+
+    Optional<ProjectGroup> findByIdAndStatus(UUID id, GroupStatus status);
+
+    List<ProjectGroup> findByTermId(UUID termId);
+
+    List<ProjectGroup> findByTermIdAndStatus(UUID termId, GroupStatus status);
+
+    long countByAdvisorIdAndTermId(UUID advisorId, UUID termId);
+}

--- a/backend/src/main/java/com/senior/spm/repository/ScheduleWindowRepository.java
+++ b/backend/src/main/java/com/senior/spm/repository/ScheduleWindowRepository.java
@@ -1,0 +1,20 @@
+package com.senior.spm.repository;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import com.senior.spm.entity.ScheduleWindow;
+import com.senior.spm.entity.ScheduleWindow.WindowType;
+
+@Repository
+public interface ScheduleWindowRepository extends JpaRepository<ScheduleWindow, UUID> {
+
+    Optional<ScheduleWindow> findByTermIdAndType(UUID termId, WindowType type);
+
+    List<ScheduleWindow> findByTypeAndClosesAtLessThan(WindowType type, LocalDateTime dateTime);
+}

--- a/backend/src/main/java/com/senior/spm/repository/ScheduleWindowRepository.java
+++ b/backend/src/main/java/com/senior/spm/repository/ScheduleWindowRepository.java
@@ -14,7 +14,7 @@ import com.senior.spm.entity.ScheduleWindow.WindowType;
 @Repository
 public interface ScheduleWindowRepository extends JpaRepository<ScheduleWindow, UUID> {
 
-    Optional<ScheduleWindow> findByTermIdAndType(UUID termId, WindowType type);
+    Optional<ScheduleWindow> findByTermIdAndType(String termId, WindowType type);
 
     List<ScheduleWindow> findByTypeAndClosesAtLessThan(WindowType type, LocalDateTime dateTime);
 }

--- a/backend/src/main/java/com/senior/spm/repository/StaffUserRepository.java
+++ b/backend/src/main/java/com/senior/spm/repository/StaffUserRepository.java
@@ -1,5 +1,6 @@
 package com.senior.spm.repository;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -7,9 +8,12 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 import com.senior.spm.entity.StaffUser;
+import com.senior.spm.entity.StaffUser.Role;
 
 @Repository
 public interface StaffUserRepository extends JpaRepository<StaffUser, UUID> {
 
     Optional<StaffUser> findByMail(String mail);
+
+    List<StaffUser> findByRole(Role role);
 }

--- a/backend/src/test/java/com/senior/spm/entity/EntityAnnotationTest.java
+++ b/backend/src/test/java/com/senior/spm/entity/EntityAnnotationTest.java
@@ -1,0 +1,163 @@
+package com.senior.spm.entity;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.lang.reflect.Field;
+import java.util.Arrays;
+
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import jakarta.persistence.Version;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Verifies entity-level constraints and annotations that the spec mandates.
+ * Pure unit tests — no database or Spring context required.
+ */
+class EntityAnnotationTest {
+
+    // ── termId type (must be String, not UUID — TermConfigService returns String) ──
+
+    @Test
+    void projectGroup_termId_isString() throws Exception {
+        Field f = ProjectGroup.class.getDeclaredField("termId");
+        assertThat(f.getType()).isEqualTo(String.class);
+    }
+
+    @Test
+    void scheduleWindow_termId_isString() throws Exception {
+        Field f = ScheduleWindow.class.getDeclaredField("termId");
+        assertThat(f.getType()).isEqualTo(String.class);
+    }
+
+    // ── Optimistic locking — @Version Long version on ProjectGroup ───────────
+
+    @Test
+    void projectGroup_version_hasVersionAnnotation() throws Exception {
+        Field f = ProjectGroup.class.getDeclaredField("version");
+        assertThat(f.isAnnotationPresent(Version.class)).isTrue();
+    }
+
+    @Test
+    void projectGroup_version_isLong() throws Exception {
+        Field f = ProjectGroup.class.getDeclaredField("version");
+        assertThat(f.getType()).isEqualTo(Long.class);
+    }
+
+    // ── GroupMembership TWO unique constraints ────────────────────────────────
+
+    @Test
+    void groupMembership_hasTwoUniqueConstraints() {
+        Table table = GroupMembership.class.getAnnotation(Table.class);
+        assertThat(table.uniqueConstraints()).hasSize(2);
+    }
+
+    @Test
+    void groupMembership_compositeConstraint_isNamedCorrectlyAndCoversGroupAndStudent() {
+        UniqueConstraint composite = findConstraint(GroupMembership.class, "uq_gm_group_student");
+        assertThat(composite.columnNames()).containsExactlyInAnyOrder("group_id", "student_id");
+    }
+
+    @Test
+    void groupMembership_singleConstraint_isNamedCorrectlyAndCoversStudentOnly() {
+        UniqueConstraint single = findConstraint(GroupMembership.class, "uq_gm_student");
+        assertThat(single.columnNames()).containsExactly("student_id");
+    }
+
+    // ── GroupInvitation column naming per ER spec ─────────────────────────────
+
+    @Test
+    void groupInvitation_invitee_joinColumnName_isInviteeStudentId() throws Exception {
+        Field f = GroupInvitation.class.getDeclaredField("invitee");
+        JoinColumn jc = f.getAnnotation(JoinColumn.class);
+        assertThat(jc.name()).isEqualTo("invitee_student_id");
+    }
+
+    // ── ProjectGroup advisor FK is nullable ───────────────────────────────────
+
+    @Test
+    void projectGroup_advisor_joinColumn_isNullable() throws Exception {
+        Field f = ProjectGroup.class.getDeclaredField("advisor");
+        JoinColumn jc = f.getAnnotation(JoinColumn.class);
+        assertThat(jc.nullable()).isTrue();
+    }
+
+    // ── Enum completeness ─────────────────────────────────────────────────────
+
+    @Test
+    void groupStatus_hasExactlyFiveValues() {
+        assertThat(ProjectGroup.GroupStatus.values())
+                .containsExactlyInAnyOrder(
+                        ProjectGroup.GroupStatus.FORMING,
+                        ProjectGroup.GroupStatus.TOOLS_PENDING,
+                        ProjectGroup.GroupStatus.TOOLS_BOUND,
+                        ProjectGroup.GroupStatus.ADVISOR_ASSIGNED,
+                        ProjectGroup.GroupStatus.DISBANDED);
+    }
+
+    @Test
+    void invitationStatus_hasAllRequiredValues() {
+        assertThat(GroupInvitation.InvitationStatus.values())
+                .containsExactlyInAnyOrder(
+                        GroupInvitation.InvitationStatus.PENDING,
+                        GroupInvitation.InvitationStatus.ACCEPTED,
+                        GroupInvitation.InvitationStatus.DECLINED,
+                        GroupInvitation.InvitationStatus.CANCELLED,
+                        GroupInvitation.InvitationStatus.AUTO_DENIED);
+    }
+
+    @Test
+    void requestStatus_hasAllRequiredValues() {
+        assertThat(AdvisorRequest.RequestStatus.values())
+                .containsExactlyInAnyOrder(
+                        AdvisorRequest.RequestStatus.PENDING,
+                        AdvisorRequest.RequestStatus.ACCEPTED,
+                        AdvisorRequest.RequestStatus.REJECTED,
+                        AdvisorRequest.RequestStatus.AUTO_REJECTED,
+                        AdvisorRequest.RequestStatus.CANCELLED);
+    }
+
+    @Test
+    void memberRole_hasTeamLeaderAndMember() {
+        assertThat(GroupMembership.MemberRole.values())
+                .containsExactlyInAnyOrder(
+                        GroupMembership.MemberRole.TEAM_LEADER,
+                        GroupMembership.MemberRole.MEMBER);
+    }
+
+    @Test
+    void windowType_hasGroupCreationAndAdvisorAssociation() {
+        assertThat(ScheduleWindow.WindowType.values())
+                .containsExactlyInAnyOrder(
+                        ScheduleWindow.WindowType.GROUP_CREATION,
+                        ScheduleWindow.WindowType.ADVISOR_ASSOCIATION);
+    }
+
+    // ── Encrypted token field lengths per ER spec (VARCHAR 1024) ─────────────
+
+    @Test
+    void projectGroup_encryptedJiraToken_columnLength_is1024() throws Exception {
+        Field f = ProjectGroup.class.getDeclaredField("encryptedJiraToken");
+        jakarta.persistence.Column col = f.getAnnotation(jakarta.persistence.Column.class);
+        assertThat(col.length()).isEqualTo(1024);
+    }
+
+    @Test
+    void projectGroup_encryptedGithubPat_columnLength_is1024() throws Exception {
+        Field f = ProjectGroup.class.getDeclaredField("encryptedGithubPat");
+        jakarta.persistence.Column col = f.getAnnotation(jakarta.persistence.Column.class);
+        assertThat(col.length()).isEqualTo(1024);
+    }
+
+    // ── Helper ────────────────────────────────────────────────────────────────
+
+    private UniqueConstraint findConstraint(Class<?> entityClass, String name) {
+        Table table = entityClass.getAnnotation(Table.class);
+        return Arrays.stream(table.uniqueConstraints())
+                .filter(c -> c.name().equals(name))
+                .findFirst()
+                .orElseThrow(() -> new AssertionError("Constraint '" + name + "' not found on " + entityClass.getSimpleName()));
+    }
+}

--- a/backend/src/test/java/com/senior/spm/repository/AdvisorRequestRepositoryTest.java
+++ b/backend/src/test/java/com/senior/spm/repository/AdvisorRequestRepositoryTest.java
@@ -1,0 +1,177 @@
+package com.senior.spm.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.LocalDateTime;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.test.context.TestPropertySource;
+
+import com.senior.spm.entity.AdvisorRequest;
+import com.senior.spm.entity.AdvisorRequest.RequestStatus;
+import com.senior.spm.entity.ProjectGroup;
+import com.senior.spm.entity.StaffUser;
+
+/**
+ * Verifies AdvisorRequestRepository query methods.
+ *
+ * Critical methods under test:
+ *   findTopByGroupIdOrderBySentAtDesc  — P3 Rule 7: used for getAdvisorRequest/cancel (not findByGroupIdAndStatus)
+ *   bulkUpdateStatusForGroup           — exclude one ID (accept path: auto-reject competing requests)
+ *   bulkUpdateStatusByGroupId          — update ALL (sanitization + coordinator assign)
+ */
+@DataJpaTest
+@TestPropertySource(properties = "spring.sql.init.mode=never")
+class AdvisorRequestRepositoryTest extends RepositoryTestBase {
+
+    @Autowired
+    AdvisorRequestRepository repo;
+
+    // ── findTopByGroupIdOrderBySentAtDesc ─────────────────────────────────────
+    // P3 Rule 7: this is the primary lookup for getAdvisorRequest and cancelAdvisorRequest
+
+    @Test
+    void findTopByGroupIdOrderBySentAtDesc_returnsMostRecentRequest() {
+        StaffUser prof = makeProfessor("prof1@test.com");
+        ProjectGroup group = makeGroup("Group A", "2024-FALL", ProjectGroup.GroupStatus.TOOLS_BOUND);
+
+        LocalDateTime earlier = LocalDateTime.now().minusHours(2);
+        LocalDateTime later = LocalDateTime.now().minusHours(1);
+
+        AdvisorRequest old = makeAdvisorRequest(group, prof, RequestStatus.REJECTED, earlier);
+        AdvisorRequest recent = makeAdvisorRequest(group, prof, RequestStatus.PENDING, later);
+
+        var result = repo.findTopByGroupIdOrderBySentAtDesc(group.getId());
+
+        assertThat(result).isPresent();
+        assertThat(result.get().getId()).isEqualTo(recent.getId());
+    }
+
+    @Test
+    void findTopByGroupIdOrderBySentAtDesc_emptyWhenNoRequests() {
+        ProjectGroup group = makeGroup("Group A", "2024-FALL", ProjectGroup.GroupStatus.TOOLS_BOUND);
+
+        assertThat(repo.findTopByGroupIdOrderBySentAtDesc(group.getId())).isEmpty();
+    }
+
+    // ── bulkUpdateStatusForGroup (with excludeId) ─────────────────────────────
+    // Used on advisor ACCEPT: auto-reject all OTHER pending requests for same group, preserve accepted one
+
+    @Test
+    void bulkUpdateStatusForGroup_updatesAllPendingExceptExcluded() {
+        StaffUser prof1 = makeProfessor("prof2@test.com");
+        StaffUser prof2 = makeProfessor("prof3@test.com");
+        StaffUser prof3 = makeProfessor("prof4@test.com");
+        ProjectGroup group = makeGroup("Group A", "2024-FALL", ProjectGroup.GroupStatus.TOOLS_BOUND);
+
+        AdvisorRequest accepted = makeAdvisorRequest(group, prof1, RequestStatus.PENDING, LocalDateTime.now().minusMinutes(10));
+        AdvisorRequest other1 = makeAdvisorRequest(group, prof2, RequestStatus.PENDING, LocalDateTime.now().minusMinutes(5));
+        AdvisorRequest other2 = makeAdvisorRequest(group, prof3, RequestStatus.PENDING, LocalDateTime.now());
+
+        repo.bulkUpdateStatusForGroup(RequestStatus.AUTO_REJECTED, group.getId(), accepted.getId());
+        clearCache();
+
+        assertThat(repo.findById(accepted.getId()).get().getStatus()).isEqualTo(RequestStatus.PENDING);
+        assertThat(repo.findById(other1.getId()).get().getStatus()).isEqualTo(RequestStatus.AUTO_REJECTED);
+        assertThat(repo.findById(other2.getId()).get().getStatus()).isEqualTo(RequestStatus.AUTO_REJECTED);
+    }
+
+    @Test
+    void bulkUpdateStatusForGroup_doesNotAffectNonPendingRequests() {
+        StaffUser prof1 = makeProfessor("prof5@test.com");
+        StaffUser prof2 = makeProfessor("prof6@test.com");
+        ProjectGroup group = makeGroup("Group A", "2024-FALL", ProjectGroup.GroupStatus.TOOLS_BOUND);
+
+        AdvisorRequest accepted = makeAdvisorRequest(group, prof1, RequestStatus.PENDING, LocalDateTime.now().minusMinutes(5));
+        AdvisorRequest alreadyRejected = makeAdvisorRequest(group, prof2, RequestStatus.REJECTED, LocalDateTime.now());
+
+        repo.bulkUpdateStatusForGroup(RequestStatus.AUTO_REJECTED, group.getId(), accepted.getId());
+        clearCache();
+
+        // REJECTED should stay REJECTED, not changed to AUTO_REJECTED
+        assertThat(repo.findById(alreadyRejected.getId()).get().getStatus()).isEqualTo(RequestStatus.REJECTED);
+    }
+
+    // ── bulkUpdateStatusByGroupId (no excludeId) ──────────────────────────────
+    // Used by SanitizationService (seq 3.4) and coordinator assign (seq 3.5): update ALL pending
+
+    @Test
+    void bulkUpdateStatusByGroupId_updatesAllPendingRequestsForGroup() {
+        StaffUser prof1 = makeProfessor("prof7@test.com");
+        StaffUser prof2 = makeProfessor("prof8@test.com");
+        ProjectGroup group = makeGroup("Group A", "2024-FALL", ProjectGroup.GroupStatus.TOOLS_BOUND);
+
+        AdvisorRequest r1 = makeAdvisorRequest(group, prof1, RequestStatus.PENDING, LocalDateTime.now().minusMinutes(5));
+        AdvisorRequest r2 = makeAdvisorRequest(group, prof2, RequestStatus.PENDING, LocalDateTime.now());
+
+        repo.bulkUpdateStatusByGroupId(RequestStatus.AUTO_REJECTED, group.getId());
+        clearCache();
+
+        assertThat(repo.findById(r1.getId()).get().getStatus()).isEqualTo(RequestStatus.AUTO_REJECTED);
+        assertThat(repo.findById(r2.getId()).get().getStatus()).isEqualTo(RequestStatus.AUTO_REJECTED);
+    }
+
+    @Test
+    void bulkUpdateStatusByGroupId_doesNotAffectOtherGroups() {
+        StaffUser prof = makeProfessor("prof9@test.com");
+        ProjectGroup groupA = makeGroup("Group A", "2024-FALL", ProjectGroup.GroupStatus.TOOLS_BOUND);
+        ProjectGroup groupB = makeGroup("Group B", "2024-FALL", ProjectGroup.GroupStatus.TOOLS_BOUND);
+
+        makeAdvisorRequest(groupA, prof, RequestStatus.PENDING, LocalDateTime.now());
+        AdvisorRequest groupBRequest = makeAdvisorRequest(groupB, prof, RequestStatus.PENDING, LocalDateTime.now());
+
+        repo.bulkUpdateStatusByGroupId(RequestStatus.AUTO_REJECTED, groupA.getId());
+        clearCache();
+
+        // Group B's request must not be touched
+        assertThat(repo.findById(groupBRequest.getId()).get().getStatus()).isEqualTo(RequestStatus.PENDING);
+    }
+
+    // ── findByAdvisorIdAndStatus ──────────────────────────────────────────────
+    // Used by professor inbox (seq 3.2)
+
+    @Test
+    void findByAdvisorIdAndStatus_returnsPendingRequestsForAdvisor() {
+        StaffUser prof = makeProfessor("prof10@test.com");
+        StaffUser otherProf = makeProfessor("prof11@test.com");
+        ProjectGroup g1 = makeGroup("Group A", "2024-FALL", ProjectGroup.GroupStatus.TOOLS_BOUND);
+        ProjectGroup g2 = makeGroup("Group B", "2024-FALL", ProjectGroup.GroupStatus.TOOLS_BOUND);
+        ProjectGroup g3 = makeGroup("Group C", "2024-FALL", ProjectGroup.GroupStatus.TOOLS_BOUND);
+
+        makeAdvisorRequest(g1, prof, RequestStatus.PENDING, LocalDateTime.now());
+        makeAdvisorRequest(g2, prof, RequestStatus.REJECTED, LocalDateTime.now()); // not PENDING
+        makeAdvisorRequest(g3, otherProf, RequestStatus.PENDING, LocalDateTime.now()); // different advisor
+
+        var result = repo.findByAdvisorIdAndStatus(prof.getId(), RequestStatus.PENDING);
+
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).getGroup().getId()).isEqualTo(g1.getId());
+    }
+
+    // ── findByGroupIdAndStatus ────────────────────────────────────────────────
+    // Used for duplicate-request check in sendAdvisorRequest (seq 3.1)
+
+    @Test
+    void findByGroupIdAndStatus_returnsPendingRequestIfExists() {
+        StaffUser prof = makeProfessor("prof12@test.com");
+        ProjectGroup group = makeGroup("Group A", "2024-FALL", ProjectGroup.GroupStatus.TOOLS_BOUND);
+
+        AdvisorRequest pending = makeAdvisorRequest(group, prof, RequestStatus.PENDING, LocalDateTime.now());
+
+        var result = repo.findByGroupIdAndStatus(group.getId(), RequestStatus.PENDING);
+        assertThat(result).isPresent();
+        assertThat(result.get().getId()).isEqualTo(pending.getId());
+    }
+
+    @Test
+    void findByGroupIdAndStatus_emptyWhenNoPendingRequest() {
+        StaffUser prof = makeProfessor("prof13@test.com");
+        ProjectGroup group = makeGroup("Group A", "2024-FALL", ProjectGroup.GroupStatus.TOOLS_BOUND);
+
+        makeAdvisorRequest(group, prof, RequestStatus.REJECTED, LocalDateTime.now());
+
+        assertThat(repo.findByGroupIdAndStatus(group.getId(), RequestStatus.PENDING)).isEmpty();
+    }
+}

--- a/backend/src/test/java/com/senior/spm/repository/GroupInvitationRepositoryTest.java
+++ b/backend/src/test/java/com/senior/spm/repository/GroupInvitationRepositoryTest.java
@@ -1,0 +1,226 @@
+package com.senior.spm.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.test.context.TestPropertySource;
+
+import com.senior.spm.entity.GroupInvitation;
+import com.senior.spm.entity.GroupInvitation.InvitationStatus;
+import com.senior.spm.entity.ProjectGroup;
+import com.senior.spm.entity.Student;
+
+/**
+ * Verifies GroupInvitationRepository query methods.
+ *
+ * Critical methods under test:
+ *   countByGroupIdAndStatus           — used for max-team-size check (seq 2.2, 2.3)
+ *   autoDenyOtherPendingInvitations   — on accept: deny invitations from OTHER groups (seq 2.3)
+ *   autoDenyAllPendingByGroupId       — on disband: deny all outbound pending invites (seq 2.6)
+ */
+@DataJpaTest
+@TestPropertySource(properties = "spring.sql.init.mode=never")
+class GroupInvitationRepositoryTest extends RepositoryTestBase {
+
+    @Autowired
+    GroupInvitationRepository repo;
+
+    // ── countByGroupIdAndStatus ────────────────────────────────────────────────
+    // Max-team-size check: count = current members + pending outbound invitations
+
+    @Test
+    void countByGroupIdAndStatus_countsPendingInvitationsOnly() {
+        Student s1 = makeStudent("23070000101");
+        Student s2 = makeStudent("23070000102");
+        Student s3 = makeStudent("23070000103");
+        ProjectGroup group = makeGroup("Group A", "2024-FALL", ProjectGroup.GroupStatus.FORMING);
+
+        makeInvitation(group, s1, InvitationStatus.PENDING);
+        makeInvitation(group, s2, InvitationStatus.PENDING);
+        makeInvitation(group, s3, InvitationStatus.DECLINED); // not PENDING
+
+        long count = repo.countByGroupIdAndStatus(group.getId(), InvitationStatus.PENDING);
+
+        assertThat(count).isEqualTo(2);
+    }
+
+    @Test
+    void countByGroupIdAndStatus_returnsZeroWhenNoPendingInvitations() {
+        ProjectGroup group = makeGroup("Group A", "2024-FALL", ProjectGroup.GroupStatus.FORMING);
+
+        assertThat(repo.countByGroupIdAndStatus(group.getId(), InvitationStatus.PENDING)).isEqualTo(0);
+    }
+
+    @Test
+    void countByGroupIdAndStatus_doesNotCountOtherGroupsInvitations() {
+        Student s1 = makeStudent("23070000104");
+        Student s2 = makeStudent("23070000105");
+        ProjectGroup groupA = makeGroup("Group A", "2024-FALL", ProjectGroup.GroupStatus.FORMING);
+        ProjectGroup groupB = makeGroup("Group B", "2024-FALL", ProjectGroup.GroupStatus.FORMING);
+
+        makeInvitation(groupA, s1, InvitationStatus.PENDING);
+        makeInvitation(groupB, s2, InvitationStatus.PENDING);
+
+        assertThat(repo.countByGroupIdAndStatus(groupA.getId(), InvitationStatus.PENDING)).isEqualTo(1);
+    }
+
+    // ── autoDenyOtherPendingInvitations ───────────────────────────────────────
+    // On accept: AUTO_DENY all pending invitations for this student from OTHER groups,
+    //            but NOT the accepted group's invitation.
+
+    @Test
+    void autoDenyOtherPendingInvitations_deniesInvitationsFromOtherGroups() {
+        Student student = makeStudent("23070000106");
+        ProjectGroup accepted = makeGroup("Accepted Group", "2024-FALL", ProjectGroup.GroupStatus.FORMING);
+        ProjectGroup other1 = makeGroup("Other Group 1", "2024-FALL", ProjectGroup.GroupStatus.FORMING);
+        ProjectGroup other2 = makeGroup("Other Group 2", "2024-FALL", ProjectGroup.GroupStatus.FORMING);
+
+        GroupInvitation acceptedInv = makeInvitation(accepted, student, InvitationStatus.ACCEPTED);
+        GroupInvitation pending1 = makeInvitation(other1, student, InvitationStatus.PENDING);
+        GroupInvitation pending2 = makeInvitation(other2, student, InvitationStatus.PENDING);
+
+        repo.autoDenyOtherPendingInvitations(student.getId(), accepted.getId());
+        clearCache();
+
+        assertThat(repo.findById(acceptedInv.getId()).get().getStatus()).isEqualTo(InvitationStatus.ACCEPTED);
+        assertThat(repo.findById(pending1.getId()).get().getStatus()).isEqualTo(InvitationStatus.AUTO_DENIED);
+        assertThat(repo.findById(pending2.getId()).get().getStatus()).isEqualTo(InvitationStatus.AUTO_DENIED);
+    }
+
+    @Test
+    void autoDenyOtherPendingInvitations_doesNotDenyNonPendingInvitations() {
+        Student student = makeStudent("23070000107");
+        ProjectGroup accepted = makeGroup("Accepted Group", "2024-FALL", ProjectGroup.GroupStatus.FORMING);
+        ProjectGroup other = makeGroup("Other Group", "2024-FALL", ProjectGroup.GroupStatus.FORMING);
+
+        makeInvitation(accepted, student, InvitationStatus.ACCEPTED);
+        GroupInvitation declined = makeInvitation(other, student, InvitationStatus.DECLINED);
+
+        repo.autoDenyOtherPendingInvitations(student.getId(), accepted.getId());
+        clearCache();
+
+        // DECLINED should not be changed to AUTO_DENIED
+        assertThat(repo.findById(declined.getId()).get().getStatus()).isEqualTo(InvitationStatus.DECLINED);
+    }
+
+    @Test
+    void autoDenyOtherPendingInvitations_doesNotAffectOtherStudents() {
+        Student student = makeStudent("23070000108");
+        Student otherStudent = makeStudent("23070000109");
+        ProjectGroup accepted = makeGroup("Accepted Group", "2024-FALL", ProjectGroup.GroupStatus.FORMING);
+        ProjectGroup other = makeGroup("Other Group", "2024-FALL", ProjectGroup.GroupStatus.FORMING);
+
+        makeInvitation(accepted, student, InvitationStatus.ACCEPTED);
+        GroupInvitation otherStudentInv = makeInvitation(other, otherStudent, InvitationStatus.PENDING);
+
+        repo.autoDenyOtherPendingInvitations(student.getId(), accepted.getId());
+        clearCache();
+
+        // Other student's invitation must not be touched
+        assertThat(repo.findById(otherStudentInv.getId()).get().getStatus()).isEqualTo(InvitationStatus.PENDING);
+    }
+
+    // ── autoDenyAllPendingByGroupId ───────────────────────────────────────────
+    // On group disband: AUTO_DENY all pending outbound invitations from the disbanded group
+
+    @Test
+    void autoDenyAllPendingByGroupId_deniesAllPendingForGroup() {
+        Student s1 = makeStudent("23070000110");
+        Student s2 = makeStudent("23070000111");
+        ProjectGroup group = makeGroup("Group A", "2024-FALL", ProjectGroup.GroupStatus.FORMING);
+
+        GroupInvitation inv1 = makeInvitation(group, s1, InvitationStatus.PENDING);
+        GroupInvitation inv2 = makeInvitation(group, s2, InvitationStatus.PENDING);
+
+        repo.autoDenyAllPendingByGroupId(group.getId());
+        clearCache();
+
+        assertThat(repo.findById(inv1.getId()).get().getStatus()).isEqualTo(InvitationStatus.AUTO_DENIED);
+        assertThat(repo.findById(inv2.getId()).get().getStatus()).isEqualTo(InvitationStatus.AUTO_DENIED);
+    }
+
+    @Test
+    void autoDenyAllPendingByGroupId_doesNotAffectOtherGroups() {
+        Student s1 = makeStudent("23070000112");
+        Student s2 = makeStudent("23070000113");
+        ProjectGroup disbanded = makeGroup("Disbanded", "2024-FALL", ProjectGroup.GroupStatus.DISBANDED);
+        ProjectGroup active = makeGroup("Active", "2024-FALL", ProjectGroup.GroupStatus.FORMING);
+
+        makeInvitation(disbanded, s1, InvitationStatus.PENDING);
+        GroupInvitation activeInv = makeInvitation(active, s2, InvitationStatus.PENDING);
+
+        repo.autoDenyAllPendingByGroupId(disbanded.getId());
+        clearCache();
+
+        // Active group's invitations must not be touched
+        assertThat(repo.findById(activeInv.getId()).get().getStatus()).isEqualTo(InvitationStatus.PENDING);
+    }
+
+    @Test
+    void autoDenyAllPendingByGroupId_doesNotTouchNonPendingInvitations() {
+        Student s1 = makeStudent("23070000114");
+        ProjectGroup group = makeGroup("Group A", "2024-FALL", ProjectGroup.GroupStatus.FORMING);
+
+        GroupInvitation declined = makeInvitation(group, s1, InvitationStatus.DECLINED);
+
+        repo.autoDenyAllPendingByGroupId(group.getId());
+        clearCache();
+
+        assertThat(repo.findById(declined.getId()).get().getStatus()).isEqualTo(InvitationStatus.DECLINED);
+    }
+
+    // ── findByInviteeIdAndStatus ──────────────────────────────────────────────
+    // Used for student's pending invitations inbox (seq 2.3)
+
+    @Test
+    void findByInviteeIdAndStatus_returnsStudentsPendingInvitations() {
+        Student student = makeStudent("23070000115");
+        Student other = makeStudent("23070000116");
+        ProjectGroup g1 = makeGroup("Group A", "2024-FALL", ProjectGroup.GroupStatus.FORMING);
+        ProjectGroup g2 = makeGroup("Group B", "2024-FALL", ProjectGroup.GroupStatus.FORMING);
+        ProjectGroup g3 = makeGroup("Group C", "2024-FALL", ProjectGroup.GroupStatus.FORMING);
+
+        makeInvitation(g1, student, InvitationStatus.PENDING);
+        makeInvitation(g2, student, InvitationStatus.DECLINED); // not PENDING
+        makeInvitation(g3, other, InvitationStatus.PENDING);    // different student
+
+        var result = repo.findByInviteeIdAndStatus(student.getId(), InvitationStatus.PENDING);
+
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).getGroup().getId()).isEqualTo(g1.getId());
+    }
+
+    // ── existsByGroupIdAndInviteeIdAndStatus ──────────────────────────────────
+    // Duplicate-invite check (seq 2.2)
+
+    @Test
+    void existsByGroupIdAndInviteeIdAndStatus_trueWhenPendingInviteExists() {
+        Student student = makeStudent("23070000117");
+        ProjectGroup group = makeGroup("Group A", "2024-FALL", ProjectGroup.GroupStatus.FORMING);
+        makeInvitation(group, student, InvitationStatus.PENDING);
+
+        assertThat(repo.existsByGroupIdAndInviteeIdAndStatus(
+                group.getId(), student.getId(), InvitationStatus.PENDING)).isTrue();
+    }
+
+    @Test
+    void existsByGroupIdAndInviteeIdAndStatus_falseWhenNoInvite() {
+        Student student = makeStudent("23070000118");
+        ProjectGroup group = makeGroup("Group A", "2024-FALL", ProjectGroup.GroupStatus.FORMING);
+
+        assertThat(repo.existsByGroupIdAndInviteeIdAndStatus(
+                group.getId(), student.getId(), InvitationStatus.PENDING)).isFalse();
+    }
+
+    @Test
+    void existsByGroupIdAndInviteeIdAndStatus_falseWhenInviteIsNotPending() {
+        Student student = makeStudent("23070000119");
+        ProjectGroup group = makeGroup("Group A", "2024-FALL", ProjectGroup.GroupStatus.FORMING);
+        makeInvitation(group, student, InvitationStatus.DECLINED);
+
+        assertThat(repo.existsByGroupIdAndInviteeIdAndStatus(
+                group.getId(), student.getId(), InvitationStatus.PENDING)).isFalse();
+    }
+}

--- a/backend/src/test/java/com/senior/spm/repository/GroupMembershipRepositoryTest.java
+++ b/backend/src/test/java/com/senior/spm/repository/GroupMembershipRepositoryTest.java
@@ -1,0 +1,185 @@
+package com.senior.spm.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.time.LocalDateTime;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.test.context.TestPropertySource;
+
+import com.senior.spm.entity.GroupMembership;
+import com.senior.spm.entity.ProjectGroup;
+import com.senior.spm.entity.Student;
+
+/**
+ * Verifies GroupMembership repository + DB-level unique constraints.
+ *
+ * Key constraints under test:
+ *   uq_gm_group_student (group_id, student_id) — no duplicate row for same pair
+ *   uq_gm_student (student_id)               — a student can only be in ONE group
+ */
+@DataJpaTest
+@TestPropertySource(properties = "spring.sql.init.mode=never")
+class GroupMembershipRepositoryTest extends RepositoryTestBase {
+
+    @Autowired
+    GroupMembershipRepository repo;
+
+    // ── uq_gm_student: student can only be in one group ──────────────────────
+    // Uses repo.saveAndFlush() so Spring Data translates PersistenceException → DataIntegrityViolationException
+
+    @Test
+    void uq_gm_student_preventsStudentInTwoGroups() {
+        Student student = makeStudent("23070000001");
+        ProjectGroup g1 = makeGroup("Group A", "2024-FALL", ProjectGroup.GroupStatus.FORMING);
+        ProjectGroup g2 = makeGroup("Group B", "2024-FALL", ProjectGroup.GroupStatus.FORMING);
+
+        GroupMembership first = new GroupMembership();
+        first.setGroup(g1); first.setStudent(student);
+        first.setRole(GroupMembership.MemberRole.TEAM_LEADER); first.setJoinedAt(LocalDateTime.now());
+        repo.saveAndFlush(first);
+
+        assertThatThrownBy(() -> {
+            GroupMembership second = new GroupMembership();
+            second.setGroup(g2); second.setStudent(student);
+            second.setRole(GroupMembership.MemberRole.MEMBER); second.setJoinedAt(LocalDateTime.now());
+            repo.saveAndFlush(second);
+        }).isInstanceOf(DataIntegrityViolationException.class);
+    }
+
+    // ── uq_gm_group_student: no duplicate (group, student) row ───────────────
+
+    @Test
+    void uq_gm_group_student_preventsDuplicateMembershipSameGroupSameStudent() {
+        Student student = makeStudent("23070000002");
+        ProjectGroup group = makeGroup("Group A", "2024-FALL", ProjectGroup.GroupStatus.FORMING);
+
+        GroupMembership first = new GroupMembership();
+        first.setGroup(group); first.setStudent(student);
+        first.setRole(GroupMembership.MemberRole.TEAM_LEADER); first.setJoinedAt(LocalDateTime.now());
+        repo.saveAndFlush(first);
+
+        assertThatThrownBy(() -> {
+            GroupMembership second = new GroupMembership();
+            second.setGroup(group); second.setStudent(student);
+            second.setRole(GroupMembership.MemberRole.MEMBER); second.setJoinedAt(LocalDateTime.now());
+            repo.saveAndFlush(second);
+        }).isInstanceOf(DataIntegrityViolationException.class);
+    }
+
+    // ── Two different students can be in the same group ───────────────────────
+
+    @Test
+    void twoDifferentStudents_canJoinSameGroup() {
+        Student s1 = makeStudent("23070000003");
+        Student s2 = makeStudent("23070000004");
+        ProjectGroup group = makeGroup("Group A", "2024-FALL", ProjectGroup.GroupStatus.FORMING);
+
+        makeMembership(group, s1, GroupMembership.MemberRole.TEAM_LEADER);
+        makeMembership(group, s2, GroupMembership.MemberRole.MEMBER);
+
+        assertThat(repo.countByGroupId(group.getId())).isEqualTo(2);
+    }
+
+    // ── existsByStudentId ─────────────────────────────────────────────────────
+
+    @Test
+    void existsByStudentId_trueWhenMemberExists() {
+        Student student = makeStudent("23070000005");
+        ProjectGroup group = makeGroup("Group A", "2024-FALL", ProjectGroup.GroupStatus.FORMING);
+        makeMembership(group, student, GroupMembership.MemberRole.TEAM_LEADER);
+
+        assertThat(repo.existsByStudentId(student.getId())).isTrue();
+    }
+
+    @Test
+    void existsByStudentId_falseWhenNoMembership() {
+        Student student = makeStudent("23070000006");
+
+        assertThat(repo.existsByStudentId(student.getId())).isFalse();
+    }
+
+    // ── findByGroupId ─────────────────────────────────────────────────────────
+
+    @Test
+    void findByGroupId_returnsAllMembersOfGroup() {
+        Student s1 = makeStudent("23070000007");
+        Student s2 = makeStudent("23070000008");
+        ProjectGroup group = makeGroup("Group A", "2024-FALL", ProjectGroup.GroupStatus.FORMING);
+        ProjectGroup other = makeGroup("Group B", "2024-FALL", ProjectGroup.GroupStatus.FORMING);
+
+        makeMembership(group, s1, GroupMembership.MemberRole.TEAM_LEADER);
+        makeMembership(group, s2, GroupMembership.MemberRole.MEMBER);
+        makeStudent("23070000009"); // student in other group
+        makeMembership(other, makeStudent("23070000010"), GroupMembership.MemberRole.TEAM_LEADER);
+
+        assertThat(repo.findByGroupId(group.getId())).hasSize(2);
+    }
+
+    // ── countByGroupId ────────────────────────────────────────────────────────
+
+    @Test
+    void countByGroupId_returnsCorrectMemberCount() {
+        Student s1 = makeStudent("23070000011");
+        Student s2 = makeStudent("23070000012");
+        Student s3 = makeStudent("23070000013");
+        ProjectGroup group = makeGroup("Group A", "2024-FALL", ProjectGroup.GroupStatus.FORMING);
+
+        makeMembership(group, s1, GroupMembership.MemberRole.TEAM_LEADER);
+        makeMembership(group, s2, GroupMembership.MemberRole.MEMBER);
+        makeMembership(group, s3, GroupMembership.MemberRole.MEMBER);
+
+        assertThat(repo.countByGroupId(group.getId())).isEqualTo(3);
+    }
+
+    // ── deleteByGroupId ───────────────────────────────────────────────────────
+
+    @Test
+    void deleteByGroupId_removesAllMembershipsForGroup() {
+        Student s1 = makeStudent("23070000014");
+        Student s2 = makeStudent("23070000015");
+        ProjectGroup group = makeGroup("Group A", "2024-FALL", ProjectGroup.GroupStatus.FORMING);
+
+        makeMembership(group, s1, GroupMembership.MemberRole.TEAM_LEADER);
+        makeMembership(group, s2, GroupMembership.MemberRole.MEMBER);
+
+        repo.deleteByGroupId(group.getId());
+        clearCache();
+
+        assertThat(repo.countByGroupId(group.getId())).isEqualTo(0);
+        // students themselves should still exist
+        assertThat(em.find(com.senior.spm.entity.Student.class, s1.getId())).isNotNull();
+    }
+
+    // ── findByGroupIdAndRole ──────────────────────────────────────────────────
+
+    @Test
+    void findByGroupIdAndRole_returnsTeamLeader() {
+        Student leader = makeStudent("23070000016");
+        Student member = makeStudent("23070000017");
+        ProjectGroup group = makeGroup("Group A", "2024-FALL", ProjectGroup.GroupStatus.FORMING);
+
+        makeMembership(group, leader, GroupMembership.MemberRole.TEAM_LEADER);
+        makeMembership(group, member, GroupMembership.MemberRole.MEMBER);
+
+        var result = repo.findByGroupIdAndRole(group.getId(), GroupMembership.MemberRole.TEAM_LEADER);
+        assertThat(result).isPresent();
+        assertThat(result.get().getStudent().getId()).isEqualTo(leader.getId());
+    }
+
+    // ── findByGroupIdAndStudentId ─────────────────────────────────────────────
+
+    @Test
+    void findByGroupIdAndStudentId_returnsCorrectMembership() {
+        Student student = makeStudent("23070000018");
+        ProjectGroup group = makeGroup("Group A", "2024-FALL", ProjectGroup.GroupStatus.FORMING);
+        makeMembership(group, student, GroupMembership.MemberRole.TEAM_LEADER);
+
+        var result = repo.findByGroupIdAndStudentId(group.getId(), student.getId());
+        assertThat(result).isPresent();
+    }
+}

--- a/backend/src/test/java/com/senior/spm/repository/ProjectGroupRepositoryTest.java
+++ b/backend/src/test/java/com/senior/spm/repository/ProjectGroupRepositoryTest.java
@@ -1,0 +1,167 @@
+package com.senior.spm.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.test.context.TestPropertySource;
+
+import com.senior.spm.entity.ProjectGroup;
+import com.senior.spm.entity.StaffUser;
+
+/**
+ * Verifies ProjectGroupRepository query methods.
+ *
+ * Critical methods under test:
+ *   countByAdvisorIdAndTermIdAndStatusNot — must EXCLUDE disbanded groups (P3 Rule 1)
+ *   findByTermIdAndStatusNotAndAdvisorIsNull — used by SanitizationService (seq 3.4)
+ */
+@DataJpaTest
+@TestPropertySource(properties = "spring.sql.init.mode=never")
+class ProjectGroupRepositoryTest extends RepositoryTestBase {
+
+    @Autowired
+    ProjectGroupRepository repo;
+
+    // ── existsByGroupNameAndTermId ────────────────────────────────────────────
+
+    @Test
+    void existsByGroupNameAndTermId_trueForDuplicateNameInSameTerm() {
+        makeGroup("Team Alpha", "2024-FALL", ProjectGroup.GroupStatus.FORMING);
+
+        assertThat(repo.existsByGroupNameAndTermId("Team Alpha", "2024-FALL")).isTrue();
+    }
+
+    @Test
+    void existsByGroupNameAndTermId_falseForSameNameDifferentTerm() {
+        makeGroup("Team Alpha", "2024-FALL", ProjectGroup.GroupStatus.FORMING);
+
+        assertThat(repo.existsByGroupNameAndTermId("Team Alpha", "2025-SPRING")).isFalse();
+    }
+
+    @Test
+    void existsByGroupNameAndTermId_falseForDifferentName() {
+        makeGroup("Team Alpha", "2024-FALL", ProjectGroup.GroupStatus.FORMING);
+
+        assertThat(repo.existsByGroupNameAndTermId("Team Beta", "2024-FALL")).isFalse();
+    }
+
+    // ── countByAdvisorIdAndTermIdAndStatusNot ─────────────────────────────────
+    // SPEC: must exclude DISBANDED groups — plain countByAdvisorIdAndTermId inflates load
+
+    @Test
+    void countByAdvisorIdAndTermIdAndStatusNot_countsActiveGroupsForAdvisor() {
+        StaffUser prof = makeProfessor("prof1@test.com");
+
+        makeGroupWithAdvisor("Group A", "2024-FALL", ProjectGroup.GroupStatus.ADVISOR_ASSIGNED, prof);
+        makeGroupWithAdvisor("Group B", "2024-FALL", ProjectGroup.GroupStatus.ADVISOR_ASSIGNED, prof);
+
+        long count = repo.countByAdvisorIdAndTermIdAndStatusNot(
+                prof.getId(), "2024-FALL", ProjectGroup.GroupStatus.DISBANDED);
+
+        assertThat(count).isEqualTo(2);
+    }
+
+    @Test
+    void countByAdvisorIdAndTermIdAndStatusNot_excludesDisbandedGroups() {
+        StaffUser prof = makeProfessor("prof2@test.com");
+
+        makeGroupWithAdvisor("Group A", "2024-FALL", ProjectGroup.GroupStatus.ADVISOR_ASSIGNED, prof);
+        makeGroupWithAdvisor("Group Disbanded", "2024-FALL", ProjectGroup.GroupStatus.DISBANDED, prof);
+
+        long count = repo.countByAdvisorIdAndTermIdAndStatusNot(
+                prof.getId(), "2024-FALL", ProjectGroup.GroupStatus.DISBANDED);
+
+        assertThat(count).isEqualTo(1); // disbanded group must NOT be counted
+    }
+
+    @Test
+    void countByAdvisorIdAndTermIdAndStatusNot_doesNotCountOtherAdvisorsGroups() {
+        StaffUser prof1 = makeProfessor("prof3@test.com");
+        StaffUser prof2 = makeProfessor("prof4@test.com");
+
+        makeGroupWithAdvisor("Group A", "2024-FALL", ProjectGroup.GroupStatus.ADVISOR_ASSIGNED, prof1);
+        makeGroupWithAdvisor("Group B", "2024-FALL", ProjectGroup.GroupStatus.ADVISOR_ASSIGNED, prof2);
+
+        long count = repo.countByAdvisorIdAndTermIdAndStatusNot(
+                prof1.getId(), "2024-FALL", ProjectGroup.GroupStatus.DISBANDED);
+
+        assertThat(count).isEqualTo(1);
+    }
+
+    @Test
+    void countByAdvisorIdAndTermIdAndStatusNot_doesNotCountOtherTermGroups() {
+        StaffUser prof = makeProfessor("prof5@test.com");
+
+        makeGroupWithAdvisor("Group A", "2024-FALL", ProjectGroup.GroupStatus.ADVISOR_ASSIGNED, prof);
+        makeGroupWithAdvisor("Group B", "2025-SPRING", ProjectGroup.GroupStatus.ADVISOR_ASSIGNED, prof);
+
+        long count = repo.countByAdvisorIdAndTermIdAndStatusNot(
+                prof.getId(), "2024-FALL", ProjectGroup.GroupStatus.DISBANDED);
+
+        assertThat(count).isEqualTo(1);
+    }
+
+    // ── findByTermIdAndStatusNotAndAdvisorIsNull ──────────────────────────────
+    // Used by SanitizationService to find groups without advisor that need disbanding
+
+    @Test
+    void findByTermIdAndStatusNotAndAdvisorIsNull_returnsGroupsWithNoAdvisor() {
+        ProjectGroup noAdvisor = makeGroup("No Advisor", "2024-FALL", ProjectGroup.GroupStatus.TOOLS_BOUND);
+        StaffUser prof = makeProfessor("prof6@test.com");
+        makeGroupWithAdvisor("Has Advisor", "2024-FALL", ProjectGroup.GroupStatus.ADVISOR_ASSIGNED, prof);
+
+        var result = repo.findByTermIdAndStatusNotAndAdvisorIsNull("2024-FALL", ProjectGroup.GroupStatus.DISBANDED);
+
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).getId()).isEqualTo(noAdvisor.getId());
+    }
+
+    @Test
+    void findByTermIdAndStatusNotAndAdvisorIsNull_excludesAlreadyDisbandedGroups() {
+        makeGroup("Active", "2024-FALL", ProjectGroup.GroupStatus.FORMING);
+        makeGroup("Already Disbanded", "2024-FALL", ProjectGroup.GroupStatus.DISBANDED);
+
+        var result = repo.findByTermIdAndStatusNotAndAdvisorIsNull("2024-FALL", ProjectGroup.GroupStatus.DISBANDED);
+
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).getGroupName()).isEqualTo("Active");
+    }
+
+    @Test
+    void findByTermIdAndStatusNotAndAdvisorIsNull_excludesOtherTerms() {
+        makeGroup("Fall Group", "2024-FALL", ProjectGroup.GroupStatus.FORMING);
+        makeGroup("Spring Group", "2025-SPRING", ProjectGroup.GroupStatus.FORMING);
+
+        var result = repo.findByTermIdAndStatusNotAndAdvisorIsNull("2024-FALL", ProjectGroup.GroupStatus.DISBANDED);
+
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).getGroupName()).isEqualTo("Fall Group");
+    }
+
+    // ── findByTermId ──────────────────────────────────────────────────────────
+
+    @Test
+    void findByTermId_returnsAllGroupsForTerm() {
+        makeGroup("Group A", "2024-FALL", ProjectGroup.GroupStatus.FORMING);
+        makeGroup("Group B", "2024-FALL", ProjectGroup.GroupStatus.FORMING);
+        makeGroup("Group C", "2025-SPRING", ProjectGroup.GroupStatus.FORMING);
+
+        assertThat(repo.findByTermId("2024-FALL")).hasSize(2);
+    }
+
+    // ── findByTermIdAndStatus ─────────────────────────────────────────────────
+
+    @Test
+    void findByTermIdAndStatus_returnsOnlyMatchingStatus() {
+        makeGroup("Forming", "2024-FALL", ProjectGroup.GroupStatus.FORMING);
+        makeGroup("Tools Bound", "2024-FALL", ProjectGroup.GroupStatus.TOOLS_BOUND);
+        makeGroup("Disbanded", "2024-FALL", ProjectGroup.GroupStatus.DISBANDED);
+
+        var result = repo.findByTermIdAndStatus("2024-FALL", ProjectGroup.GroupStatus.FORMING);
+
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).getGroupName()).isEqualTo("Forming");
+    }
+}

--- a/backend/src/test/java/com/senior/spm/repository/RepositoryTestBase.java
+++ b/backend/src/test/java/com/senior/spm/repository/RepositoryTestBase.java
@@ -1,0 +1,104 @@
+package com.senior.spm.repository;
+
+import java.time.LocalDateTime;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+
+import com.senior.spm.entity.AdvisorRequest;
+import com.senior.spm.entity.GroupInvitation;
+import com.senior.spm.entity.GroupMembership;
+import com.senior.spm.entity.ProjectGroup;
+import com.senior.spm.entity.ScheduleWindow;
+import com.senior.spm.entity.StaffUser;
+import com.senior.spm.entity.Student;
+
+/**
+ * Shared factory methods for building test entities.
+ * All data is in-memory (H2); each test rolls back after completion.
+ */
+abstract class RepositoryTestBase {
+
+    @Autowired
+    TestEntityManager em;
+
+    protected Student makeStudent(String studentId) {
+        Student s = new Student();
+        s.setStudentId(studentId);
+        return em.persistAndFlush(s);
+    }
+
+    protected StaffUser makeProfessor(String mail) {
+        StaffUser u = new StaffUser();
+        u.setMail(mail);
+        u.setPasswordHash("hash");
+        u.setRole(StaffUser.Role.Professor);
+        return em.persistAndFlush(u);
+    }
+
+    protected ProjectGroup makeGroup(String name, String termId, ProjectGroup.GroupStatus status) {
+        ProjectGroup g = new ProjectGroup();
+        g.setGroupName(name);
+        g.setTermId(termId);
+        g.setStatus(status);
+        g.setCreatedAt(LocalDateTime.now());
+        return em.persistAndFlush(g);
+    }
+
+    protected ProjectGroup makeGroupWithAdvisor(String name, String termId,
+            ProjectGroup.GroupStatus status, StaffUser advisor) {
+        ProjectGroup g = new ProjectGroup();
+        g.setGroupName(name);
+        g.setTermId(termId);
+        g.setStatus(status);
+        g.setCreatedAt(LocalDateTime.now());
+        g.setAdvisor(advisor);
+        return em.persistAndFlush(g);
+    }
+
+    protected GroupMembership makeMembership(ProjectGroup group, Student student,
+            GroupMembership.MemberRole role) {
+        GroupMembership m = new GroupMembership();
+        m.setGroup(group);
+        m.setStudent(student);
+        m.setRole(role);
+        m.setJoinedAt(LocalDateTime.now());
+        return em.persistAndFlush(m);
+    }
+
+    protected GroupInvitation makeInvitation(ProjectGroup group, Student invitee,
+            GroupInvitation.InvitationStatus status) {
+        GroupInvitation inv = new GroupInvitation();
+        inv.setGroup(group);
+        inv.setInvitee(invitee);
+        inv.setStatus(status);
+        inv.setSentAt(LocalDateTime.now());
+        return em.persistAndFlush(inv);
+    }
+
+    protected AdvisorRequest makeAdvisorRequest(ProjectGroup group, StaffUser advisor,
+            AdvisorRequest.RequestStatus status, LocalDateTime sentAt) {
+        AdvisorRequest req = new AdvisorRequest();
+        req.setGroup(group);
+        req.setAdvisor(advisor);
+        req.setStatus(status);
+        req.setSentAt(sentAt);
+        return em.persistAndFlush(req);
+    }
+
+    protected ScheduleWindow makeScheduleWindow(String termId, ScheduleWindow.WindowType type,
+            LocalDateTime opens, LocalDateTime closes) {
+        ScheduleWindow sw = new ScheduleWindow();
+        sw.setTermId(termId);
+        sw.setType(type);
+        sw.setOpensAt(opens);
+        sw.setClosesAt(closes);
+        return em.persistAndFlush(sw);
+    }
+
+    /** Clears the 1st-level cache so JPQL bulk updates are visible on re-fetch. */
+    protected void clearCache() {
+        em.flush();
+        em.getEntityManager().clear();
+    }
+}


### PR DESCRIPTION
## Issue #39: Core Domain Entities & Repositories

Implements the complete JPA data layer for Process 2 with:
- ScheduleWindow entity (time-bounded windows)
- ProjectGroup entity with optimistic locking
- GroupMembership entity (student-group mapping)
- GroupInvitation entity (invitation lifecycle)
- AdvisorRequest entity
- All corresponding repositories with custom query methods
- Bidirectional relationships and unique constraints

Resolves #39 