### PR TITLE
feat: implement term config resolution for p2 services (#55)

### DIFF
--- a/backend/src/main/java/com/senior/spm/entity/SystemConfig.java
+++ b/backend/src/main/java/com/senior/spm/entity/SystemConfig.java
@@ -1,0 +1,24 @@
+package com.senior.spm.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Table(name = "system_config")
+@Getter
+@Setter
+@NoArgsConstructor
+public class SystemConfig {
+
+    @Id
+    @Column(name = "config_key", nullable = false, unique = true)
+    private String configKey;
+
+    @Column(name = "config_value", nullable = false)
+    private String configValue;
+}

--- a/backend/src/main/java/com/senior/spm/exception/TermConfigNotFoundException.java
+++ b/backend/src/main/java/com/senior/spm/exception/TermConfigNotFoundException.java
@@ -1,0 +1,11 @@
+package com.senior.spm.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
+public class TermConfigNotFoundException extends RuntimeException {
+    public TermConfigNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/backend/src/main/java/com/senior/spm/repository/SystemConfigRepository.java
+++ b/backend/src/main/java/com/senior/spm/repository/SystemConfigRepository.java
@@ -1,0 +1,12 @@
+package com.senior.spm.repository;
+
+import com.senior.spm.entity.SystemConfig;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface SystemConfigRepository extends JpaRepository<SystemConfig, String> {
+    Optional<SystemConfig> findByConfigKey(String configKey);
+}

--- a/backend/src/main/java/com/senior/spm/service/TermConfigService.java
+++ b/backend/src/main/java/com/senior/spm/service/TermConfigService.java
@@ -1,20 +1,26 @@
 package com.senior.spm.service;
 
+import com.senior.spm.entity.SystemConfig;
+import com.senior.spm.exception.TermConfigNotFoundException;
+import com.senior.spm.repository.SystemConfigRepository;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 @Service
+@RequiredArgsConstructor
 public class TermConfigService {
 
-    /**
-     * Get active term ID for the current semester
-     * This should be fetched from system_config table or similar
-     * Returns term as String (e.g., "2024-FALL", "2025-SPRING")
-     * 
-     * @return String identifier of the active term
-     */
+    private final SystemConfigRepository systemConfigRepository;
+
     public String getActiveTermId() {
-        // TODO: Implement by fetching from system_config table
-        // For now, return a placeholder
-        return "PLACEHOLDER-TERM";
+        SystemConfig config = systemConfigRepository.findByConfigKey("active_term_id")
+                .orElseThrow(() -> new TermConfigNotFoundException("active_term_id not found in system_config"));
+        return config.getConfigValue();
+    }
+
+    public Integer getMaxTeamSize() {
+        SystemConfig config = systemConfigRepository.findByConfigKey("max_team_size")
+                .orElseThrow(() -> new TermConfigNotFoundException("max_team_size not found in system_config"));
+        return Integer.parseInt(config.getConfigValue());
     }
 }

--- a/backend/src/main/java/com/senior/spm/service/TermConfigService.java
+++ b/backend/src/main/java/com/senior/spm/service/TermConfigService.java
@@ -12,15 +12,49 @@ public class TermConfigService {
 
     private final SystemConfigRepository systemConfigRepository;
 
+    /**
+     * Retrieves the active term ID for the current semester from the system configuration.
+     *
+     * @return The active term ID as a String (e.g., "2026-SPRING").
+     * @throws TermConfigNotFoundException if the 'active_term_id' key is missing from the database.
+     */
     public String getActiveTermId() {
         SystemConfig config = systemConfigRepository.findByConfigKey("active_term_id")
                 .orElseThrow(() -> new TermConfigNotFoundException("active_term_id not found in system_config"));
-        return config.getConfigValue();
+
+        String value = config.getConfigValue();
+        if (value == null || value.isBlank()) {
+            throw new TermConfigNotFoundException("active_term_id contains a blank value");
+        }
+
+        return value;
     }
 
+    /**
+     * Retrieves the maximum allowed team size from the system configuration.
+     * Validates that the stored string value is a proper integer.
+     *
+     * @return The maximum team size as an Integer.
+     * @throws TermConfigNotFoundException if the key is missing OR if the value is not a valid number.
+     */
     public Integer getMaxTeamSize() {
         SystemConfig config = systemConfigRepository.findByConfigKey("max_team_size")
                 .orElseThrow(() -> new TermConfigNotFoundException("max_team_size not found in system_config"));
-        return Integer.parseInt(config.getConfigValue());
+
+        String value = config.getConfigValue();
+        if (value == null || value.isBlank()) {
+            throw new TermConfigNotFoundException("max_team_size config value is not a valid integer: " + value);
+        }
+
+        try {
+            int maxTeamSize = Integer.parseInt(value);
+            if (maxTeamSize <= 0) {
+                throw new TermConfigNotFoundException("max_team_size must be a positive integer: " + value);
+            }
+
+            return maxTeamSize;
+        } catch (NumberFormatException e) {
+            throw new TermConfigNotFoundException("max_team_size config value is not a valid integer: " + value);
+        }
     }
 }

--- a/backend/src/main/resources/data.sql
+++ b/backend/src/main/resources/data.sql
@@ -50,3 +50,7 @@ VALUES
 		'$2a$10$tj811p0KDPOD6Dd58xb0.uBNIT8.CXeJPKoSUSwPuJ0BI.RuC5yGq',
 		'PROFESSOR'
 	);
+
+-- Issue 55: Red Team system_config seed data
+INSERT IGNORE INTO system_config (config_key, config_value) VALUES ('active_term_id', '2026-SPRING');
+INSERT IGNORE INTO system_config (config_key, config_value) VALUES ('max_team_size', '4');

--- a/backend/src/test/java/com/senior/spm/service/TermConfigServiceTest.java
+++ b/backend/src/test/java/com/senior/spm/service/TermConfigServiceTest.java
@@ -1,0 +1,139 @@
+package com.senior.spm.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.when;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.senior.spm.entity.SystemConfig;
+import com.senior.spm.exception.TermConfigNotFoundException;
+import com.senior.spm.repository.SystemConfigRepository;
+
+@ExtendWith(MockitoExtension.class)
+class TermConfigServiceTest {
+
+    @Mock
+    private SystemConfigRepository systemConfigRepository;
+
+    @InjectMocks
+    private TermConfigService termConfigService;
+
+    // ── getActiveTermId ──────────────────────────────────────────────────────
+
+    @Test
+    void getActiveTermId_keyExists_returnsValue() {
+        SystemConfig config = configEntry("active_term_id", "2026-SPRING");
+        when(systemConfigRepository.findByConfigKey("active_term_id"))
+                .thenReturn(Optional.of(config));
+
+        assertThat(termConfigService.getActiveTermId()).isEqualTo("2026-SPRING");
+    }
+
+    @Test
+    void getActiveTermId_keyMissing_throwsTermConfigNotFoundException() {
+        // Requirement: both getActiveTermId() and getMaxTeamSize() throw
+        // TermConfigNotFoundException (HTTP 500) if the key is missing — CLAUDE.md
+        when(systemConfigRepository.findByConfigKey("active_term_id"))
+                .thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> termConfigService.getActiveTermId())
+                .isInstanceOf(TermConfigNotFoundException.class)
+                .hasMessageContaining("active_term_id");
+    }
+
+    // ── getMaxTeamSize ───────────────────────────────────────────────────────
+
+    @Test
+    void getMaxTeamSize_keyExists_returnsInteger() {
+        SystemConfig config = configEntry("max_team_size", "5");
+        when(systemConfigRepository.findByConfigKey("max_team_size"))
+                .thenReturn(Optional.of(config));
+
+        assertThat(termConfigService.getMaxTeamSize()).isEqualTo(5);
+    }
+
+    @Test
+    void getMaxTeamSize_keyMissing_throwsTermConfigNotFoundException() {
+        when(systemConfigRepository.findByConfigKey("max_team_size"))
+                .thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> termConfigService.getMaxTeamSize())
+                .isInstanceOf(TermConfigNotFoundException.class)
+                .hasMessageContaining("max_team_size");
+    }
+
+    @Test
+    void getMaxTeamSize_valueBoundary_one_returnsOne() {
+        // P2 rule: max_team_size enforced at 1 should allow no invitations
+        SystemConfig config = configEntry("max_team_size", "1");
+        when(systemConfigRepository.findByConfigKey("max_team_size"))
+                .thenReturn(Optional.of(config));
+
+        assertThat(termConfigService.getMaxTeamSize()).isEqualTo(1);
+    }
+
+    @Test
+    void getMaxTeamSize_valueBoundary_large_returnsValue() {
+        SystemConfig config = configEntry("max_team_size", "100");
+        when(systemConfigRepository.findByConfigKey("max_team_size"))
+                .thenReturn(Optional.of(config));
+
+        assertThat(termConfigService.getMaxTeamSize()).isEqualTo(100);
+    }
+
+    /**
+     * BUG: getMaxTeamSize() does not guard against non-numeric config_value.
+     * Integer.parseInt("abc") throws NumberFormatException — not TermConfigNotFoundException.
+     * The raw NumberFormatException bypasses @ResponseStatus and GlobalExceptionHandler,
+     * producing an unstructured 500 with a cryptic message.
+     *
+     * Suggested Fix: wrap parseInt in try-catch and re-throw as TermConfigNotFoundException.
+     *
+     *   try {
+     *       return Integer.parseInt(config.getConfigValue().trim());
+     *   } catch (NumberFormatException e) {
+     *       throw new TermConfigNotFoundException(
+     *           "max_team_size config value is not a valid integer: " + config.getConfigValue());
+     *   }
+     */
+    @Test
+    void getMaxTeamSize_valueNotNumeric_shouldThrowTermConfigNotFoundException() {
+        SystemConfig config = configEntry("max_team_size", "abc");
+        when(systemConfigRepository.findByConfigKey("max_team_size"))
+                .thenReturn(Optional.of(config));
+
+        // FAILS until the fix above is applied — NumberFormatException leaks instead.
+        assertThatThrownBy(() -> termConfigService.getMaxTeamSize())
+                .isInstanceOf(TermConfigNotFoundException.class)
+                .hasMessageContaining("not a valid integer");
+    }
+
+    @Test
+    void getMaxTeamSize_valueWithWhitespace_shouldThrowTermConfigNotFoundException() {
+        // " 4 " — Integer.parseInt does not trim, same root cause.
+        SystemConfig config = configEntry("max_team_size", " 4 ");
+        when(systemConfigRepository.findByConfigKey("max_team_size"))
+                .thenReturn(Optional.of(config));
+
+        // FAILS until the fix above is applied.
+        assertThatThrownBy(() -> termConfigService.getMaxTeamSize())
+                .isInstanceOf(TermConfigNotFoundException.class)
+                .hasMessageContaining("not a valid integer");
+    }
+
+    // ── helpers ──────────────────────────────────────────────────────────────
+
+    private static SystemConfig configEntry(String key, String value) {
+        SystemConfig c = new SystemConfig();
+        c.setConfigKey(key);
+        c.setConfigValue(value);
+        return c;
+    }
+}


### PR DESCRIPTION
Part of #55

## Summary

Implements the backend configuration foundation for Process 2 by introducing server-side resolution of `active_term_id` and `max_team_size` from the shared `system_config` table.

This PR covers the data layer and service layer responsibilities defined in Issue #55 and removes the remaining placeholder behavior in `TermConfigService`. It also seeds the required Red Team configuration keys so dependent P2 services can rely on consistent configuration at runtime.

---

## Changes

### New Files

| File | Description |
|------|-------------|
| `entity/SystemConfig.java` | JPA entity mapped to `system_config` with `config_key` as PK and `config_value` as value column |
| `repository/SystemConfigRepository.java` | Repository with `findByConfigKey(String key)` lookup |
| `exception/TermConfigNotFoundException.java` | Runtime exception mapped to HTTP 500 when a required config key is missing |

### Modified Files

**`TermConfigService`**
- Replaced placeholder active term logic with database-backed resolution
- Added `getActiveTermId()` to read `active_term_id` from `system_config`
- Added `getMaxTeamSize()` to read and parse `max_team_size` from `system_config`
- Throws `TermConfigNotFoundException` if either required key is missing

**`data.sql`**
- Seeded Red Team required configuration rows:
  - `active_term_id`
  - `max_team_size`

---

## Behavior

- `active_term_id` is now resolved exclusively from the backend configuration table
- `max_team_size` is now available as a typed integer through `TermConfigService`
- Missing configuration fails explicitly with HTTP 500 instead of silently falling back to placeholder values
- Current P2 group flow continues to resolve `termId` server-side rather than accepting it from the client

---

## Validation

- Ran backend test suite with `./mvnw test`
- Verified all backend tests pass
- Verified Hibernate auto-creates the `system_config` table on startup
- Verified seeded `system_config` rows are present locally
- Verified `TermConfigService` returns:
  - `active_term_id` as a `String`
  - `max_team_size` as an `Integer`

---

## Acceptance Criteria

- [x] `system_config` table is auto-created by Hibernate on startup
- [x] `getActiveTermId()` returns the value where `config_key = 'active_term_id'`
- [x] `getMaxTeamSize()` returns the integer value where `config_key = 'max_team_size'`
- [x] Missing key throws `TermConfigNotFoundException` with HTTP 500
- [x] No implemented P2 endpoint accepts `termId` as a request parameter; current group flow resolves it via `TermConfigService`

---

## Out of Scope (deferred)

- The invitation-side wiring referenced by Issue #55 is expected to be completed in **Issue #45** 

---

## Notes

- `application.properties` was not included because it is a local ignored environment file
