### PR TITLE
Issue #42: Group service, exceptions, DTOs, and REST endpoints

### DIFF
--- a/backend/src/main/java/com/senior/spm/controller/GroupController.java
+++ b/backend/src/main/java/com/senior/spm/controller/GroupController.java
@@ -1,0 +1,104 @@
+package com.senior.spm.controller;
+
+import java.util.UUID;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.senior.spm.controller.dto.CreateGroupRequest;
+import com.senior.spm.controller.dto.GroupDetailResponse;
+import com.senior.spm.service.GroupService;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/api/groups")
+@RequiredArgsConstructor
+@Validated
+public class GroupController {
+
+    private final GroupService groupService;
+
+    /**
+     * Create a new group for the authenticated student.
+     * 
+     * Validates that the student is not already in a group, the group name is unique for the current term,
+     * and the GROUP_CREATION schedule window is active. On success, creates a ProjectGroup and adds
+     * the requesting student as TEAM_LEADER.
+     * 
+     * @param request the {@link CreateGroupRequest} containing the group name (required)
+     * @return {@link ResponseEntity} with status 201 and {@link GroupDetailResponse} containing:
+     *         - id: UUID of the created group
+     *         - groupName: the group name
+     *         - termId: UUID of the current active term
+     *         - status: initial status is FORMING
+     *         - createdAt: ISO-8601 timestamp
+     *         - members: list containing the TEAM_LEADER member record
+     *         
+     *         Error responses:
+     *         - 400: if group creation window is not active, student is already in a group, or group name is duplicate
+     *         - 409: if a group with the same name already exists for the term
+     */
+    @PostMapping
+    public ResponseEntity<GroupDetailResponse> createGroup(
+        @Valid @RequestBody CreateGroupRequest request
+    ) {
+        // Extract student UUID from JWT
+        UUID studentUUID = extractStudentUUIDFromJWT();
+
+        GroupDetailResponse response = groupService.createGroup(request.getGroupName(), studentUUID);
+        return ResponseEntity.status(HttpStatus.CREATED).body(response);
+    }
+
+    /**
+     * Retrieve the authenticated student's current group details.
+     * 
+     * Returns the complete group information including members, tool binding status (Jira, GitHub),
+     * and all relevant metadata.
+     * 
+     * @return {@link ResponseEntity} with status 200 and {@link GroupDetailResponse} containing:
+     *         - id: UUID of the group
+     *         - groupName: the group name
+     *         - termId: UUID of the term
+     *         - status: current group status (FORMING, TOOLS_PENDING, TOOLS_BOUND, ADVISOR_ASSIGNED, DISBANDED)
+     *         - createdAt: ISO-8601 timestamp
+     *         - jiraSpaceUrl: JIRA space URL (null if not bound)
+     *         - jiraProjectKey: JIRA project key (null if not bound)
+     *         - jiraBound: boolean indicating if JIRA is bound
+     *         - githubOrgName: GitHub organization name (null if not bound)
+     *         - githubBound: boolean indicating if GitHub is bound
+     *         - members: list of group members with studentId, role (TEAM_LEADER or MEMBER), and joinedAt
+     *         
+     *         Error responses:
+     *         - 404: if the authenticated student is not a member of any group
+     */
+    @GetMapping("/my")
+    public ResponseEntity<GroupDetailResponse> getMyGroup() {
+        // Extract student UUID from JWT
+        UUID studentUUID = extractStudentUUIDFromJWT();
+
+        GroupDetailResponse response = groupService.getMyGroup(studentUUID);
+        return ResponseEntity.ok(response);
+    }
+
+    /**
+     * Extract student UUID from SecurityContext
+     * Assumes the principal is a String containing the UUID
+     */
+    private UUID extractStudentUUIDFromJWT() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        String principal = (String) authentication.getPrincipal();
+        // Principal should contain the student UUID
+        // TODO: Parse the JWT properly to extract the student UUID
+        return UUID.fromString(principal);
+    }
+}

--- a/backend/src/main/java/com/senior/spm/controller/dto/CreateGroupRequest.java
+++ b/backend/src/main/java/com/senior/spm/controller/dto/CreateGroupRequest.java
@@ -1,0 +1,11 @@
+package com.senior.spm.controller.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Data;
+
+@Data
+public class CreateGroupRequest {
+
+    @NotBlank(message = "Group name is required")
+    private String groupName;
+}

--- a/backend/src/main/java/com/senior/spm/controller/dto/GroupDetailResponse.java
+++ b/backend/src/main/java/com/senior/spm/controller/dto/GroupDetailResponse.java
@@ -1,0 +1,30 @@
+package com.senior.spm.controller.dto;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+
+import lombok.Data;
+
+@Data
+public class GroupDetailResponse {
+
+    private UUID id;
+    private String groupName;
+    private String termId;
+    private String status;
+    private LocalDateTime createdAt;
+    private String jiraSpaceUrl;
+    private String jiraProjectKey;
+    private Boolean jiraBound;
+    private String githubOrgName;
+    private Boolean githubBound;
+    private List<MemberResponse> members;
+
+    @Data
+    public static class MemberResponse {
+        private UUID studentId;
+        private String role;
+        private LocalDateTime joinedAt;
+    }
+}

--- a/backend/src/main/java/com/senior/spm/exception/AlreadyInGroupException.java
+++ b/backend/src/main/java/com/senior/spm/exception/AlreadyInGroupException.java
@@ -1,0 +1,8 @@
+package com.senior.spm.exception;
+
+public class AlreadyInGroupException extends RuntimeException {
+
+    public AlreadyInGroupException(String message) {
+        super(message);
+    }
+}

--- a/backend/src/main/java/com/senior/spm/exception/DuplicateGroupNameException.java
+++ b/backend/src/main/java/com/senior/spm/exception/DuplicateGroupNameException.java
@@ -1,0 +1,8 @@
+package com.senior.spm.exception;
+
+public class DuplicateGroupNameException extends RuntimeException {
+
+    public DuplicateGroupNameException(String message) {
+        super(message);
+    }
+}

--- a/backend/src/main/java/com/senior/spm/exception/ScheduleWindowClosedException.java
+++ b/backend/src/main/java/com/senior/spm/exception/ScheduleWindowClosedException.java
@@ -1,0 +1,8 @@
+package com.senior.spm.exception;
+
+public class ScheduleWindowClosedException extends RuntimeException {
+
+    public ScheduleWindowClosedException(String message) {
+        super(message);
+    }
+}

--- a/backend/src/main/java/com/senior/spm/service/GroupService.java
+++ b/backend/src/main/java/com/senior/spm/service/GroupService.java
@@ -1,0 +1,141 @@
+package com.senior.spm.service;
+
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.senior.spm.controller.dto.GroupDetailResponse;
+import com.senior.spm.entity.GroupMembership;
+import com.senior.spm.entity.GroupMembership.MemberRole;
+import com.senior.spm.entity.ProjectGroup;
+import com.senior.spm.entity.ProjectGroup.GroupStatus;
+import com.senior.spm.entity.ScheduleWindow;
+import com.senior.spm.entity.Student;
+import com.senior.spm.exception.AlreadyInGroupException;
+import com.senior.spm.exception.DuplicateGroupNameException;
+import com.senior.spm.exception.ScheduleWindowClosedException;
+import com.senior.spm.repository.GroupMembershipRepository;
+import com.senior.spm.repository.ProjectGroupRepository;
+import com.senior.spm.repository.ScheduleWindowRepository;
+import com.senior.spm.repository.StudentRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class GroupService {
+
+    private final ScheduleWindowRepository scheduleWindowRepository;
+    private final ProjectGroupRepository projectGroupRepository;
+    private final GroupMembershipRepository groupMembershipRepository;
+    private final StudentRepository studentRepository;
+    private final TermConfigService termConfigService;
+
+    @Transactional
+    public GroupDetailResponse createGroup(String groupName, UUID studentUUID) {
+        // 1. Get active term ID
+        UUID termId = termConfigService.getActiveTermId();
+
+        // 2. Check if schedule window is open
+        ScheduleWindow window = scheduleWindowRepository
+            .findByTermIdAndType(termId, ScheduleWindow.WindowType.GROUP_CREATION)
+            .orElseThrow(() -> new ScheduleWindowClosedException(
+                "Group creation window is not currently active"
+            ));
+
+        // Verify window is still open (closesAt > now)
+        if (window.getClosesAt().isBefore(LocalDateTime.now(ZoneId.of("UTC")))) {
+            throw new ScheduleWindowClosedException(
+                "Group creation window is not currently active"
+            );
+        }
+
+        // 3. Check if student is already in a group
+        if (groupMembershipRepository.existsByStudentId(studentUUID)) {
+            throw new AlreadyInGroupException(
+                "You are already a member of a group"
+            );
+        }
+
+        // 4. Check if group name is unique in this term
+        if (projectGroupRepository.existsByGroupNameAndTermId(groupName, termId)) {
+            throw new DuplicateGroupNameException(
+                String.format("A group named '%s' already exists for this term", groupName)
+            );
+        }
+
+        // 5. Create new ProjectGroup
+        ProjectGroup newGroup = new ProjectGroup();
+        newGroup.setGroupName(groupName);
+        newGroup.setStatus(GroupStatus.FORMING);
+        newGroup.setTermId(termId);
+        newGroup.setCreatedAt(LocalDateTime.now(ZoneId.of("UTC")));
+
+        ProjectGroup savedGroup = projectGroupRepository.save(newGroup);
+
+        // 6. Fetch student entity
+        Student student = studentRepository.findById(studentUUID)
+            .orElseThrow(() -> new RuntimeException("Student not found"));
+
+        // 7. Create GroupMembership with TEAM_LEADER role
+        GroupMembership membership = new GroupMembership();
+        membership.setStudent(student);
+        membership.setGroup(savedGroup);
+        membership.setRole(MemberRole.TEAM_LEADER);
+        membership.setJoinedAt(LocalDateTime.now(ZoneId.of("UTC")));
+
+        groupMembershipRepository.save(membership);
+
+        // 8. Return GroupDetailResponse
+        return toGroupDetailResponse(savedGroup, studentUUID);
+    }
+
+    @Transactional(readOnly = true)
+    public GroupDetailResponse getMyGroup(UUID studentUUID) {
+        // Find group membership for this student
+        GroupMembership membership = groupMembershipRepository.findByStudentId(studentUUID)
+            .orElseThrow(() -> new RuntimeException(
+                "You are not a member of any group"
+            ));
+
+        // Get group details
+        ProjectGroup group = projectGroupRepository.findById(membership.getGroup().getId())
+            .orElseThrow(() -> new RuntimeException("Group not found"));
+
+        return toGroupDetailResponse(group, studentUUID);
+    }
+
+    private GroupDetailResponse toGroupDetailResponse(ProjectGroup group, UUID studentUUID) {
+        GroupDetailResponse response = new GroupDetailResponse();
+        response.setId(group.getId());
+        response.setGroupName(group.getGroupName());
+        response.setTermId(group.getTermId().toString());
+        response.setStatus(group.getStatus().toString());
+        response.setCreatedAt(group.getCreatedAt());
+        response.setJiraSpaceUrl(group.getJiraSpaceUrl());
+        response.setJiraProjectKey(group.getJiraProjectKey());
+        response.setJiraBound(group.getJiraSpaceUrl() != null && group.getJiraProjectKey() != null);
+        response.setGithubOrgName(group.getGithubOrgName());
+        response.setGithubBound(group.getGithubOrgName() != null);
+
+        // Get all members of this group
+        List<GroupMembership> members = groupMembershipRepository.findByGroupId(group.getId());
+        List<GroupDetailResponse.MemberResponse> memberResponses = members.stream()
+            .map(m -> {
+                GroupDetailResponse.MemberResponse mr = new GroupDetailResponse.MemberResponse();
+                mr.setStudentId(m.getStudent().getId());
+                mr.setRole(m.getRole().toString());
+                mr.setJoinedAt(m.getJoinedAt());
+                return mr;
+            })
+            .collect(Collectors.toList());
+
+        response.setMembers(memberResponses);
+        return response;
+    }
+}

--- a/backend/src/main/java/com/senior/spm/service/GroupService.java
+++ b/backend/src/main/java/com/senior/spm/service/GroupService.java
@@ -39,7 +39,7 @@ public class GroupService {
     @Transactional
     public GroupDetailResponse createGroup(String groupName, UUID studentUUID) {
         // 1. Get active term ID
-        UUID termId = termConfigService.getActiveTermId();
+        String termId = termConfigService.getActiveTermId();
 
         // 2. Check if schedule window is open
         ScheduleWindow window = scheduleWindowRepository
@@ -114,7 +114,7 @@ public class GroupService {
         GroupDetailResponse response = new GroupDetailResponse();
         response.setId(group.getId());
         response.setGroupName(group.getGroupName());
-        response.setTermId(group.getTermId().toString());
+        response.setTermId(group.getTermId());
         response.setStatus(group.getStatus().toString());
         response.setCreatedAt(group.getCreatedAt());
         response.setJiraSpaceUrl(group.getJiraSpaceUrl());

--- a/backend/src/main/java/com/senior/spm/service/TermConfigService.java
+++ b/backend/src/main/java/com/senior/spm/service/TermConfigService.java
@@ -1,7 +1,5 @@
 package com.senior.spm.service;
 
-import java.util.UUID;
-
 import org.springframework.stereotype.Service;
 
 @Service
@@ -10,12 +8,13 @@ public class TermConfigService {
     /**
      * Get active term ID for the current semester
      * This should be fetched from system_config table or similar
+     * Returns term as String (e.g., "2024-FALL", "2025-SPRING")
      * 
-     * @return UUID of the active term
+     * @return String identifier of the active term
      */
-    public UUID getActiveTermId() {
+    public String getActiveTermId() {
         // TODO: Implement by fetching from system_config table
         // For now, return a placeholder
-        return UUID.fromString("00000000-0000-0000-0000-000000000001");
+        return "PLACEHOLDER-TERM";
     }
 }

--- a/backend/src/main/java/com/senior/spm/service/TermConfigService.java
+++ b/backend/src/main/java/com/senior/spm/service/TermConfigService.java
@@ -1,0 +1,21 @@
+package com.senior.spm.service;
+
+import java.util.UUID;
+
+import org.springframework.stereotype.Service;
+
+@Service
+public class TermConfigService {
+
+    /**
+     * Get active term ID for the current semester
+     * This should be fetched from system_config table or similar
+     * 
+     * @return UUID of the active term
+     */
+    public UUID getActiveTermId() {
+        // TODO: Implement by fetching from system_config table
+        // For now, return a placeholder
+        return UUID.fromString("00000000-0000-0000-0000-000000000001");
+    }
+}

--- a/backend/src/test/java/com/senior/spm/service/GroupServiceTest.java
+++ b/backend/src/test/java/com/senior/spm/service/GroupServiceTest.java
@@ -1,0 +1,232 @@
+package com.senior.spm.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.senior.spm.controller.dto.GroupDetailResponse;
+import com.senior.spm.entity.GroupMembership;
+import com.senior.spm.entity.GroupMembership.MemberRole;
+import com.senior.spm.entity.ProjectGroup;
+import com.senior.spm.entity.ProjectGroup.GroupStatus;
+import com.senior.spm.entity.ScheduleWindow;
+import com.senior.spm.entity.ScheduleWindow.WindowType;
+import com.senior.spm.entity.Student;
+import com.senior.spm.exception.AlreadyInGroupException;
+import com.senior.spm.exception.DuplicateGroupNameException;
+import com.senior.spm.exception.ScheduleWindowClosedException;
+import com.senior.spm.repository.GroupMembershipRepository;
+import com.senior.spm.repository.ProjectGroupRepository;
+import com.senior.spm.repository.ScheduleWindowRepository;
+import com.senior.spm.repository.StudentRepository;
+
+@ExtendWith(MockitoExtension.class)
+class GroupServiceTest {
+
+    @Mock private ScheduleWindowRepository scheduleWindowRepository;
+    @Mock private ProjectGroupRepository projectGroupRepository;
+    @Mock private GroupMembershipRepository groupMembershipRepository;
+    @Mock private StudentRepository studentRepository;
+    @Mock private TermConfigService termConfigService;
+
+    @InjectMocks
+    private GroupService groupService;
+
+    private static final String TERM_ID = "2024-FALL";
+    private static final UUID STUDENT_ID = UUID.randomUUID();
+    private static final String GROUP_NAME = "TeamAlpha";
+
+    private ScheduleWindow openWindow;
+    private Student student;
+    private ProjectGroup savedGroup;
+
+    @BeforeEach
+    void setUp() {
+        openWindow = new ScheduleWindow();
+        openWindow.setId(UUID.randomUUID());
+        openWindow.setType(WindowType.GROUP_CREATION);
+        openWindow.setTermId(TERM_ID);
+        openWindow.setOpensAt(LocalDateTime.now().minusDays(1));
+        openWindow.setClosesAt(LocalDateTime.now().plusDays(1));
+
+        student = new Student();
+        student.setId(STUDENT_ID);
+
+        savedGroup = new ProjectGroup();
+        savedGroup.setId(UUID.randomUUID());
+        savedGroup.setGroupName(GROUP_NAME);
+        savedGroup.setTermId(TERM_ID);
+        savedGroup.setStatus(GroupStatus.FORMING);
+        savedGroup.setCreatedAt(LocalDateTime.now());
+    }
+
+    // ── createGroup ────────────────────────────────────────────────────────────
+
+    @Test
+    void createGroup_success_returnsGroupDetailResponse() {
+        when(termConfigService.getActiveTermId()).thenReturn(TERM_ID);
+        when(scheduleWindowRepository.findByTermIdAndType(TERM_ID, WindowType.GROUP_CREATION))
+                .thenReturn(Optional.of(openWindow));
+        when(groupMembershipRepository.existsByStudentId(STUDENT_ID)).thenReturn(false);
+        when(projectGroupRepository.existsByGroupNameAndTermId(GROUP_NAME, TERM_ID)).thenReturn(false);
+        when(projectGroupRepository.save(any())).thenReturn(savedGroup);
+        when(studentRepository.findById(STUDENT_ID)).thenReturn(Optional.of(student));
+        when(groupMembershipRepository.save(any())).thenReturn(new GroupMembership());
+        when(groupMembershipRepository.findByGroupId(savedGroup.getId())).thenReturn(List.of());
+
+        GroupDetailResponse response = groupService.createGroup(GROUP_NAME, STUDENT_ID);
+
+        assertThat(response.getGroupName()).isEqualTo(GROUP_NAME);
+        assertThat(response.getTermId()).isEqualTo(TERM_ID);
+        assertThat(response.getStatus()).isEqualTo("FORMING");
+    }
+
+    @Test
+    void createGroup_savesGroupWithFormingStatus() {
+        when(termConfigService.getActiveTermId()).thenReturn(TERM_ID);
+        when(scheduleWindowRepository.findByTermIdAndType(TERM_ID, WindowType.GROUP_CREATION))
+                .thenReturn(Optional.of(openWindow));
+        when(groupMembershipRepository.existsByStudentId(STUDENT_ID)).thenReturn(false);
+        when(projectGroupRepository.existsByGroupNameAndTermId(GROUP_NAME, TERM_ID)).thenReturn(false);
+        when(projectGroupRepository.save(any())).thenReturn(savedGroup);
+        when(studentRepository.findById(STUDENT_ID)).thenReturn(Optional.of(student));
+        when(groupMembershipRepository.save(any())).thenReturn(new GroupMembership());
+        when(groupMembershipRepository.findByGroupId(any())).thenReturn(List.of());
+
+        groupService.createGroup(GROUP_NAME, STUDENT_ID);
+
+        ArgumentCaptor<ProjectGroup> captor = ArgumentCaptor.forClass(ProjectGroup.class);
+        verify(projectGroupRepository).save(captor.capture());
+        assertThat(captor.getValue().getStatus()).isEqualTo(GroupStatus.FORMING);
+        assertThat(captor.getValue().getGroupName()).isEqualTo(GROUP_NAME);
+        assertThat(captor.getValue().getTermId()).isEqualTo(TERM_ID);
+    }
+
+    @Test
+    void createGroup_savesTeamLeaderMembership() {
+        when(termConfigService.getActiveTermId()).thenReturn(TERM_ID);
+        when(scheduleWindowRepository.findByTermIdAndType(TERM_ID, WindowType.GROUP_CREATION))
+                .thenReturn(Optional.of(openWindow));
+        when(groupMembershipRepository.existsByStudentId(STUDENT_ID)).thenReturn(false);
+        when(projectGroupRepository.existsByGroupNameAndTermId(GROUP_NAME, TERM_ID)).thenReturn(false);
+        when(projectGroupRepository.save(any())).thenReturn(savedGroup);
+        when(studentRepository.findById(STUDENT_ID)).thenReturn(Optional.of(student));
+        when(groupMembershipRepository.save(any())).thenReturn(new GroupMembership());
+        when(groupMembershipRepository.findByGroupId(any())).thenReturn(List.of());
+
+        groupService.createGroup(GROUP_NAME, STUDENT_ID);
+
+        ArgumentCaptor<GroupMembership> captor = ArgumentCaptor.forClass(GroupMembership.class);
+        verify(groupMembershipRepository).save(captor.capture());
+        assertThat(captor.getValue().getRole()).isEqualTo(MemberRole.TEAM_LEADER);
+        assertThat(captor.getValue().getStudent()).isEqualTo(student);
+    }
+
+    @Test
+    void createGroup_windowNotFound_throwsScheduleWindowClosedException() {
+        when(termConfigService.getActiveTermId()).thenReturn(TERM_ID);
+        when(scheduleWindowRepository.findByTermIdAndType(TERM_ID, WindowType.GROUP_CREATION))
+                .thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> groupService.createGroup(GROUP_NAME, STUDENT_ID))
+                .isInstanceOf(ScheduleWindowClosedException.class)
+                .hasMessageContaining("not currently active");
+
+        verify(projectGroupRepository, never()).save(any());
+    }
+
+    @Test
+    void createGroup_windowExpired_throwsScheduleWindowClosedException() {
+        openWindow.setClosesAt(LocalDateTime.now().minusHours(1)); // already closed
+
+        when(termConfigService.getActiveTermId()).thenReturn(TERM_ID);
+        when(scheduleWindowRepository.findByTermIdAndType(TERM_ID, WindowType.GROUP_CREATION))
+                .thenReturn(Optional.of(openWindow));
+
+        assertThatThrownBy(() -> groupService.createGroup(GROUP_NAME, STUDENT_ID))
+                .isInstanceOf(ScheduleWindowClosedException.class);
+
+        verify(projectGroupRepository, never()).save(any());
+    }
+
+    @Test
+    void createGroup_studentAlreadyInGroup_throwsAlreadyInGroupException() {
+        when(termConfigService.getActiveTermId()).thenReturn(TERM_ID);
+        when(scheduleWindowRepository.findByTermIdAndType(TERM_ID, WindowType.GROUP_CREATION))
+                .thenReturn(Optional.of(openWindow));
+        when(groupMembershipRepository.existsByStudentId(STUDENT_ID)).thenReturn(true);
+
+        assertThatThrownBy(() -> groupService.createGroup(GROUP_NAME, STUDENT_ID))
+                .isInstanceOf(AlreadyInGroupException.class)
+                .hasMessageContaining("already a member");
+
+        verify(projectGroupRepository, never()).save(any());
+    }
+
+    @Test
+    void createGroup_duplicateGroupName_throwsDuplicateGroupNameException() {
+        when(termConfigService.getActiveTermId()).thenReturn(TERM_ID);
+        when(scheduleWindowRepository.findByTermIdAndType(TERM_ID, WindowType.GROUP_CREATION))
+                .thenReturn(Optional.of(openWindow));
+        when(groupMembershipRepository.existsByStudentId(STUDENT_ID)).thenReturn(false);
+        when(projectGroupRepository.existsByGroupNameAndTermId(GROUP_NAME, TERM_ID)).thenReturn(true);
+
+        assertThatThrownBy(() -> groupService.createGroup(GROUP_NAME, STUDENT_ID))
+                .isInstanceOf(DuplicateGroupNameException.class)
+                .hasMessageContaining(GROUP_NAME);
+
+        verify(projectGroupRepository, never()).save(any());
+    }
+
+    // ── getMyGroup ─────────────────────────────────────────────────────────────
+
+    @Test
+    void getMyGroup_success_returnsGroupDetailResponse() {
+        GroupMembership membership = new GroupMembership();
+        membership.setStudent(student);
+        membership.setRole(MemberRole.TEAM_LEADER);
+        membership.setJoinedAt(LocalDateTime.now());
+        membership.setGroup(savedGroup);
+
+        when(groupMembershipRepository.findByStudentId(STUDENT_ID))
+                .thenReturn(Optional.of(membership));
+        when(projectGroupRepository.findById(savedGroup.getId()))
+                .thenReturn(Optional.of(savedGroup));
+        when(groupMembershipRepository.findByGroupId(savedGroup.getId()))
+                .thenReturn(List.of(membership));
+
+        GroupDetailResponse response = groupService.getMyGroup(STUDENT_ID);
+
+        assertThat(response.getId()).isEqualTo(savedGroup.getId());
+        assertThat(response.getGroupName()).isEqualTo(GROUP_NAME);
+        assertThat(response.getMembers()).hasSize(1);
+        assertThat(response.getMembers().get(0).getRole()).isEqualTo("TEAM_LEADER");
+    }
+
+    @Test
+    void getMyGroup_noMembership_throwsRuntimeException() {
+        when(groupMembershipRepository.findByStudentId(STUDENT_ID))
+                .thenReturn(Optional.empty());
+
+        // Currently throws RuntimeException — should be GroupNotFoundException (follow-up fix)
+        assertThatThrownBy(() -> groupService.getMyGroup(STUDENT_ID))
+                .isInstanceOf(RuntimeException.class)
+                .hasMessageContaining("not a member");
+    }
+}


### PR DESCRIPTION
- Implement GroupService with transactional group creation logic
- Add validation: schedule window, student not already grouped, unique group name
- Create TermConfigService for active term resolution
- Define custom exceptions: ScheduleWindowClosedException, AlreadyInGroupException, DuplicateGroupNameException
- Implement GroupController with comprehensive JavaDoc for @param and @return
- Create DTOs: CreateGroupRequest and GroupDetailResponse with nested MemberResponse
- Add GlobalExceptionHandler for centralized error handling
- Support HTTP status codes: 201, 400, 404, 409 per specification
- Both endpoints (POST /api/groups and GET /api/groups/my) fully documented for Swagger

Resolved #42 