### PR TITLE
Test/issue 44 group creation end-to-end integration tests 

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,111 @@
+# Red Team — Contribution Guidelines
+
+This document defines the workflow rules for all contributions to the Red Team's scope of the Senior Project Management (SPM) platform. All red team members are expected to follow these guidelines without exception.
+
+---
+
+## The Default Rule: Open a Pull Request
+
+**If you implemented something, open a PR. Full stop.**
+
+This is the expected workflow for 95% of all work. Every issue, every feature, every endpoint, every fix goes through a pull request — not directly to `main`.
+
+Direct pushes to `main` are the **exception**, not the norm. See Section 1 for the narrow cases where it is allowed.
+
+---
+
+## 1. Branch & Push Policy
+
+### Pull Request Required
+A pull request is **mandatory** for:
+
+- Any implementation tied to a GitHub issue
+- New endpoints, services, entities, or repository methods
+- Changes to existing business logic or validation rules
+- Database schema changes (new columns, tables, constraints)
+- Any modification to `SecurityConfig`, `GlobalExceptionHandler`, or `application.properties`
+- Frontend page or component additions
+- Anything that touches code owned by another team member
+
+### Exception: Direct Push to `main`
+This is only allowed for changes that are genuinely trivial. A change qualifies **only if it meets all of the following**:
+
+- Touches 1–2 files with zero logic changes (e.g. fixing a typo, updating a comment, reformatting)
+- Has no effect on any API contract, business rule, or database schema
+- Is verifiable by reading it — no running or testing needed
+
+If you are unsure whether your change qualifies, it does not qualify. Open a PR.
+
+---
+
+## 2. Pull Request Rules
+
+### Opening a PR
+- Link the PR to its issue using `Resolves #<issue-number>` in the PR body.
+- Write a short description of what was implemented and any notable decisions made.
+- Branch naming: `feature/issue-<number>-<short-description>`
+
+### Review Requirements
+- **Authors must not approve their own pull requests** — no exceptions.
+- Any team member may review and leave comments on an open PR.
+- **Only the team lead may give the final approval and perform the merge.**
+- A PR must have at least one approving review before it can be merged.
+
+### Review Etiquette
+- Leave specific, actionable comments — avoid vague feedback like "fix this."
+- If a comment is a suggestion rather than a blocker, mark it clearly (e.g. `nit:` or `suggestion:`).
+- The author is responsible for responding to all comments before requesting re-review.
+- Resolved threads should be marked resolved by the reviewer who raised them, not the author.
+
+---
+
+## 3. Commit Message Convention
+
+Use the following prefixes for all commit messages:
+
+| Prefix | When to use |
+|--------|-------------|
+| `feat:` | New feature or endpoint |
+| `fix:` | Bug fix |
+| `refactor:` | Code restructure with no behavior change |
+| `chore:` | Config, dependency, or tooling change |
+| `docs:` | Documentation only |
+| `test:` | Tests only |
+| `QA:` | Postman collections, test data, QA scripts |
+
+Example: `feat: implement group invitation endpoint (#42)`
+
+---
+
+## 4. Code Quality Expectations
+
+- Every new service method must handle its failure cases explicitly — no silent swallowing of exceptions.
+- The architectural decisions and business rules for P2/P3 are finalized. Do not deviate from them without consulting the team lead first. If you are unsure about a rule, ask before implementing.
+- `termId` is never accepted from the frontend. Always resolve via `TermConfigService.getActiveTermId()`.
+- Do not add endpoints to controllers without a corresponding entry in `docs/openapi.yaml`.
+
+---
+
+## 5. Issue Workflow
+
+1. Pick up an issue assigned to you, or claim an unassigned one by commenting on it.
+2. Create a feature branch from the latest `main`.
+3. Implement, test locally, then open a PR.
+4. Address all review comments.
+5. Team lead approves and merges.
+6. Close the issue if not automatically closed by the merge.
+
+---
+
+## 6. What Blocks a Merge
+
+The team lead will not merge a PR if any of the following are true:
+
+- The PR has unresolved review comments
+- The author has not responded to feedback
+- The implementation deviates from the spec in `docs/openapi.yaml` without justification
+- The PR breaks the build or introduces a compile error
+
+---
+
+*These guidelines apply to all Red Team members. Questions or proposed changes to this document should be raised with the team lead.*

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -85,6 +85,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.springframework.security</groupId>
             <artifactId>spring-security-test</artifactId>
             <scope>test</scope>

--- a/backend/src/main/java/com/senior/spm/config/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/senior/spm/config/GlobalExceptionHandler.java
@@ -12,7 +12,11 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 import com.senior.spm.controller.response.ErrorMessage;
+import com.senior.spm.exception.AdvisorAtCapacityException;
 import com.senior.spm.exception.ExternalToolValidationException;
+import com.senior.spm.exception.ForbiddenException;
+import com.senior.spm.exception.RequestNotFoundException;
+import com.senior.spm.exception.RequestNotPendingException;
 
 @RestControllerAdvice
 public class GlobalExceptionHandler {
@@ -47,5 +51,25 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(ExternalToolValidationException.class)
     public ResponseEntity<ErrorMessage> handleExternalToolValidation(ExternalToolValidationException ex) {
         return ResponseEntity.status(HttpStatus.UNPROCESSABLE_ENTITY).body(new ErrorMessage(ex.getMessage()));
+    }
+
+    @ExceptionHandler(AdvisorAtCapacityException.class)
+    public ResponseEntity<ErrorMessage> handleAdvisorAtCapacity(AdvisorAtCapacityException ex) {
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(new ErrorMessage(ex.getMessage()));
+    }
+
+    @ExceptionHandler(ForbiddenException.class)
+    public ResponseEntity<ErrorMessage> handleForbidden(ForbiddenException ex) {
+        return ResponseEntity.status(HttpStatus.FORBIDDEN).body(new ErrorMessage(ex.getMessage()));
+    }
+
+    @ExceptionHandler(RequestNotFoundException.class)
+    public ResponseEntity<ErrorMessage> handleRequestNotFound(RequestNotFoundException ex) {
+        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(new ErrorMessage(ex.getMessage()));
+    }
+
+    @ExceptionHandler(RequestNotPendingException.class)
+    public ResponseEntity<ErrorMessage> handleRequestNotPending(RequestNotPendingException ex) {
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(new ErrorMessage(ex.getMessage()));
     }
 }

--- a/backend/src/main/java/com/senior/spm/config/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/senior/spm/config/GlobalExceptionHandler.java
@@ -13,10 +13,14 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 import com.senior.spm.controller.response.ErrorMessage;
 import com.senior.spm.exception.AdvisorAtCapacityException;
+import com.senior.spm.exception.AlreadyInGroupException;
+import com.senior.spm.exception.DuplicateGroupNameException;
 import com.senior.spm.exception.ExternalToolValidationException;
 import com.senior.spm.exception.ForbiddenException;
+import com.senior.spm.exception.NotInGroupException;
 import com.senior.spm.exception.RequestNotFoundException;
 import com.senior.spm.exception.RequestNotPendingException;
+import com.senior.spm.exception.ScheduleWindowClosedException;
 
 @RestControllerAdvice
 public class GlobalExceptionHandler {
@@ -42,6 +46,26 @@ public class GlobalExceptionHandler {
     public ResponseEntity<ErrorMessage> handleRuntimeException(RuntimeException ex) {
         return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
                 .body(new ErrorMessage("An unexpected error occurred: " + ex.getMessage()));
+    }
+
+    @ExceptionHandler(ScheduleWindowClosedException.class)
+    public ResponseEntity<ErrorMessage> handleScheduleWindowClosed(ScheduleWindowClosedException ex) {
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(new ErrorMessage(ex.getMessage()));
+    }
+
+    @ExceptionHandler(AlreadyInGroupException.class)
+    public ResponseEntity<ErrorMessage> handleAlreadyInGroup(AlreadyInGroupException ex) {
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(new ErrorMessage(ex.getMessage()));
+    }
+
+    @ExceptionHandler(DuplicateGroupNameException.class)
+    public ResponseEntity<ErrorMessage> handleDuplicateGroupName(DuplicateGroupNameException ex) {
+        return ResponseEntity.status(HttpStatus.CONFLICT).body(new ErrorMessage(ex.getMessage()));
+    }
+
+    @ExceptionHandler(NotInGroupException.class)
+    public ResponseEntity<ErrorMessage> handleNotInGroup(NotInGroupException ex) {
+        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(new ErrorMessage(ex.getMessage()));
     }
 
     // Maps JiraValidationException and GitHubValidationException (both extend

--- a/backend/src/main/java/com/senior/spm/config/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/senior/spm/config/GlobalExceptionHandler.java
@@ -12,6 +12,7 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 import com.senior.spm.controller.response.ErrorMessage;
+import com.senior.spm.exception.ExternalToolValidationException;
 
 @RestControllerAdvice
 public class GlobalExceptionHandler {
@@ -35,6 +36,16 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(RuntimeException.class)
     public ResponseEntity<ErrorMessage> handleRuntimeException(RuntimeException ex) {
-        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(new ErrorMessage("An unexpected error occurred: " + ex.getMessage()));
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                .body(new ErrorMessage("An unexpected error occurred: " + ex.getMessage()));
+    }
+
+    // Maps JiraValidationException and GitHubValidationException (both extend
+    // ExternalToolValidationException) to HTTP 422 Unprocessable Entity.
+    // The exception message is the exact user-facing string defined in the API spec
+    // (e.g. "JIRA validation failed: API token is invalid or expired").
+    @ExceptionHandler(ExternalToolValidationException.class)
+    public ResponseEntity<ErrorMessage> handleExternalToolValidation(ExternalToolValidationException ex) {
+        return ResponseEntity.status(HttpStatus.UNPROCESSABLE_ENTITY).body(new ErrorMessage(ex.getMessage()));
     }
 }

--- a/backend/src/main/java/com/senior/spm/config/RestTemplateConfig.java
+++ b/backend/src/main/java/com/senior/spm/config/RestTemplateConfig.java
@@ -1,0 +1,27 @@
+package com.senior.spm.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.client.SimpleClientHttpRequestFactory;
+import org.springframework.web.client.RestTemplate;
+
+/**
+ * Configures a RestTemplate bean with a strict 5-second timeout
+ * for all outbound HTTP calls to external APIs (JIRA, GitHub).
+ *
+ * Acceptance criterion: "Services strictly enforce a 5-second timeout."
+ * Issue #48 — [Backend] External Tool Validation Services
+ */
+@Configuration
+public class RestTemplateConfig {
+
+    private static final int TIMEOUT_MS = 5_000;
+
+    @Bean
+    public RestTemplate restTemplate() {
+        var factory = new SimpleClientHttpRequestFactory();
+        factory.setConnectTimeout(TIMEOUT_MS);
+        factory.setReadTimeout(TIMEOUT_MS);
+        return new RestTemplate(factory);
+    }
+}

--- a/backend/src/main/java/com/senior/spm/controller/GroupController.java
+++ b/backend/src/main/java/com/senior/spm/controller/GroupController.java
@@ -1,5 +1,6 @@
 package com.senior.spm.controller;
 
+import java.util.List;
 import java.util.UUID;
 
 import org.springframework.http.HttpStatus;
@@ -8,13 +9,18 @@ import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.senior.spm.controller.dto.BindGithubRequest;
+import com.senior.spm.controller.dto.BindJiraRequest;
 import com.senior.spm.controller.dto.CreateGroupRequest;
 import com.senior.spm.controller.dto.GroupDetailResponse;
+import com.senior.spm.controller.dto.InvitationResponse;
+import com.senior.spm.controller.dto.SendInvitationRequest;
 import com.senior.spm.service.GroupService;
 
 import jakarta.validation.Valid;
@@ -88,6 +94,62 @@ public class GroupController {
 
         GroupDetailResponse response = groupService.getMyGroup(studentUUID);
         return ResponseEntity.ok(response);
+    }
+
+    // TODO: Issue #45 — [Backend] Invitation Lifecycle Services & Controller
+    /**
+     * Send a group invitation to a target student.
+     * Auth: Student JWT (must be TEAM_LEADER of groupId)
+     * POST /api/groups/{groupId}/invitations
+     */
+    @PostMapping("/{groupId}/invitations")
+    public ResponseEntity<InvitationResponse> sendInvitation(
+        @PathVariable UUID groupId,
+        @Valid @RequestBody SendInvitationRequest request
+    ) {
+        // TODO: Issue #45 — wire to InvitationService.sendInvitation(groupId, extractStudentUUIDFromJWT(), request.getTargetStudentId())
+        throw new UnsupportedOperationException("Not implemented yet");
+    }
+
+    /**
+     * List all invitations sent by the group.
+     * Auth: Student JWT (must be TEAM_LEADER of groupId)
+     * GET /api/groups/{groupId}/invitations
+     */
+    @GetMapping("/{groupId}/invitations")
+    public ResponseEntity<List<InvitationResponse>> getGroupInvitations(
+        @PathVariable UUID groupId
+    ) {
+        // TODO: Issue #45 — wire to InvitationService.getGroupInvitations(groupId, extractStudentUUIDFromJWT())
+        throw new UnsupportedOperationException("Not implemented yet");
+    }
+
+    /**
+     * Bind JIRA workspace to the group.
+     * Auth: Student JWT (must be TEAM_LEADER of groupId)
+     * POST /api/groups/{groupId}/jira
+     */
+    @PostMapping("/{groupId}/jira")
+    public ResponseEntity<GroupDetailResponse> bindJira(
+        @PathVariable UUID groupId,
+        @Valid @RequestBody BindJiraRequest request
+    ) {
+        // TODO: Issue #49 — wire to GroupService.bindJira(groupId, extractStudentUUIDFromJWT(), request)
+        throw new UnsupportedOperationException("Not implemented yet");
+    }
+
+    /**
+     * Bind GitHub organization to the group.
+     * Auth: Student JWT (must be TEAM_LEADER of groupId)
+     * POST /api/groups/{groupId}/github
+     */
+    @PostMapping("/{groupId}/github")
+    public ResponseEntity<GroupDetailResponse> bindGithub(
+        @PathVariable UUID groupId,
+        @Valid @RequestBody BindGithubRequest request
+    ) {
+        // TODO: Issue #49 — wire to GroupService.bindGithub(groupId, extractStudentUUIDFromJWT(), request)
+        throw new UnsupportedOperationException("Not implemented yet");
     }
 
     /**

--- a/backend/src/main/java/com/senior/spm/controller/GroupController.java
+++ b/backend/src/main/java/com/senior/spm/controller/GroupController.java
@@ -1,0 +1,104 @@
+package com.senior.spm.controller;
+
+import java.util.UUID;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.senior.spm.controller.dto.CreateGroupRequest;
+import com.senior.spm.controller.dto.GroupDetailResponse;
+import com.senior.spm.service.GroupService;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/api/groups")
+@RequiredArgsConstructor
+@Validated
+public class GroupController {
+
+    private final GroupService groupService;
+
+    /**
+     * Create a new group for the authenticated student.
+     * 
+     * Validates that the student is not already in a group, the group name is unique for the current term,
+     * and the GROUP_CREATION schedule window is active. On success, creates a ProjectGroup and adds
+     * the requesting student as TEAM_LEADER.
+     * 
+     * @param request the {@link CreateGroupRequest} containing the group name (required)
+     * @return {@link ResponseEntity} with status 201 and {@link GroupDetailResponse} containing:
+     *         - id: UUID of the created group
+     *         - groupName: the group name
+     *         - termId: UUID of the current active term
+     *         - status: initial status is FORMING
+     *         - createdAt: ISO-8601 timestamp
+     *         - members: list containing the TEAM_LEADER member record
+     *         
+     *         Error responses:
+     *         - 400: if group creation window is not active, student is already in a group, or group name is duplicate
+     *         - 409: if a group with the same name already exists for the term
+     */
+    @PostMapping
+    public ResponseEntity<GroupDetailResponse> createGroup(
+        @Valid @RequestBody CreateGroupRequest request
+    ) {
+        // Extract student UUID from JWT
+        UUID studentUUID = extractStudentUUIDFromJWT();
+
+        GroupDetailResponse response = groupService.createGroup(request.getGroupName(), studentUUID);
+        return ResponseEntity.status(HttpStatus.CREATED).body(response);
+    }
+
+    /**
+     * Retrieve the authenticated student's current group details.
+     * 
+     * Returns the complete group information including members, tool binding status (Jira, GitHub),
+     * and all relevant metadata.
+     * 
+     * @return {@link ResponseEntity} with status 200 and {@link GroupDetailResponse} containing:
+     *         - id: UUID of the group
+     *         - groupName: the group name
+     *         - termId: UUID of the term
+     *         - status: current group status (FORMING, TOOLS_PENDING, TOOLS_BOUND, ADVISOR_ASSIGNED, DISBANDED)
+     *         - createdAt: ISO-8601 timestamp
+     *         - jiraSpaceUrl: JIRA space URL (null if not bound)
+     *         - jiraProjectKey: JIRA project key (null if not bound)
+     *         - jiraBound: boolean indicating if JIRA is bound
+     *         - githubOrgName: GitHub organization name (null if not bound)
+     *         - githubBound: boolean indicating if GitHub is bound
+     *         - members: list of group members with studentId, role (TEAM_LEADER or MEMBER), and joinedAt
+     *         
+     *         Error responses:
+     *         - 404: if the authenticated student is not a member of any group
+     */
+    @GetMapping("/my")
+    public ResponseEntity<GroupDetailResponse> getMyGroup() {
+        // Extract student UUID from JWT
+        UUID studentUUID = extractStudentUUIDFromJWT();
+
+        GroupDetailResponse response = groupService.getMyGroup(studentUUID);
+        return ResponseEntity.ok(response);
+    }
+
+    /**
+     * Extract student UUID from SecurityContext
+     * Assumes the principal is a String containing the UUID
+     */
+    private UUID extractStudentUUIDFromJWT() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        String principal = (String) authentication.getPrincipal();
+        // Principal should contain the student UUID
+        // TODO: Parse the JWT properly to extract the student UUID
+        return UUID.fromString(principal);
+    }
+}

--- a/backend/src/main/java/com/senior/spm/controller/InvitationController.java
+++ b/backend/src/main/java/com/senior/spm/controller/InvitationController.java
@@ -1,0 +1,70 @@
+package com.senior.spm.controller;
+
+import java.util.List;
+import java.util.UUID;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.senior.spm.controller.dto.InvitationResponse;
+import com.senior.spm.controller.dto.RespondInvitationRequest;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+
+// TODO: Issue #45 — [Backend] Invitation Lifecycle Services & Controller
+// This skeleton was scaffolded as part of Issue #40 (Base API Layer).
+// Full service wiring, business rules, and transactional logic belong to Issue #45.
+@RestController
+@RequestMapping("/api/invitations")
+@RequiredArgsConstructor
+@Validated
+public class InvitationController {
+
+    /**
+     * Get all pending invitations for the authenticated student.
+     * Auth: Student JWT
+     * GET /api/invitations/pending
+     */
+    @GetMapping("/pending")
+    public ResponseEntity<List<InvitationResponse>> getPendingInvitations() {
+        // TODO: wire to InvitationService.getPendingInvitations(extractStudentUUIDFromJWT())
+        throw new UnsupportedOperationException("Not implemented yet");
+    }
+
+    /**
+     * Accept or decline an invitation.
+     * Auth: Student JWT (must be the invitee)
+     * PATCH /api/invitations/{invitationId}/respond
+     * Returns GroupDetailResponse on accept, InvitationResponse on decline
+     */
+    @PatchMapping("/{invitationId}/respond")
+    public ResponseEntity<?> respondToInvitation(
+        @PathVariable UUID invitationId,
+        @Valid @RequestBody RespondInvitationRequest request
+    ) {
+        // TODO: wire to InvitationService.respondToInvitation(invitationId, extractStudentUUIDFromJWT(), request.getAccept())
+        throw new UnsupportedOperationException("Not implemented yet");
+    }
+
+    /**
+     * Cancel a pending invitation.
+     * Auth: Student JWT (must be TEAM_LEADER of the inviting group)
+     * DELETE /api/invitations/{invitationId}
+     */
+    @DeleteMapping("/{invitationId}")
+    public ResponseEntity<InvitationResponse> cancelInvitation(
+        @PathVariable UUID invitationId
+    ) {
+        // TODO: wire to InvitationService.cancelInvitation(invitationId, extractStudentUUIDFromJWT())
+        throw new UnsupportedOperationException("Not implemented yet");
+    }
+
+}

--- a/backend/src/main/java/com/senior/spm/controller/StudentController.java
+++ b/backend/src/main/java/com/senior/spm/controller/StudentController.java
@@ -1,0 +1,33 @@
+package com.senior.spm.controller;
+
+import java.util.List;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import lombok.RequiredArgsConstructor;
+
+// TODO: Issue #45 — [Backend] Invitation Lifecycle Services & Controller
+// Student search is part of the invitation dispatch flow (DFD 2.2).
+@RestController
+@RequestMapping("/api/students")
+@RequiredArgsConstructor
+@Validated
+public class StudentController {
+
+    /**
+     * Search for students not currently in any group.
+     * Auth: Student JWT
+     * GET /api/students/search?q={query} (min 3 chars)
+     * Returns students with studentId, githubUsername, inGroup=false
+     */
+    @GetMapping("/search")
+    public ResponseEntity<List<?>> searchStudents(@RequestParam String q) {
+        // TODO: wire to StudentService.searchAvailableStudents(q)
+        throw new UnsupportedOperationException("Not implemented yet");
+    }
+}

--- a/backend/src/main/java/com/senior/spm/controller/dto/BindGithubRequest.java
+++ b/backend/src/main/java/com/senior/spm/controller/dto/BindGithubRequest.java
@@ -1,0 +1,15 @@
+// TODO: Issue #49 — [Backend] Tool Binding & Encryption Orchestration
+package com.senior.spm.controller.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Data;
+
+@Data
+public class BindGithubRequest {
+
+    @NotBlank(message = "GitHub organization name is required")
+    private String githubOrgName;
+
+    @NotBlank(message = "GitHub PAT is required")
+    private String githubPat;
+}

--- a/backend/src/main/java/com/senior/spm/controller/dto/BindJiraRequest.java
+++ b/backend/src/main/java/com/senior/spm/controller/dto/BindJiraRequest.java
@@ -1,0 +1,18 @@
+// TODO: Issue #49 — [Backend] Tool Binding & Encryption Orchestration
+package com.senior.spm.controller.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Data;
+
+@Data
+public class BindJiraRequest {
+
+    @NotBlank(message = "JIRA space URL is required")
+    private String jiraSpaceUrl;
+
+    @NotBlank(message = "JIRA project key is required")
+    private String jiraProjectKey;
+
+    @NotBlank(message = "JIRA API token is required")
+    private String jiraApiToken;
+}

--- a/backend/src/main/java/com/senior/spm/controller/dto/CreateGroupRequest.java
+++ b/backend/src/main/java/com/senior/spm/controller/dto/CreateGroupRequest.java
@@ -1,0 +1,11 @@
+package com.senior.spm.controller.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Data;
+
+@Data
+public class CreateGroupRequest {
+
+    @NotBlank(message = "Group name is required")
+    private String groupName;
+}

--- a/backend/src/main/java/com/senior/spm/controller/dto/GroupDetailResponse.java
+++ b/backend/src/main/java/com/senior/spm/controller/dto/GroupDetailResponse.java
@@ -23,7 +23,7 @@ public class GroupDetailResponse {
 
     @Data
     public static class MemberResponse {
-        private UUID studentId;
+        private String studentId;
         private String role;
         private LocalDateTime joinedAt;
     }

--- a/backend/src/main/java/com/senior/spm/controller/dto/GroupDetailResponse.java
+++ b/backend/src/main/java/com/senior/spm/controller/dto/GroupDetailResponse.java
@@ -1,0 +1,30 @@
+package com.senior.spm.controller.dto;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+
+import lombok.Data;
+
+@Data
+public class GroupDetailResponse {
+
+    private UUID id;
+    private String groupName;
+    private String termId;
+    private String status;
+    private LocalDateTime createdAt;
+    private String jiraSpaceUrl;
+    private String jiraProjectKey;
+    private Boolean jiraBound;
+    private String githubOrgName;
+    private Boolean githubBound;
+    private List<MemberResponse> members;
+
+    @Data
+    public static class MemberResponse {
+        private UUID studentId;
+        private String role;
+        private LocalDateTime joinedAt;
+    }
+}

--- a/backend/src/main/java/com/senior/spm/controller/dto/InvitationResponse.java
+++ b/backend/src/main/java/com/senior/spm/controller/dto/InvitationResponse.java
@@ -1,0 +1,17 @@
+// TODO: Issue #45 — [Backend] Invitation Lifecycle Services & Controller
+package com.senior.spm.controller.dto;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+import lombok.Data;
+
+@Data
+public class InvitationResponse {
+
+    private UUID invitationId;
+    private UUID groupId;
+    private String targetStudentId;
+    private String status;
+    private LocalDateTime sentAt;
+}

--- a/backend/src/main/java/com/senior/spm/controller/dto/RespondInvitationRequest.java
+++ b/backend/src/main/java/com/senior/spm/controller/dto/RespondInvitationRequest.java
@@ -1,0 +1,12 @@
+// TODO: Issue #45 — [Backend] Invitation Lifecycle Services & Controller
+package com.senior.spm.controller.dto;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.Data;
+
+@Data
+public class RespondInvitationRequest {
+
+    @NotNull(message = "accept field is required")
+    private Boolean accept;
+}

--- a/backend/src/main/java/com/senior/spm/controller/dto/SendInvitationRequest.java
+++ b/backend/src/main/java/com/senior/spm/controller/dto/SendInvitationRequest.java
@@ -1,0 +1,12 @@
+// TODO: Issue #45 — [Backend] Invitation Lifecycle Services & Controller
+package com.senior.spm.controller.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Data;
+
+@Data
+public class SendInvitationRequest {
+
+    @NotBlank(message = "Target student ID is required")
+    private String targetStudentId;
+}

--- a/backend/src/main/java/com/senior/spm/entity/AdvisorRequest.java
+++ b/backend/src/main/java/com/senior/spm/entity/AdvisorRequest.java
@@ -1,0 +1,57 @@
+package com.senior.spm.entity;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.ForeignKey;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Table(name = "advisor_request")
+@Getter
+@Setter
+@NoArgsConstructor
+public class AdvisorRequest {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID id;
+
+    @ManyToOne
+    @JoinColumn(name = "group_id", nullable = false, foreignKey = @ForeignKey(name = "fk_advisor_request_group"))
+    private ProjectGroup group;
+
+    @ManyToOne
+    @JoinColumn(name = "advisor_id", nullable = false, foreignKey = @ForeignKey(name = "fk_advisor_request_advisor"))
+    private StaffUser advisor;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private RequestStatus status;
+
+    @Column(nullable = false)
+    private LocalDateTime sentAt;
+
+    @Column(nullable = true)
+    private LocalDateTime respondedAt;
+
+    public enum RequestStatus {
+        PENDING,
+        ACCEPTED,
+        REJECTED,
+        AUTO_REJECTED,
+        CANCELLED
+    }
+}

--- a/backend/src/main/java/com/senior/spm/entity/GroupInvitation.java
+++ b/backend/src/main/java/com/senior/spm/entity/GroupInvitation.java
@@ -1,0 +1,57 @@
+package com.senior.spm.entity;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.ForeignKey;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Table(name = "group_invitation")
+@Getter
+@Setter
+@NoArgsConstructor
+public class GroupInvitation {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID id;
+
+    @ManyToOne
+    @JoinColumn(name = "group_id", nullable = false, foreignKey = @ForeignKey(name = "fk_group_invitation_group"))
+    private ProjectGroup group;
+
+    @ManyToOne
+    @JoinColumn(name = "invitee_student_id", nullable = false, foreignKey = @ForeignKey(name = "fk_group_invitation_student"))
+    private Student invitee;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private InvitationStatus status;
+
+    @Column(nullable = false)
+    private LocalDateTime sentAt;
+
+    @Column(nullable = true)
+    private LocalDateTime respondedAt;
+
+    public enum InvitationStatus {
+        PENDING,
+        ACCEPTED,
+        DECLINED,
+        CANCELLED,
+        AUTO_DENIED
+    }
+}

--- a/backend/src/main/java/com/senior/spm/entity/GroupMembership.java
+++ b/backend/src/main/java/com/senior/spm/entity/GroupMembership.java
@@ -1,0 +1,55 @@
+package com.senior.spm.entity;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.ForeignKey;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Table(name = "group_membership", uniqueConstraints = {
+    @UniqueConstraint(name = "uq_gm_group_student", columnNames = {"group_id", "student_id"}),
+    @UniqueConstraint(name = "uq_gm_student", columnNames = {"student_id"})
+})
+@Getter
+@Setter
+@NoArgsConstructor
+public class GroupMembership {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID id;
+
+    @ManyToOne
+    @JoinColumn(name = "group_id", nullable = false, foreignKey = @ForeignKey(name = "fk_group_membership_group"))
+    private ProjectGroup group;
+
+    @ManyToOne
+    @JoinColumn(name = "student_id", nullable = false, foreignKey = @ForeignKey(name = "fk_group_membership_student"))
+    private Student student;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private MemberRole role;
+
+    @Column(nullable = false)
+    private LocalDateTime joinedAt;
+
+    public enum MemberRole {
+        TEAM_LEADER,
+        MEMBER
+    }
+}

--- a/backend/src/main/java/com/senior/spm/entity/ProjectGroup.java
+++ b/backend/src/main/java/com/senior/spm/entity/ProjectGroup.java
@@ -1,0 +1,84 @@
+package com.senior.spm.entity;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.ForeignKey;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
+import jakarta.persistence.Version;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Table(name = "project_group")
+@Getter
+@Setter
+@NoArgsConstructor
+public class ProjectGroup {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID id;
+
+    @Column(nullable = false)
+    private String groupName;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private GroupStatus status;
+
+    @Column(nullable = false)
+    private String termId;
+
+    @Column(nullable = false)
+    private LocalDateTime createdAt;
+
+    @Column(length = 500, nullable = true)
+    private String jiraSpaceUrl;
+
+    @Column(length = 100, nullable = true)
+    private String jiraProjectKey;
+
+    @Column(length = 1024, nullable = true)
+    private String encryptedJiraToken;
+
+    @Column(length = 100, nullable = true)
+    private String githubOrgName;
+
+    @Column(length = 1024, nullable = true)
+    private String encryptedGithubPat;
+
+    @ManyToOne
+    @JoinColumn(name = "advisor_id", nullable = true, foreignKey = @ForeignKey(name = "fk_project_group_advisor"))
+    private StaffUser advisor;
+
+    @OneToMany(mappedBy = "group")
+    private List<GroupMembership> members;
+
+    @OneToMany(mappedBy = "group")
+    private List<GroupInvitation> invitations;
+
+    @Version
+    @Column(nullable = false)
+    private Long version;
+
+    public enum GroupStatus {
+        FORMING,
+        TOOLS_PENDING,
+        TOOLS_BOUND,
+        ADVISOR_ASSIGNED,
+        DISBANDED
+    }
+}

--- a/backend/src/main/java/com/senior/spm/entity/ScheduleWindow.java
+++ b/backend/src/main/java/com/senior/spm/entity/ScheduleWindow.java
@@ -1,6 +1,6 @@
 package com.senior.spm.entity;
 
-import java.util.List;
+import java.time.LocalDateTime;
 import java.util.UUID;
 
 import jakarta.persistence.Column;
@@ -10,46 +10,37 @@ import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
-import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 @Entity
-@Table(name = "staffUser")
+@Table(name = "schedule_window")
 @Getter
 @Setter
 @NoArgsConstructor
-public class StaffUser {
+public class ScheduleWindow {
 
     @Id
     @GeneratedValue(strategy = GenerationType.UUID)
     private UUID id;
 
-    @Column(nullable = false, unique = true)
-    private String mail;
-
     @Column(nullable = false)
-    private String passwordHash;
+    private String termId;
 
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
-    private Role role;
+    private WindowType type;
 
     @Column(nullable = false)
-    private boolean firstLogin = true;
+    private LocalDateTime opensAt;
 
     @Column(nullable = false)
-    private int advisorCapacity = 5;
+    private LocalDateTime closesAt;
 
-    @OneToMany(mappedBy = "advisor")
-    private List<ProjectGroup> advisedGroups;
-
-    @OneToMany(mappedBy = "advisor")
-    private List<AdvisorRequest> receivedRequests;
-
-    public enum Role {
-        Admin, Coordinator, Professor
+    public enum WindowType {
+        GROUP_CREATION,
+        ADVISOR_ASSOCIATION
     }
 }

--- a/backend/src/main/java/com/senior/spm/entity/Student.java
+++ b/backend/src/main/java/com/senior/spm/entity/Student.java
@@ -1,5 +1,6 @@
 package com.senior.spm.entity;
 
+import java.util.List;
 import java.util.UUID;
 
 import jakarta.persistence.Column;
@@ -7,6 +8,7 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 import jakarta.validation.constraints.Pattern;
 import lombok.Getter;
@@ -30,4 +32,10 @@ public class Student {
 
     @Column(length = 255, nullable = true, unique = true)
     private String githubUsername;
+
+    @OneToMany(mappedBy = "student")
+    private List<GroupMembership> memberships;
+
+    @OneToMany(mappedBy = "invitee")
+    private List<GroupInvitation> invitations;
 }

--- a/backend/src/main/java/com/senior/spm/entity/SystemConfig.java
+++ b/backend/src/main/java/com/senior/spm/entity/SystemConfig.java
@@ -1,0 +1,24 @@
+package com.senior.spm.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Table(name = "system_config")
+@Getter
+@Setter
+@NoArgsConstructor
+public class SystemConfig {
+
+    @Id
+    @Column(name = "config_key", nullable = false, unique = true)
+    private String configKey;
+
+    @Column(name = "config_value", nullable = false)
+    private String configValue;
+}

--- a/backend/src/main/java/com/senior/spm/exception/AdvisorAtCapacityException.java
+++ b/backend/src/main/java/com/senior/spm/exception/AdvisorAtCapacityException.java
@@ -1,0 +1,11 @@
+package com.senior.spm.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(HttpStatus.BAD_REQUEST)
+public class AdvisorAtCapacityException extends RuntimeException {
+    public AdvisorAtCapacityException(String message) {
+        super(message);
+    }
+}

--- a/backend/src/main/java/com/senior/spm/exception/AlreadyInGroupException.java
+++ b/backend/src/main/java/com/senior/spm/exception/AlreadyInGroupException.java
@@ -1,0 +1,8 @@
+package com.senior.spm.exception;
+
+public class AlreadyInGroupException extends RuntimeException {
+
+    public AlreadyInGroupException(String message) {
+        super(message);
+    }
+}

--- a/backend/src/main/java/com/senior/spm/exception/DuplicateGroupNameException.java
+++ b/backend/src/main/java/com/senior/spm/exception/DuplicateGroupNameException.java
@@ -1,0 +1,8 @@
+package com.senior.spm.exception;
+
+public class DuplicateGroupNameException extends RuntimeException {
+
+    public DuplicateGroupNameException(String message) {
+        super(message);
+    }
+}

--- a/backend/src/main/java/com/senior/spm/exception/ExternalToolValidationException.java
+++ b/backend/src/main/java/com/senior/spm/exception/ExternalToolValidationException.java
@@ -1,0 +1,12 @@
+package com.senior.spm.exception;
+
+/**
+ * Base exception for external tool validation failures (JIRA, GitHub).
+ * Subclasses carry the exact user-facing 422 message defined in the API spec.
+ */
+public class ExternalToolValidationException extends RuntimeException {
+
+    public ExternalToolValidationException(String message) {
+        super(message);
+    }
+}

--- a/backend/src/main/java/com/senior/spm/exception/ForbiddenException.java
+++ b/backend/src/main/java/com/senior/spm/exception/ForbiddenException.java
@@ -1,0 +1,11 @@
+package com.senior.spm.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(HttpStatus.FORBIDDEN)
+public class ForbiddenException extends RuntimeException {
+    public ForbiddenException(String message) {
+        super(message);
+    }
+}

--- a/backend/src/main/java/com/senior/spm/exception/GitHubValidationException.java
+++ b/backend/src/main/java/com/senior/spm/exception/GitHubValidationException.java
@@ -1,0 +1,12 @@
+package com.senior.spm.exception;
+
+/**
+ * Thrown by GitHubValidationService when a live GitHub API call fails.
+ * Maps to HTTP 422 Unprocessable Entity.
+ */
+public class GitHubValidationException extends ExternalToolValidationException {
+
+    public GitHubValidationException(String message) {
+        super(message);
+    }
+}

--- a/backend/src/main/java/com/senior/spm/exception/JiraValidationException.java
+++ b/backend/src/main/java/com/senior/spm/exception/JiraValidationException.java
@@ -1,0 +1,12 @@
+package com.senior.spm.exception;
+
+/**
+ * Thrown by JiraValidationService when a live JIRA API call fails.
+ * Maps to HTTP 422 Unprocessable Entity.
+ */
+public class JiraValidationException extends ExternalToolValidationException {
+
+    public JiraValidationException(String message) {
+        super(message);
+    }
+}

--- a/backend/src/main/java/com/senior/spm/exception/NotInGroupException.java
+++ b/backend/src/main/java/com/senior/spm/exception/NotInGroupException.java
@@ -1,0 +1,8 @@
+package com.senior.spm.exception;
+
+public class NotInGroupException extends RuntimeException {
+
+    public NotInGroupException(String message) {
+        super(message);
+    }
+}

--- a/backend/src/main/java/com/senior/spm/exception/RequestNotFoundException.java
+++ b/backend/src/main/java/com/senior/spm/exception/RequestNotFoundException.java
@@ -1,0 +1,11 @@
+package com.senior.spm.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(HttpStatus.NOT_FOUND)
+public class RequestNotFoundException extends RuntimeException {
+    public RequestNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/backend/src/main/java/com/senior/spm/exception/RequestNotPendingException.java
+++ b/backend/src/main/java/com/senior/spm/exception/RequestNotPendingException.java
@@ -1,0 +1,11 @@
+package com.senior.spm.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(HttpStatus.BAD_REQUEST)
+public class RequestNotPendingException extends RuntimeException {
+    public RequestNotPendingException(String message) {
+        super(message);
+    }
+}

--- a/backend/src/main/java/com/senior/spm/exception/ScheduleWindowClosedException.java
+++ b/backend/src/main/java/com/senior/spm/exception/ScheduleWindowClosedException.java
@@ -1,0 +1,8 @@
+package com.senior.spm.exception;
+
+public class ScheduleWindowClosedException extends RuntimeException {
+
+    public ScheduleWindowClosedException(String message) {
+        super(message);
+    }
+}

--- a/backend/src/main/java/com/senior/spm/exception/TermConfigNotFoundException.java
+++ b/backend/src/main/java/com/senior/spm/exception/TermConfigNotFoundException.java
@@ -1,0 +1,11 @@
+package com.senior.spm.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
+public class TermConfigNotFoundException extends RuntimeException {
+    public TermConfigNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/backend/src/main/java/com/senior/spm/repository/AdvisorRequestRepository.java
+++ b/backend/src/main/java/com/senior/spm/repository/AdvisorRequestRepository.java
@@ -1,0 +1,37 @@
+package com.senior.spm.repository;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.stereotype.Repository;
+
+import com.senior.spm.entity.AdvisorRequest;
+import com.senior.spm.entity.AdvisorRequest.RequestStatus;
+
+@Repository
+public interface AdvisorRequestRepository extends JpaRepository<AdvisorRequest, UUID> {
+
+    List<AdvisorRequest> findByGroupId(UUID groupId);
+
+    List<AdvisorRequest> findByAdvisorId(UUID advisorId);
+
+    List<AdvisorRequest> findByAdvisorIdAndStatus(UUID advisorId, RequestStatus status);
+
+    Optional<AdvisorRequest> findByGroupIdAndStatus(UUID groupId, RequestStatus status);
+
+    Optional<AdvisorRequest> findTopByGroupIdOrderBySentAtDesc(UUID groupId);
+
+    long countByAdvisorIdAndStatus(UUID advisorId, RequestStatus status);
+
+    @Modifying
+    @Query("UPDATE AdvisorRequest ar SET ar.status = ?1 WHERE ar.status = 'PENDING' AND ar.group.id = ?2 AND ar.id != ?3")
+    void bulkUpdateStatusForGroup(RequestStatus status, UUID groupId, UUID excludeId);
+
+    @Modifying
+    @Query("UPDATE AdvisorRequest ar SET ar.status = :status WHERE ar.status = 'PENDING' AND ar.group.id = :groupId")
+    void bulkUpdateStatusByGroupId(@org.springframework.data.repository.query.Param("status") RequestStatus status, @org.springframework.data.repository.query.Param("groupId") UUID groupId);
+}

--- a/backend/src/main/java/com/senior/spm/repository/GroupInvitationRepository.java
+++ b/backend/src/main/java/com/senior/spm/repository/GroupInvitationRepository.java
@@ -1,0 +1,34 @@
+package com.senior.spm.repository;
+
+import java.util.List;
+import java.util.UUID;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.stereotype.Repository;
+
+import com.senior.spm.entity.GroupInvitation;
+import com.senior.spm.entity.GroupInvitation.InvitationStatus;
+
+@Repository
+public interface GroupInvitationRepository extends JpaRepository<GroupInvitation, UUID> {
+
+    List<GroupInvitation> findByGroupId(UUID groupId);
+
+    List<GroupInvitation> findByInviteeId(UUID inviteeId);
+
+    List<GroupInvitation> findByInviteeIdAndStatus(UUID inviteeId, InvitationStatus status);
+
+    boolean existsByGroupIdAndInviteeIdAndStatus(UUID groupId, UUID inviteeId, InvitationStatus status);
+
+    long countByGroupIdAndStatus(UUID groupId, InvitationStatus status);
+
+    @Modifying
+    @Query("UPDATE GroupInvitation gi SET gi.status = 'AUTO_DENIED' WHERE gi.status = 'PENDING' AND gi.invitee.id = ?1 AND gi.group.id != ?2")
+    void autoDenyOtherPendingInvitations(UUID studentId, UUID acceptedGroupId);
+
+    @Modifying
+    @Query("UPDATE GroupInvitation gi SET gi.status = 'AUTO_DENIED' WHERE gi.status = 'PENDING' AND gi.group.id = ?1")
+    void autoDenyAllPendingByGroupId(UUID groupId);
+}

--- a/backend/src/main/java/com/senior/spm/repository/GroupMembershipRepository.java
+++ b/backend/src/main/java/com/senior/spm/repository/GroupMembershipRepository.java
@@ -1,0 +1,29 @@
+package com.senior.spm.repository;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import com.senior.spm.entity.GroupMembership;
+import com.senior.spm.entity.GroupMembership.MemberRole;
+
+@Repository
+public interface GroupMembershipRepository extends JpaRepository<GroupMembership, UUID> {
+
+    Optional<GroupMembership> findByStudentId(UUID studentId);
+
+    Optional<GroupMembership> findByGroupIdAndStudentId(UUID groupId, UUID studentId);
+
+    boolean existsByStudentId(UUID studentId);
+
+    List<GroupMembership> findByGroupId(UUID groupId);
+
+    Optional<GroupMembership> findByGroupIdAndRole(UUID groupId, MemberRole role);
+
+    long countByGroupId(UUID groupId);
+
+    void deleteByGroupId(UUID groupId);
+}

--- a/backend/src/main/java/com/senior/spm/repository/ProjectGroupRepository.java
+++ b/backend/src/main/java/com/senior/spm/repository/ProjectGroupRepository.java
@@ -1,0 +1,27 @@
+package com.senior.spm.repository;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import com.senior.spm.entity.ProjectGroup;
+import com.senior.spm.entity.ProjectGroup.GroupStatus;
+
+@Repository
+public interface ProjectGroupRepository extends JpaRepository<ProjectGroup, UUID> {
+
+    boolean existsByGroupNameAndTermId(String groupName, String termId);
+
+    Optional<ProjectGroup> findByIdAndStatus(UUID id, GroupStatus status);
+
+    List<ProjectGroup> findByTermId(String termId);
+
+    List<ProjectGroup> findByTermIdAndStatus(String termId, GroupStatus status);
+
+    long countByAdvisorIdAndTermIdAndStatusNot(UUID advisorId, String termId, GroupStatus status);
+
+    List<ProjectGroup> findByTermIdAndStatusNotAndAdvisorIsNull(String termId, GroupStatus status);
+}

--- a/backend/src/main/java/com/senior/spm/repository/ScheduleWindowRepository.java
+++ b/backend/src/main/java/com/senior/spm/repository/ScheduleWindowRepository.java
@@ -1,0 +1,20 @@
+package com.senior.spm.repository;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import com.senior.spm.entity.ScheduleWindow;
+import com.senior.spm.entity.ScheduleWindow.WindowType;
+
+@Repository
+public interface ScheduleWindowRepository extends JpaRepository<ScheduleWindow, UUID> {
+
+    Optional<ScheduleWindow> findByTermIdAndType(String termId, WindowType type);
+
+    List<ScheduleWindow> findByTypeAndClosesAtLessThan(WindowType type, LocalDateTime dateTime);
+}

--- a/backend/src/main/java/com/senior/spm/repository/StaffUserRepository.java
+++ b/backend/src/main/java/com/senior/spm/repository/StaffUserRepository.java
@@ -1,5 +1,6 @@
 package com.senior.spm.repository;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -7,9 +8,12 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 import com.senior.spm.entity.StaffUser;
+import com.senior.spm.entity.StaffUser.Role;
 
 @Repository
 public interface StaffUserRepository extends JpaRepository<StaffUser, UUID> {
 
     Optional<StaffUser> findByMail(String mail);
+
+    List<StaffUser> findByRole(Role role);
 }

--- a/backend/src/main/java/com/senior/spm/repository/SystemConfigRepository.java
+++ b/backend/src/main/java/com/senior/spm/repository/SystemConfigRepository.java
@@ -1,0 +1,12 @@
+package com.senior.spm.repository;
+
+import com.senior.spm.entity.SystemConfig;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface SystemConfigRepository extends JpaRepository<SystemConfig, String> {
+    Optional<SystemConfig> findByConfigKey(String configKey);
+}

--- a/backend/src/main/java/com/senior/spm/service/AdvisorService.java
+++ b/backend/src/main/java/com/senior/spm/service/AdvisorService.java
@@ -1,0 +1,146 @@
+package com.senior.spm.service;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.senior.spm.entity.AdvisorRequest;
+import com.senior.spm.entity.ProjectGroup;
+import com.senior.spm.exception.AdvisorAtCapacityException;
+import com.senior.spm.exception.ForbiddenException;
+import com.senior.spm.exception.RequestNotFoundException;
+import com.senior.spm.exception.RequestNotPendingException;
+import com.senior.spm.repository.AdvisorRequestRepository;
+import com.senior.spm.repository.GroupMembershipRepository;
+import com.senior.spm.repository.ProjectGroupRepository;
+import com.senior.spm.service.dto.AdvisorRequestDetail;
+import com.senior.spm.service.dto.AdvisorRequestSummary;
+import com.senior.spm.service.dto.AdvisorRespondResponse;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class AdvisorService {
+
+    private final AdvisorRequestRepository advisorRequestRepository;
+    private final ProjectGroupRepository projectGroupRepository;
+    private final GroupMembershipRepository groupMembershipRepository;
+    private final TermConfigService termConfigService;
+
+    @Transactional(readOnly = true)
+    public List<AdvisorRequestSummary> getPendingRequestsForAdvisor(UUID professorId) {
+        List<AdvisorRequest> requests = advisorRequestRepository.findByAdvisorIdAndStatus(professorId, AdvisorRequest.RequestStatus.PENDING);
+        
+        return requests.stream().map(req -> 
+            AdvisorRequestSummary.builder()
+                .requestId(req.getId())
+                .groupId(req.getGroup().getId())
+                .groupName(req.getGroup().getGroupName())
+                .termId(req.getGroup().getTermId())
+                .memberCount((int) groupMembershipRepository.countByGroupId(req.getGroup().getId()))
+                .sentAt(req.getSentAt())
+                .build()
+        ).collect(Collectors.toList());
+    }
+
+    @Transactional(readOnly = true)
+    public AdvisorRequestDetail getRequestDetail(UUID requestId, UUID professorId) {
+        AdvisorRequest request = advisorRequestRepository.findById(requestId)
+            .orElseThrow(() -> new RequestNotFoundException("Request not found"));
+            
+        if (!request.getAdvisor().getId().equals(professorId)) {
+            throw new ForbiddenException("This request is not addressed to you");
+        }
+
+        ProjectGroup group = request.getGroup();
+        
+        var members = group.getMembers().stream()
+            .map(m -> AdvisorRequestDetail.GroupMemberDetail.builder()
+                .studentId(m.getStudent().getStudentId())
+                .role(m.getRole().name())
+                .joinedAt(m.getJoinedAt())
+                .build()
+            ).collect(Collectors.toList());
+
+        var groupDetail = AdvisorRequestDetail.RequestGroupDetail.builder()
+            .id(group.getId())
+            .groupName(group.getGroupName())
+            .termId(group.getTermId())
+            .status(group.getStatus())
+            .members(members)
+            .build();
+
+        return AdvisorRequestDetail.builder()
+            .requestId(request.getId())
+            .group(groupDetail)
+            .sentAt(request.getSentAt())
+            .build();
+    }
+
+    @Transactional
+    public AdvisorRespondResponse respondToRequest(UUID requestId, UUID professorId, boolean accept) {
+        AdvisorRequest request = advisorRequestRepository.findById(requestId)
+            .orElseThrow(() -> new RequestNotFoundException("Request not found"));
+
+        if (!request.getAdvisor().getId().equals(professorId)) {
+            throw new ForbiddenException("This request is not addressed to you");
+        }
+
+        if (request.getStatus() != AdvisorRequest.RequestStatus.PENDING) {
+            throw new RequestNotPendingException("Request is no longer pending");
+        }
+        
+        LocalDateTime now = LocalDateTime.now();
+
+        if (!accept) {
+            request.setStatus(AdvisorRequest.RequestStatus.REJECTED);
+            request.setRespondedAt(now);
+            advisorRequestRepository.save(request);
+            
+            return AdvisorRespondResponse.builder()
+                .requestId(request.getId())
+                .status(AdvisorRequest.RequestStatus.REJECTED)
+                .build();
+        }
+
+        // Accept Flow
+        String activeTermId = termConfigService.getActiveTermId();
+        
+        long currentGroupCount = projectGroupRepository.countByAdvisorIdAndTermIdAndStatusNot(
+                professorId, activeTermId, ProjectGroup.GroupStatus.DISBANDED);
+                
+        if (currentGroupCount >= request.getAdvisor().getAdvisorCapacity()) {
+            throw new AdvisorAtCapacityException("You have reached your maximum group capacity for this term");
+        }
+
+        // Proceed to accept
+        request.setStatus(AdvisorRequest.RequestStatus.ACCEPTED);
+        request.setRespondedAt(now);
+        advisorRequestRepository.save(request);
+
+        ProjectGroup group = request.getGroup();
+        
+        if (group.getStatus() != ProjectGroup.GroupStatus.TOOLS_BOUND) {
+            throw new RequestNotPendingException("Group is no longer in TOOLS_BOUND status");
+        }
+        
+        group.setAdvisor(request.getAdvisor());
+        group.setStatus(ProjectGroup.GroupStatus.ADVISOR_ASSIGNED);
+        projectGroupRepository.save(group);
+
+        // Auto-reject other pending requests for this group
+        advisorRequestRepository.bulkUpdateStatusForGroup(AdvisorRequest.RequestStatus.AUTO_REJECTED, group.getId(), request.getId());
+
+        return AdvisorRespondResponse.builder()
+            .requestId(request.getId())
+            .status(AdvisorRequest.RequestStatus.ACCEPTED)
+            .groupId(group.getId())
+            .groupStatus(ProjectGroup.GroupStatus.ADVISOR_ASSIGNED)
+            .build();
+    }
+}

--- a/backend/src/main/java/com/senior/spm/service/GitHubValidationService.java
+++ b/backend/src/main/java/com/senior/spm/service/GitHubValidationService.java
@@ -1,0 +1,115 @@
+package com.senior.spm.service;
+
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.client.ResourceAccessException;
+import org.springframework.web.client.RestTemplate;
+
+import com.senior.spm.exception.GitHubValidationException;
+
+/**
+ * Validates GitHub credentials by making two sequential live HTTP calls to the
+ * GitHub REST API.
+ *
+ * Called by GroupService.bindGitHub()
+ * Nothing is persisted until this service returns without throwing.
+ *
+ * Call sequence:
+ * 1. GET /orgs/{githubOrgName} → verifies org existence + PAT validity
+ * 2. GET /orgs/{githubOrgName}/repos → verifies the PAT has 'repo' scope
+ *
+ */
+@Service
+public class GitHubValidationService {
+
+    private static final String GITHUB_API_BASE = "https://api.github.com";
+
+    private final RestTemplate restTemplate;
+
+    public GitHubValidationService(RestTemplate restTemplate) {
+        this.restTemplate = restTemplate;
+    }
+
+    /**
+     * Runs the two-step GitHub validation.
+     *
+     * @throws GitHubValidationException on any failure (401 → invalid PAT,
+     *                                   404 → org not found,
+     *                                   403 on second call → missing 'repo' scope)
+     */
+    public void validate(String githubOrgName, String githubPat) {
+        var headers = new HttpHeaders();
+        // GitHub REST API v3 accepts a PAT as a Bearer token.
+        headers.set(HttpHeaders.AUTHORIZATION, "Bearer " + githubPat);
+        var entity = new HttpEntity<>(headers);
+
+        // Step 1: verify org existence and PAT validity
+        // If this call fails for any reason, Step 2 is NOT executed (fail-fast).
+        callStep1OrgExists(githubOrgName, entity);
+
+        // Step 2: verify the PAT has 'repo' scope
+        // Only reached when Step 1 succeeds (200 OK).
+        callStep2RepoScope(githubOrgName, entity);
+    }
+
+    /**
+     * GET /orgs/{githubOrgName}
+     * 401 → invalid PAT, 404 → org not found, anything else → rethrow as
+     * unreachable.
+     */
+    private void callStep1OrgExists(String githubOrgName, HttpEntity<?> entity) {
+        var url = GITHUB_API_BASE + "/orgs/" + githubOrgName;
+        try {
+            restTemplate.exchange(url, HttpMethod.GET, entity, Void.class);
+
+        } catch (HttpClientErrorException ex) {
+            HttpStatus status = HttpStatus.resolve(ex.getStatusCode().value());
+
+            if (status == HttpStatus.UNAUTHORIZED) {
+                throw new GitHubValidationException("GitHub validation failed: PAT is invalid or expired");
+            }
+
+            if (status == HttpStatus.NOT_FOUND) {
+                throw new GitHubValidationException(
+                        "GitHub validation failed: Organization '" + githubOrgName + "' not found");
+            }
+
+            // Any other 4xx from the first call — treat as a PAT / auth problem.
+            throw new GitHubValidationException("GitHub validation failed: PAT is invalid or expired");
+
+        } catch (ResourceAccessException ex) {
+            // Timeout or network failure on the first call — skip Step 2 (fail-fast).
+            throw new GitHubValidationException("GitHub validation failed: PAT is invalid or expired");
+        }
+    }
+
+    /**
+     * GET /orgs/{githubOrgName}/repos?per_page=1
+     * GitHub returns 403 (not 401) when the PAT lacks 'repo' scope.
+     */
+    private void callStep2RepoScope(String githubOrgName, HttpEntity<?> entity) {
+        var url = GITHUB_API_BASE + "/orgs/" + githubOrgName + "/repos?per_page=1";
+        try {
+            restTemplate.exchange(url, HttpMethod.GET, entity, Void.class);
+
+        } catch (HttpClientErrorException ex) {
+            HttpStatus status = HttpStatus.resolve(ex.getStatusCode().value());
+
+            if (status == HttpStatus.FORBIDDEN) {
+                // GitHub returns 403 specifically when the PAT is missing the 'repo' scope.
+                throw new GitHubValidationException("GitHub validation failed: PAT lacks required 'repo' scope");
+            }
+
+            // Unexpected error on the second call.
+            throw new GitHubValidationException("GitHub validation failed: PAT lacks required 'repo' scope");
+
+        } catch (ResourceAccessException ex) {
+            // Timeout on the second call — scope check inconclusive; reject to be safe.
+            throw new GitHubValidationException("GitHub validation failed: PAT lacks required 'repo' scope");
+        }
+    }
+}

--- a/backend/src/main/java/com/senior/spm/service/GroupService.java
+++ b/backend/src/main/java/com/senior/spm/service/GroupService.java
@@ -1,0 +1,141 @@
+package com.senior.spm.service;
+
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.senior.spm.controller.dto.GroupDetailResponse;
+import com.senior.spm.entity.GroupMembership;
+import com.senior.spm.entity.GroupMembership.MemberRole;
+import com.senior.spm.entity.ProjectGroup;
+import com.senior.spm.entity.ProjectGroup.GroupStatus;
+import com.senior.spm.entity.ScheduleWindow;
+import com.senior.spm.entity.Student;
+import com.senior.spm.exception.AlreadyInGroupException;
+import com.senior.spm.exception.DuplicateGroupNameException;
+import com.senior.spm.exception.ScheduleWindowClosedException;
+import com.senior.spm.repository.GroupMembershipRepository;
+import com.senior.spm.repository.ProjectGroupRepository;
+import com.senior.spm.repository.ScheduleWindowRepository;
+import com.senior.spm.repository.StudentRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class GroupService {
+
+    private final ScheduleWindowRepository scheduleWindowRepository;
+    private final ProjectGroupRepository projectGroupRepository;
+    private final GroupMembershipRepository groupMembershipRepository;
+    private final StudentRepository studentRepository;
+    private final TermConfigService termConfigService;
+
+    @Transactional
+    public GroupDetailResponse createGroup(String groupName, UUID studentUUID) {
+        // 1. Get active term ID
+        String termId = termConfigService.getActiveTermId();
+
+        // 2. Check if schedule window is open
+        ScheduleWindow window = scheduleWindowRepository
+            .findByTermIdAndType(termId, ScheduleWindow.WindowType.GROUP_CREATION)
+            .orElseThrow(() -> new ScheduleWindowClosedException(
+                "Group creation window is not currently active"
+            ));
+
+        // Verify window is still open (closesAt > now)
+        if (window.getClosesAt().isBefore(LocalDateTime.now(ZoneId.of("UTC")))) {
+            throw new ScheduleWindowClosedException(
+                "Group creation window is not currently active"
+            );
+        }
+
+        // 3. Check if student is already in a group
+        if (groupMembershipRepository.existsByStudentId(studentUUID)) {
+            throw new AlreadyInGroupException(
+                "You are already a member of a group"
+            );
+        }
+
+        // 4. Check if group name is unique in this term
+        if (projectGroupRepository.existsByGroupNameAndTermId(groupName, termId)) {
+            throw new DuplicateGroupNameException(
+                String.format("A group named '%s' already exists for this term", groupName)
+            );
+        }
+
+        // 5. Create new ProjectGroup
+        ProjectGroup newGroup = new ProjectGroup();
+        newGroup.setGroupName(groupName);
+        newGroup.setStatus(GroupStatus.FORMING);
+        newGroup.setTermId(termId);
+        newGroup.setCreatedAt(LocalDateTime.now(ZoneId.of("UTC")));
+
+        ProjectGroup savedGroup = projectGroupRepository.save(newGroup);
+
+        // 6. Fetch student entity
+        Student student = studentRepository.findById(studentUUID)
+            .orElseThrow(() -> new RuntimeException("Student not found"));
+
+        // 7. Create GroupMembership with TEAM_LEADER role
+        GroupMembership membership = new GroupMembership();
+        membership.setStudent(student);
+        membership.setGroup(savedGroup);
+        membership.setRole(MemberRole.TEAM_LEADER);
+        membership.setJoinedAt(LocalDateTime.now(ZoneId.of("UTC")));
+
+        groupMembershipRepository.save(membership);
+
+        // 8. Return GroupDetailResponse
+        return toGroupDetailResponse(savedGroup, studentUUID);
+    }
+
+    @Transactional(readOnly = true)
+    public GroupDetailResponse getMyGroup(UUID studentUUID) {
+        // Find group membership for this student
+        GroupMembership membership = groupMembershipRepository.findByStudentId(studentUUID)
+            .orElseThrow(() -> new RuntimeException(
+                "You are not a member of any group"
+            ));
+
+        // Get group details
+        ProjectGroup group = projectGroupRepository.findById(membership.getGroup().getId())
+            .orElseThrow(() -> new RuntimeException("Group not found"));
+
+        return toGroupDetailResponse(group, studentUUID);
+    }
+
+    private GroupDetailResponse toGroupDetailResponse(ProjectGroup group, UUID studentUUID) {
+        GroupDetailResponse response = new GroupDetailResponse();
+        response.setId(group.getId());
+        response.setGroupName(group.getGroupName());
+        response.setTermId(group.getTermId());
+        response.setStatus(group.getStatus().toString());
+        response.setCreatedAt(group.getCreatedAt());
+        response.setJiraSpaceUrl(group.getJiraSpaceUrl());
+        response.setJiraProjectKey(group.getJiraProjectKey());
+        response.setJiraBound(group.getJiraSpaceUrl() != null && group.getJiraProjectKey() != null);
+        response.setGithubOrgName(group.getGithubOrgName());
+        response.setGithubBound(group.getGithubOrgName() != null);
+
+        // Get all members of this group
+        List<GroupMembership> members = groupMembershipRepository.findByGroupId(group.getId());
+        List<GroupDetailResponse.MemberResponse> memberResponses = members.stream()
+            .map(m -> {
+                GroupDetailResponse.MemberResponse mr = new GroupDetailResponse.MemberResponse();
+                mr.setStudentId(m.getStudent().getId());
+                mr.setRole(m.getRole().toString());
+                mr.setJoinedAt(m.getJoinedAt());
+                return mr;
+            })
+            .collect(Collectors.toList());
+
+        response.setMembers(memberResponses);
+        return response;
+    }
+}

--- a/backend/src/main/java/com/senior/spm/service/GroupService.java
+++ b/backend/src/main/java/com/senior/spm/service/GroupService.java
@@ -18,6 +18,7 @@ import com.senior.spm.entity.ScheduleWindow;
 import com.senior.spm.entity.Student;
 import com.senior.spm.exception.AlreadyInGroupException;
 import com.senior.spm.exception.DuplicateGroupNameException;
+import com.senior.spm.exception.NotInGroupException;
 import com.senior.spm.exception.ScheduleWindowClosedException;
 import com.senior.spm.repository.GroupMembershipRepository;
 import com.senior.spm.repository.ProjectGroupRepository;
@@ -48,8 +49,9 @@ public class GroupService {
                 "Group creation window is not currently active"
             ));
 
-        // Verify window is still open (closesAt > now)
-        if (window.getClosesAt().isBefore(LocalDateTime.now(ZoneId.of("UTC")))) {
+        // Verify window is currently active: opensAt <= now <= closesAt
+        LocalDateTime now = LocalDateTime.now(ZoneId.of("UTC"));
+        if (window.getOpensAt().isAfter(now) || window.getClosesAt().isBefore(now)) {
             throw new ScheduleWindowClosedException(
                 "Group creation window is not currently active"
             );
@@ -99,7 +101,7 @@ public class GroupService {
     public GroupDetailResponse getMyGroup(UUID studentUUID) {
         // Find group membership for this student
         GroupMembership membership = groupMembershipRepository.findByStudentId(studentUUID)
-            .orElseThrow(() -> new RuntimeException(
+            .orElseThrow(() -> new NotInGroupException(
                 "You are not a member of any group"
             ));
 
@@ -128,7 +130,7 @@ public class GroupService {
         List<GroupDetailResponse.MemberResponse> memberResponses = members.stream()
             .map(m -> {
                 GroupDetailResponse.MemberResponse mr = new GroupDetailResponse.MemberResponse();
-                mr.setStudentId(m.getStudent().getId());
+                mr.setStudentId(m.getStudent().getStudentId());
                 mr.setRole(m.getRole().toString());
                 mr.setJoinedAt(m.getJoinedAt());
                 return mr;

--- a/backend/src/main/java/com/senior/spm/service/JiraValidationService.java
+++ b/backend/src/main/java/com/senior/spm/service/JiraValidationService.java
@@ -1,0 +1,72 @@
+package com.senior.spm.service;
+
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.client.ResourceAccessException;
+import org.springframework.web.client.RestTemplate;
+
+import com.senior.spm.exception.JiraValidationException;
+
+/**
+ * Validates JIRA credentials by making a single live HTTP call to the JIRA REST
+ * API.
+ * Called by GroupService.bindJira()
+ * Nothing is persisted until this service returns without throwing.
+ *
+ */
+@Service
+public class JiraValidationService {
+
+    private final RestTemplate restTemplate;
+
+    public JiraValidationService(RestTemplate restTemplate) {
+        this.restTemplate = restTemplate;
+    }
+
+    /**
+     * Performs a single GET against:
+     * {jiraSpaceUrl}/rest/api/3/project/{jiraProjectKey}
+     *
+     * @throws JiraValidationException on any failure (401/403 → invalid token,
+     *                                 404 → project key not found,
+     *                                 timeout/network → unreachable)
+     */
+    public void validate(String jiraSpaceUrl, String jiraProjectKey, String jiraApiToken) {
+        var url = jiraSpaceUrl.strip().replaceAll("/+$", "") + "/rest/api/3/project/" + jiraProjectKey;
+
+        var headers = new HttpHeaders();
+        // JIRA Cloud accepts a Bearer token; on-prem may need Basic – Bearer covers
+        // both cases here.
+        headers.set(HttpHeaders.AUTHORIZATION, "Bearer " + jiraApiToken);
+        var entity = new HttpEntity<>(headers);
+
+        try {
+            restTemplate.exchange(url, HttpMethod.GET, entity, Void.class);
+
+        } catch (HttpClientErrorException ex) {
+            HttpStatus status = HttpStatus.resolve(ex.getStatusCode().value());
+
+            if (status == HttpStatus.UNAUTHORIZED || status == HttpStatus.FORBIDDEN) {
+                // JIRA returns 401 for bad tokens and 403 for insufficient permissions.
+                throw new JiraValidationException("JIRA validation failed: API token is invalid or expired");
+            }
+
+            if (status == HttpStatus.NOT_FOUND) {
+                // The project key does not exist in the given JIRA space.
+                throw new JiraValidationException(
+                        "JIRA validation failed: Project key '" + jiraProjectKey + "' not found");
+            }
+
+            // Any other 4xx — treat as unreachable / misconfigured URL.
+            throw new JiraValidationException("JIRA validation failed: JIRA space URL is unreachable");
+
+        } catch (ResourceAccessException ex) {
+            // Covers connection timeout, read timeout, DNS failure, etc.
+            throw new JiraValidationException("JIRA validation failed: JIRA space URL is unreachable");
+        }
+    }
+}

--- a/backend/src/main/java/com/senior/spm/service/TermConfigService.java
+++ b/backend/src/main/java/com/senior/spm/service/TermConfigService.java
@@ -1,0 +1,20 @@
+package com.senior.spm.service;
+
+import org.springframework.stereotype.Service;
+
+@Service
+public class TermConfigService {
+
+    /**
+     * Get active term ID for the current semester
+     * This should be fetched from system_config table or similar
+     * Returns term as String (e.g., "2024-FALL", "2025-SPRING")
+     * 
+     * @return String identifier of the active term
+     */
+    public String getActiveTermId() {
+        // TODO: Implement by fetching from system_config table
+        // For now, return a placeholder
+        return "PLACEHOLDER-TERM";
+    }
+}

--- a/backend/src/main/java/com/senior/spm/service/TermConfigService.java
+++ b/backend/src/main/java/com/senior/spm/service/TermConfigService.java
@@ -1,20 +1,60 @@
 package com.senior.spm.service;
 
+import com.senior.spm.entity.SystemConfig;
+import com.senior.spm.exception.TermConfigNotFoundException;
+import com.senior.spm.repository.SystemConfigRepository;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 @Service
+@RequiredArgsConstructor
 public class TermConfigService {
 
+    private final SystemConfigRepository systemConfigRepository;
+
     /**
-     * Get active term ID for the current semester
-     * This should be fetched from system_config table or similar
-     * Returns term as String (e.g., "2024-FALL", "2025-SPRING")
-     * 
-     * @return String identifier of the active term
+     * Retrieves the active term ID for the current semester from the system configuration.
+     *
+     * @return The active term ID as a String (e.g., "2026-SPRING").
+     * @throws TermConfigNotFoundException if the 'active_term_id' key is missing from the database.
      */
     public String getActiveTermId() {
-        // TODO: Implement by fetching from system_config table
-        // For now, return a placeholder
-        return "PLACEHOLDER-TERM";
+        SystemConfig config = systemConfigRepository.findByConfigKey("active_term_id")
+                .orElseThrow(() -> new TermConfigNotFoundException("active_term_id not found in system_config"));
+
+        String value = config.getConfigValue();
+        if (value == null || value.isBlank()) {
+            throw new TermConfigNotFoundException("active_term_id contains a blank value");
+        }
+
+        return value;
+    }
+
+    /**
+     * Retrieves the maximum allowed team size from the system configuration.
+     * Validates that the stored string value is a proper integer.
+     *
+     * @return The maximum team size as an Integer.
+     * @throws TermConfigNotFoundException if the key is missing OR if the value is not a valid number.
+     */
+    public Integer getMaxTeamSize() {
+        SystemConfig config = systemConfigRepository.findByConfigKey("max_team_size")
+                .orElseThrow(() -> new TermConfigNotFoundException("max_team_size not found in system_config"));
+
+        String value = config.getConfigValue();
+        if (value == null || value.isBlank()) {
+            throw new TermConfigNotFoundException("max_team_size config value is not a valid integer: " + value);
+        }
+
+        try {
+            int maxTeamSize = Integer.parseInt(value);
+            if (maxTeamSize <= 0) {
+                throw new TermConfigNotFoundException("max_team_size must be a positive integer: " + value);
+            }
+
+            return maxTeamSize;
+        } catch (NumberFormatException e) {
+            throw new TermConfigNotFoundException("max_team_size config value is not a valid integer: " + value);
+        }
     }
 }

--- a/backend/src/main/java/com/senior/spm/service/dto/AdvisorRequestDetail.java
+++ b/backend/src/main/java/com/senior/spm/service/dto/AdvisorRequestDetail.java
@@ -1,0 +1,44 @@
+package com.senior.spm.service.dto;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+
+import com.senior.spm.entity.ProjectGroup.GroupStatus;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class AdvisorRequestDetail {
+    private UUID requestId;
+    private RequestGroupDetail group;
+    private LocalDateTime sentAt;
+
+    @Data
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class RequestGroupDetail {
+        private UUID id;
+        private String groupName;
+        private String termId;
+        private GroupStatus status;
+        private List<GroupMemberDetail> members;
+    }
+
+    @Data
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class GroupMemberDetail {
+        private String studentId;
+        private String role;
+        private LocalDateTime joinedAt;
+    }
+}

--- a/backend/src/main/java/com/senior/spm/service/dto/AdvisorRequestSummary.java
+++ b/backend/src/main/java/com/senior/spm/service/dto/AdvisorRequestSummary.java
@@ -1,0 +1,22 @@
+package com.senior.spm.service.dto;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class AdvisorRequestSummary {
+    private UUID requestId;
+    private UUID groupId;
+    private String groupName;
+    private String termId;
+    private int memberCount;
+    private LocalDateTime sentAt;
+}

--- a/backend/src/main/java/com/senior/spm/service/dto/AdvisorRespondResponse.java
+++ b/backend/src/main/java/com/senior/spm/service/dto/AdvisorRespondResponse.java
@@ -1,0 +1,22 @@
+package com.senior.spm.service.dto;
+
+import java.util.UUID;
+
+import com.senior.spm.entity.AdvisorRequest.RequestStatus;
+import com.senior.spm.entity.ProjectGroup.GroupStatus;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class AdvisorRespondResponse {
+    private UUID requestId;
+    private RequestStatus status;
+    private UUID groupId;
+    private GroupStatus groupStatus;
+}

--- a/backend/src/main/resources/data.sql
+++ b/backend/src/main/resources/data.sql
@@ -50,3 +50,7 @@ VALUES
 		'$2a$10$tj811p0KDPOD6Dd58xb0.uBNIT8.CXeJPKoSUSwPuJ0BI.RuC5yGq',
 		'PROFESSOR'
 	);
+
+-- Issue 55: Red Team system_config seed data
+INSERT IGNORE INTO system_config (config_key, config_value) VALUES ('active_term_id', '2026-SPRING');
+INSERT IGNORE INTO system_config (config_key, config_value) VALUES ('max_team_size', '4');

--- a/backend/src/test/java/com/senior/spm/GroupCreationIntegrationTest.java
+++ b/backend/src/test/java/com/senior/spm/GroupCreationIntegrationTest.java
@@ -1,0 +1,294 @@
+package com.senior.spm;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.senior.spm.entity.GroupMembership;
+import com.senior.spm.entity.GroupMembership.MemberRole;
+import com.senior.spm.entity.ProjectGroup;
+import com.senior.spm.entity.ProjectGroup.GroupStatus;
+import com.senior.spm.entity.ScheduleWindow;
+import com.senior.spm.entity.ScheduleWindow.WindowType;
+import com.senior.spm.entity.Student;
+import com.senior.spm.entity.SystemConfig;
+import com.senior.spm.repository.AdvisorRequestRepository;
+import com.senior.spm.repository.GroupInvitationRepository;
+import com.senior.spm.repository.GroupMembershipRepository;
+import com.senior.spm.repository.ProjectGroupRepository;
+import com.senior.spm.repository.ScheduleWindowRepository;
+import com.senior.spm.repository.StudentRepository;
+import com.senior.spm.repository.SystemConfigRepository;
+import com.senior.spm.service.JWTService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * End-to-end integration tests for POST /api/groups (group creation).
+ *
+ * Covers: happy path DB integrity, all closed-window variants (no window, not yet open,
+ * expired), duplicate group name, student already in a group, and unauthenticated access.
+ *
+ * References: Process 2 – DFD 2.1 (Group Creation & Schedule Window Enforcement).
+ */
+@SpringBootTest
+@AutoConfigureMockMvc
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+class GroupCreationIntegrationTest {
+
+    @Autowired MockMvc mockMvc;
+    @Autowired ObjectMapper objectMapper;
+    @Autowired JWTService jwtService;
+
+    @Autowired StudentRepository studentRepository;
+    @Autowired SystemConfigRepository systemConfigRepository;
+    @Autowired ScheduleWindowRepository scheduleWindowRepository;
+    @Autowired ProjectGroupRepository projectGroupRepository;
+    @Autowired GroupMembershipRepository groupMembershipRepository;
+    @Autowired GroupInvitationRepository groupInvitationRepository;
+    @Autowired AdvisorRequestRepository advisorRequestRepository;
+
+    private static final String TERM_ID = "2026-SPRING-TEST";
+
+    private Student testStudent;
+    private String studentToken;
+
+    @BeforeEach
+    void setUp() {
+        // Delete in FK-safe order so constraints don't block teardown between tests
+        advisorRequestRepository.deleteAll();
+        groupInvitationRepository.deleteAll();
+        groupMembershipRepository.deleteAll();
+        projectGroupRepository.deleteAll();
+        studentRepository.deleteAll();
+        scheduleWindowRepository.deleteAll();
+        systemConfigRepository.deleteAll();
+
+        // Seed the minimum system config that GroupService requires
+        SystemConfig termConfig = new SystemConfig();
+        termConfig.setConfigKey("active_term_id");
+        termConfig.setConfigValue(TERM_ID);
+        systemConfigRepository.save(termConfig);
+
+        // Persist a student and issue a JWT for them
+        testStudent = new Student();
+        testStudent.setStudentId("12345678901");
+        testStudent.setGithubUsername("test-gh-user");
+        testStudent = studentRepository.save(testStudent);
+
+        studentToken = jwtService.issueToken(testStudent);
+    }
+
+    // ─── Happy Path ───────────────────────────────────────────────────────────
+
+    /**
+     * AC: A student inside an active window gets 201 and both ProjectGroup and
+     * GroupMembership rows land in the DB with correct values.
+     */
+    @Test
+    @Order(1)
+    void createGroup_withinActiveWindow_returns201AndPersistsRecords() throws Exception {
+        openWindow();
+
+        mockMvc.perform(post("/api/groups")
+                .header("Authorization", "Bearer " + studentToken)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(body("Alpha Team")))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.groupName").value("Alpha Team"))
+                .andExpect(jsonPath("$.status").value("FORMING"))
+                .andExpect(jsonPath("$.termId").value(TERM_ID))
+                .andExpect(jsonPath("$.members[0].role").value("TEAM_LEADER"));
+
+        // Verify ProjectGroup record
+        List<ProjectGroup> groups = projectGroupRepository.findAll();
+        assertThat(groups).hasSize(1);
+        assertThat(groups.get(0).getGroupName()).isEqualTo("Alpha Team");
+        assertThat(groups.get(0).getStatus()).isEqualTo(GroupStatus.FORMING);
+        assertThat(groups.get(0).getTermId()).isEqualTo(TERM_ID);
+
+        // Verify GroupMembership record — creator must be TEAM_LEADER
+        List<GroupMembership> memberships = groupMembershipRepository.findAll();
+        assertThat(memberships).hasSize(1);
+        assertThat(memberships.get(0).getRole()).isEqualTo(MemberRole.TEAM_LEADER);
+        assertThat(memberships.get(0).getStudent().getId()).isEqualTo(testStudent.getId());
+        assertThat(memberships.get(0).getGroup().getId()).isEqualTo(groups.get(0).getId());
+    }
+
+    // ─── Closed-Window Scenarios (AC: must all produce 400) ──────────────────
+
+    /**
+     * No ScheduleWindow row exists for the current term → 400.
+     */
+    @Test
+    @Order(2)
+    void createGroup_noWindowExists_returns400() throws Exception {
+        mockMvc.perform(post("/api/groups")
+                .header("Authorization", "Bearer " + studentToken)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(body("Beta Team")))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.message").exists());
+
+        assertThat(projectGroupRepository.count()).isZero();
+    }
+
+    /**
+     * Window exists but opensAt is in the future → 400.
+     */
+    @Test
+    @Order(3)
+    void createGroup_windowNotYetOpen_returns400() throws Exception {
+        saveWindow(
+                LocalDateTime.now(ZoneId.of("UTC")).plusDays(1),
+                LocalDateTime.now(ZoneId.of("UTC")).plusDays(2));
+
+        mockMvc.perform(post("/api/groups")
+                .header("Authorization", "Bearer " + studentToken)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(body("Gamma Team")))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.message").exists());
+
+        assertThat(projectGroupRepository.count()).isZero();
+    }
+
+    /**
+     * Window existed but closesAt is in the past → 400.
+     */
+    @Test
+    @Order(4)
+    void createGroup_windowExpired_returns400() throws Exception {
+        saveWindow(
+                LocalDateTime.now(ZoneId.of("UTC")).minusDays(2),
+                LocalDateTime.now(ZoneId.of("UTC")).minusDays(1));
+
+        mockMvc.perform(post("/api/groups")
+                .header("Authorization", "Bearer " + studentToken)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(body("Delta Team")))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.message").exists());
+
+        assertThat(projectGroupRepository.count()).isZero();
+    }
+
+    // ─── Business-Rule Violations ─────────────────────────────────────────────
+
+    /**
+     * A group with the same name already exists in the same term → 409 Conflict.
+     * No second group row must appear in the DB.
+     */
+    @Test
+    @Order(5)
+    void createGroup_duplicateName_returns409() throws Exception {
+        openWindow();
+
+        // Pre-seed a group occupying the name
+        ProjectGroup existing = new ProjectGroup();
+        existing.setGroupName("Taken Name");
+        existing.setTermId(TERM_ID);
+        existing.setStatus(GroupStatus.FORMING);
+        existing.setCreatedAt(LocalDateTime.now(ZoneId.of("UTC")));
+        projectGroupRepository.save(existing);
+
+        mockMvc.perform(post("/api/groups")
+                .header("Authorization", "Bearer " + studentToken)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(body("Taken Name")))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.message").exists());
+
+        // Only the pre-seeded group must exist — no second row created
+        assertThat(projectGroupRepository.count()).isEqualTo(1);
+    }
+
+    /**
+     * Student is already a member of another group → 400.
+     * Existing group and membership must be unchanged.
+     */
+    @Test
+    @Order(6)
+    void createGroup_studentAlreadyGrouped_returns400() throws Exception {
+        openWindow();
+
+        // Put testStudent in an existing group
+        ProjectGroup existingGroup = new ProjectGroup();
+        existingGroup.setGroupName("Already Here");
+        existingGroup.setTermId(TERM_ID);
+        existingGroup.setStatus(GroupStatus.FORMING);
+        existingGroup.setCreatedAt(LocalDateTime.now(ZoneId.of("UTC")));
+        ProjectGroup saved = projectGroupRepository.save(existingGroup);
+
+        GroupMembership membership = new GroupMembership();
+        membership.setStudent(testStudent);
+        membership.setGroup(saved);
+        membership.setRole(MemberRole.TEAM_LEADER);
+        membership.setJoinedAt(LocalDateTime.now(ZoneId.of("UTC")));
+        groupMembershipRepository.save(membership);
+
+        mockMvc.perform(post("/api/groups")
+                .header("Authorization", "Bearer " + studentToken)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(body("Second Group")))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.message").exists());
+
+        assertThat(projectGroupRepository.count()).isEqualTo(1);
+        assertThat(groupMembershipRepository.count()).isEqualTo(1);
+    }
+
+    // ─── Authentication ───────────────────────────────────────────────────────
+
+    /**
+     * No Authorization header → endpoint is protected, must be rejected (4xx).
+     */
+    @Test
+    @Order(7)
+    void createGroup_noToken_isRejected() throws Exception {
+        openWindow();
+
+        mockMvc.perform(post("/api/groups")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(body("Unauthorized Team")))
+                .andExpect(status().is4xxClientError());
+
+        assertThat(projectGroupRepository.count()).isZero();
+    }
+
+    // ─── Helpers ─────────────────────────────────────────────────────────────
+
+    private void openWindow() {
+        saveWindow(
+                LocalDateTime.now(ZoneId.of("UTC")).minusHours(1),
+                LocalDateTime.now(ZoneId.of("UTC")).plusHours(1));
+    }
+
+    private void saveWindow(LocalDateTime opensAt, LocalDateTime closesAt) {
+        ScheduleWindow window = new ScheduleWindow();
+        window.setTermId(TERM_ID);
+        window.setType(WindowType.GROUP_CREATION);
+        window.setOpensAt(opensAt);
+        window.setClosesAt(closesAt);
+        scheduleWindowRepository.save(window);
+    }
+
+    private String body(String groupName) throws Exception {
+        return objectMapper.writeValueAsString(Map.of("groupName", groupName));
+    }
+}

--- a/backend/src/test/java/com/senior/spm/SpmApplicationTests.java
+++ b/backend/src/test/java/com/senior/spm/SpmApplicationTests.java
@@ -1,9 +1,9 @@
 package com.senior.spm;
 
 import org.junit.jupiter.api.Test;
-import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.TestPropertySource;
 
-@SpringBootTest
+@TestPropertySource(locations = "classpath:test.properties")
 class SpmApplicationTests {
 
 	@Test

--- a/backend/src/test/java/com/senior/spm/config/GlobalExceptionHandlerTest.java
+++ b/backend/src/test/java/com/senior/spm/config/GlobalExceptionHandlerTest.java
@@ -1,0 +1,76 @@
+package com.senior.spm.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+
+import com.senior.spm.exception.GitHubValidationException;
+import com.senior.spm.exception.JiraValidationException;
+
+/**
+ * Verifies that GlobalExceptionHandler maps both JiraValidationException and
+ * GitHubValidationException to HTTP 422 Unprocessable Entity with the exact
+ * user-facing message from the exception.
+ *
+ * This is the integration point between the validation services and the HTTP
+ * response layer. If this mapping is broken, validation failures silently
+ * become 500 Internal Server Error responses.
+ */
+class GlobalExceptionHandlerTest {
+
+    private final GlobalExceptionHandler handler = new GlobalExceptionHandler();
+
+    // ── JIRA exceptions → 422 ─────────────────────────────────────────────
+
+    @Test
+    void jiraValidationException_mapsTo422() {
+        var ex = new JiraValidationException("JIRA validation failed: API token is invalid or expired");
+        var response = handler.handleExternalToolValidation(ex);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.UNPROCESSABLE_ENTITY);
+    }
+
+    @Test
+    void jiraValidationException_preservesMessageInBody() {
+        var message = "JIRA validation failed: Project key 'SPM' not found";
+        var ex = new JiraValidationException(message);
+        var response = handler.handleExternalToolValidation(ex);
+
+        assertThat(response.getBody()).isNotNull();
+        assertThat(response.getBody().getMessage()).isEqualTo(message);
+    }
+
+    // ── GitHub exceptions → 422 ───────────────────────────────────────────
+
+    @Test
+    void gitHubValidationException_mapsTo422() {
+        var ex = new GitHubValidationException("GitHub validation failed: PAT is invalid or expired");
+        var response = handler.handleExternalToolValidation(ex);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.UNPROCESSABLE_ENTITY);
+    }
+
+    @Test
+    void gitHubValidationException_preservesMessageInBody() {
+        var message = "GitHub validation failed: PAT lacks required 'repo' scope";
+        var ex = new GitHubValidationException(message);
+        var response = handler.handleExternalToolValidation(ex);
+
+        assertThat(response.getBody()).isNotNull();
+        assertThat(response.getBody().getMessage()).isEqualTo(message);
+    }
+
+    // ── Never returns a different status ─────────────────────────────────
+
+    @Test
+    void handler_neverReturns500_forValidationExceptions() {
+        var jiraEx = new JiraValidationException("any jira error");
+        var githubEx = new GitHubValidationException("any github error");
+
+        assertThat(handler.handleExternalToolValidation(jiraEx).getStatusCode())
+                .isNotEqualTo(HttpStatus.INTERNAL_SERVER_ERROR);
+        assertThat(handler.handleExternalToolValidation(githubEx).getStatusCode())
+                .isNotEqualTo(HttpStatus.INTERNAL_SERVER_ERROR);
+    }
+}

--- a/backend/src/test/java/com/senior/spm/config/GlobalExceptionHandlerTest.java
+++ b/backend/src/test/java/com/senior/spm/config/GlobalExceptionHandlerTest.java
@@ -6,26 +6,24 @@ import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpStatus;
 
 import com.senior.spm.exception.AdvisorAtCapacityException;
+import com.senior.spm.exception.AlreadyInGroupException;
+import com.senior.spm.exception.DuplicateGroupNameException;
 import com.senior.spm.exception.ForbiddenException;
 import com.senior.spm.exception.GitHubValidationException;
 import com.senior.spm.exception.JiraValidationException;
+import com.senior.spm.exception.NotInGroupException;
 import com.senior.spm.exception.RequestNotFoundException;
 import com.senior.spm.exception.RequestNotPendingException;
+import com.senior.spm.exception.ScheduleWindowClosedException;
 
 /**
- * Verifies that GlobalExceptionHandler maps both JiraValidationException and
- * GitHubValidationException to HTTP 422 Unprocessable Entity with the exact
- * user-facing message from the exception.
- *
- * This is the integration point between the validation services and the HTTP
- * response layer. If this mapping is broken, validation failures silently
- * become 500 Internal Server Error responses.
+ * Verifies that GlobalExceptionHandler maps exceptions to correct HTTP status codes.
  */
 class GlobalExceptionHandlerTest {
 
     private final GlobalExceptionHandler handler = new GlobalExceptionHandler();
 
-    // ── JIRA exceptions → 422 ─────────────────────────────────────────────
+    // ── Tool validation → 422 ─────────────────────────────────────────────
 
     @Test
     void jiraValidationException_mapsTo422() {
@@ -45,8 +43,6 @@ class GlobalExceptionHandlerTest {
         assertThat(response.getBody().getMessage()).isEqualTo(message);
     }
 
-    // ── GitHub exceptions → 422 ───────────────────────────────────────────
-
     @Test
     void gitHubValidationException_mapsTo422() {
         var ex = new GitHubValidationException("GitHub validation failed: PAT is invalid or expired");
@@ -65,10 +61,56 @@ class GlobalExceptionHandlerTest {
         assertThat(response.getBody().getMessage()).isEqualTo(message);
     }
 
-    // ── P3 advisor exceptions ─────────────────────────────────────────────
-    //
-    // These tests INTENTIONALLY FAIL until the corresponding @ExceptionHandler
-    // methods are added to GlobalExceptionHandler. That is the bug from PR #82.
+    @Test
+    void handler_neverReturns500_forValidationExceptions() {
+        var jiraEx = new JiraValidationException("any jira error");
+        var githubEx = new GitHubValidationException("any github error");
+
+        assertThat(handler.handleExternalToolValidation(jiraEx).getStatusCode())
+                .isNotEqualTo(HttpStatus.INTERNAL_SERVER_ERROR);
+        assertThat(handler.handleExternalToolValidation(githubEx).getStatusCode())
+                .isNotEqualTo(HttpStatus.INTERNAL_SERVER_ERROR);
+    }
+
+    // ── P2 exceptions ────────────────────────────────────────────────────
+
+    @Test
+    void scheduleWindowClosedException_mapsTo400() {
+        var ex = new ScheduleWindowClosedException("Group creation window is not currently active");
+        var response = handler.handleScheduleWindowClosed(ex);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+        assertThat(response.getBody().getMessage()).isEqualTo(ex.getMessage());
+    }
+
+    @Test
+    void alreadyInGroupException_mapsTo400() {
+        var ex = new AlreadyInGroupException("You are already a member of a group");
+        var response = handler.handleAlreadyInGroup(ex);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+        assertThat(response.getBody().getMessage()).isEqualTo(ex.getMessage());
+    }
+
+    @Test
+    void duplicateGroupNameException_mapsTo409() {
+        var ex = new DuplicateGroupNameException("A group named 'TeamAlpha' already exists for this term");
+        var response = handler.handleDuplicateGroupName(ex);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.CONFLICT);
+        assertThat(response.getBody().getMessage()).isEqualTo(ex.getMessage());
+    }
+
+    @Test
+    void notInGroupException_mapsTo404() {
+        var ex = new NotInGroupException("You are not a member of any group");
+        var response = handler.handleNotInGroup(ex);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
+        assertThat(response.getBody().getMessage()).isEqualTo(ex.getMessage());
+    }
+
+    // ── P3 exceptions ────────────────────────────────────────────────────
 
     @Test
     void advisorAtCapacityException_mapsTo400() {
@@ -104,18 +146,5 @@ class GlobalExceptionHandlerTest {
 
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
         assertThat(response.getBody().getMessage()).isEqualTo(ex.getMessage());
-    }
-
-    // ── Never returns a different status ─────────────────────────────────
-
-    @Test
-    void handler_neverReturns500_forValidationExceptions() {
-        var jiraEx = new JiraValidationException("any jira error");
-        var githubEx = new GitHubValidationException("any github error");
-
-        assertThat(handler.handleExternalToolValidation(jiraEx).getStatusCode())
-                .isNotEqualTo(HttpStatus.INTERNAL_SERVER_ERROR);
-        assertThat(handler.handleExternalToolValidation(githubEx).getStatusCode())
-                .isNotEqualTo(HttpStatus.INTERNAL_SERVER_ERROR);
     }
 }

--- a/backend/src/test/java/com/senior/spm/config/GlobalExceptionHandlerTest.java
+++ b/backend/src/test/java/com/senior/spm/config/GlobalExceptionHandlerTest.java
@@ -5,8 +5,12 @@ import static org.assertj.core.api.Assertions.assertThat;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpStatus;
 
+import com.senior.spm.exception.AdvisorAtCapacityException;
+import com.senior.spm.exception.ForbiddenException;
 import com.senior.spm.exception.GitHubValidationException;
 import com.senior.spm.exception.JiraValidationException;
+import com.senior.spm.exception.RequestNotFoundException;
+import com.senior.spm.exception.RequestNotPendingException;
 
 /**
  * Verifies that GlobalExceptionHandler maps both JiraValidationException and
@@ -59,6 +63,47 @@ class GlobalExceptionHandlerTest {
 
         assertThat(response.getBody()).isNotNull();
         assertThat(response.getBody().getMessage()).isEqualTo(message);
+    }
+
+    // ── P3 advisor exceptions ─────────────────────────────────────────────
+    //
+    // These tests INTENTIONALLY FAIL until the corresponding @ExceptionHandler
+    // methods are added to GlobalExceptionHandler. That is the bug from PR #82.
+
+    @Test
+    void advisorAtCapacityException_mapsTo400() {
+        var ex = new AdvisorAtCapacityException("You have reached your maximum group capacity for this term");
+        var response = handler.handleAdvisorAtCapacity(ex);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+        assertThat(response.getBody().getMessage()).isEqualTo(ex.getMessage());
+    }
+
+    @Test
+    void forbiddenException_mapsTo403() {
+        var ex = new ForbiddenException("This request is not addressed to you");
+        var response = handler.handleForbidden(ex);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.FORBIDDEN);
+        assertThat(response.getBody().getMessage()).isEqualTo(ex.getMessage());
+    }
+
+    @Test
+    void requestNotFoundException_mapsTo404() {
+        var ex = new RequestNotFoundException("Request not found");
+        var response = handler.handleRequestNotFound(ex);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
+        assertThat(response.getBody().getMessage()).isEqualTo(ex.getMessage());
+    }
+
+    @Test
+    void requestNotPendingException_mapsTo400() {
+        var ex = new RequestNotPendingException("Request is no longer pending");
+        var response = handler.handleRequestNotPending(ex);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+        assertThat(response.getBody().getMessage()).isEqualTo(ex.getMessage());
     }
 
     // ── Never returns a different status ─────────────────────────────────

--- a/backend/src/test/java/com/senior/spm/config/RestTemplateConfigTest.java
+++ b/backend/src/test/java/com/senior/spm/config/RestTemplateConfigTest.java
@@ -1,0 +1,41 @@
+package com.senior.spm.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.lang.reflect.Field;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.http.client.SimpleClientHttpRequestFactory;
+
+/**
+ * Verifies acceptance criterion from Issue #48:
+ * "Services strictly enforce a 5-second timeout."
+ */
+class RestTemplateConfigTest {
+
+    private static final int EXPECTED_TIMEOUT_MS = 5_000;
+
+    private final RestTemplateConfig config = new RestTemplateConfig();
+
+    @Test
+    void restTemplate_usesSimpleClientHttpRequestFactory() {
+        var restTemplate = config.restTemplate();
+        assertThat(restTemplate.getRequestFactory()).isInstanceOf(SimpleClientHttpRequestFactory.class);
+    }
+
+    @Test
+    void restTemplate_hasFiveSecondConnectTimeout() throws Exception {
+        var factory = (SimpleClientHttpRequestFactory) config.restTemplate().getRequestFactory();
+        Field field = SimpleClientHttpRequestFactory.class.getDeclaredField("connectTimeout");
+        field.setAccessible(true);
+        assertThat(field.get(factory)).isEqualTo(EXPECTED_TIMEOUT_MS);
+    }
+
+    @Test
+    void restTemplate_hasFiveSecondReadTimeout() throws Exception {
+        var factory = (SimpleClientHttpRequestFactory) config.restTemplate().getRequestFactory();
+        Field field = SimpleClientHttpRequestFactory.class.getDeclaredField("readTimeout");
+        field.setAccessible(true);
+        assertThat(field.get(factory)).isEqualTo(EXPECTED_TIMEOUT_MS);
+    }
+}

--- a/backend/src/test/java/com/senior/spm/entity/EntityAnnotationTest.java
+++ b/backend/src/test/java/com/senior/spm/entity/EntityAnnotationTest.java
@@ -1,0 +1,163 @@
+package com.senior.spm.entity;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.lang.reflect.Field;
+import java.util.Arrays;
+
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import jakarta.persistence.Version;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Verifies entity-level constraints and annotations that the spec mandates.
+ * Pure unit tests — no database or Spring context required.
+ */
+class EntityAnnotationTest {
+
+    // ── termId type (must be String, not UUID — TermConfigService returns String) ──
+
+    @Test
+    void projectGroup_termId_isString() throws Exception {
+        Field f = ProjectGroup.class.getDeclaredField("termId");
+        assertThat(f.getType()).isEqualTo(String.class);
+    }
+
+    @Test
+    void scheduleWindow_termId_isString() throws Exception {
+        Field f = ScheduleWindow.class.getDeclaredField("termId");
+        assertThat(f.getType()).isEqualTo(String.class);
+    }
+
+    // ── Optimistic locking — @Version Long version on ProjectGroup ───────────
+
+    @Test
+    void projectGroup_version_hasVersionAnnotation() throws Exception {
+        Field f = ProjectGroup.class.getDeclaredField("version");
+        assertThat(f.isAnnotationPresent(Version.class)).isTrue();
+    }
+
+    @Test
+    void projectGroup_version_isLong() throws Exception {
+        Field f = ProjectGroup.class.getDeclaredField("version");
+        assertThat(f.getType()).isEqualTo(Long.class);
+    }
+
+    // ── GroupMembership TWO unique constraints ────────────────────────────────
+
+    @Test
+    void groupMembership_hasTwoUniqueConstraints() {
+        Table table = GroupMembership.class.getAnnotation(Table.class);
+        assertThat(table.uniqueConstraints()).hasSize(2);
+    }
+
+    @Test
+    void groupMembership_compositeConstraint_isNamedCorrectlyAndCoversGroupAndStudent() {
+        UniqueConstraint composite = findConstraint(GroupMembership.class, "uq_gm_group_student");
+        assertThat(composite.columnNames()).containsExactlyInAnyOrder("group_id", "student_id");
+    }
+
+    @Test
+    void groupMembership_singleConstraint_isNamedCorrectlyAndCoversStudentOnly() {
+        UniqueConstraint single = findConstraint(GroupMembership.class, "uq_gm_student");
+        assertThat(single.columnNames()).containsExactly("student_id");
+    }
+
+    // ── GroupInvitation column naming per ER spec ─────────────────────────────
+
+    @Test
+    void groupInvitation_invitee_joinColumnName_isInviteeStudentId() throws Exception {
+        Field f = GroupInvitation.class.getDeclaredField("invitee");
+        JoinColumn jc = f.getAnnotation(JoinColumn.class);
+        assertThat(jc.name()).isEqualTo("invitee_student_id");
+    }
+
+    // ── ProjectGroup advisor FK is nullable ───────────────────────────────────
+
+    @Test
+    void projectGroup_advisor_joinColumn_isNullable() throws Exception {
+        Field f = ProjectGroup.class.getDeclaredField("advisor");
+        JoinColumn jc = f.getAnnotation(JoinColumn.class);
+        assertThat(jc.nullable()).isTrue();
+    }
+
+    // ── Enum completeness ─────────────────────────────────────────────────────
+
+    @Test
+    void groupStatus_hasExactlyFiveValues() {
+        assertThat(ProjectGroup.GroupStatus.values())
+                .containsExactlyInAnyOrder(
+                        ProjectGroup.GroupStatus.FORMING,
+                        ProjectGroup.GroupStatus.TOOLS_PENDING,
+                        ProjectGroup.GroupStatus.TOOLS_BOUND,
+                        ProjectGroup.GroupStatus.ADVISOR_ASSIGNED,
+                        ProjectGroup.GroupStatus.DISBANDED);
+    }
+
+    @Test
+    void invitationStatus_hasAllRequiredValues() {
+        assertThat(GroupInvitation.InvitationStatus.values())
+                .containsExactlyInAnyOrder(
+                        GroupInvitation.InvitationStatus.PENDING,
+                        GroupInvitation.InvitationStatus.ACCEPTED,
+                        GroupInvitation.InvitationStatus.DECLINED,
+                        GroupInvitation.InvitationStatus.CANCELLED,
+                        GroupInvitation.InvitationStatus.AUTO_DENIED);
+    }
+
+    @Test
+    void requestStatus_hasAllRequiredValues() {
+        assertThat(AdvisorRequest.RequestStatus.values())
+                .containsExactlyInAnyOrder(
+                        AdvisorRequest.RequestStatus.PENDING,
+                        AdvisorRequest.RequestStatus.ACCEPTED,
+                        AdvisorRequest.RequestStatus.REJECTED,
+                        AdvisorRequest.RequestStatus.AUTO_REJECTED,
+                        AdvisorRequest.RequestStatus.CANCELLED);
+    }
+
+    @Test
+    void memberRole_hasTeamLeaderAndMember() {
+        assertThat(GroupMembership.MemberRole.values())
+                .containsExactlyInAnyOrder(
+                        GroupMembership.MemberRole.TEAM_LEADER,
+                        GroupMembership.MemberRole.MEMBER);
+    }
+
+    @Test
+    void windowType_hasGroupCreationAndAdvisorAssociation() {
+        assertThat(ScheduleWindow.WindowType.values())
+                .containsExactlyInAnyOrder(
+                        ScheduleWindow.WindowType.GROUP_CREATION,
+                        ScheduleWindow.WindowType.ADVISOR_ASSOCIATION);
+    }
+
+    // ── Encrypted token field lengths per ER spec (VARCHAR 1024) ─────────────
+
+    @Test
+    void projectGroup_encryptedJiraToken_columnLength_is1024() throws Exception {
+        Field f = ProjectGroup.class.getDeclaredField("encryptedJiraToken");
+        jakarta.persistence.Column col = f.getAnnotation(jakarta.persistence.Column.class);
+        assertThat(col.length()).isEqualTo(1024);
+    }
+
+    @Test
+    void projectGroup_encryptedGithubPat_columnLength_is1024() throws Exception {
+        Field f = ProjectGroup.class.getDeclaredField("encryptedGithubPat");
+        jakarta.persistence.Column col = f.getAnnotation(jakarta.persistence.Column.class);
+        assertThat(col.length()).isEqualTo(1024);
+    }
+
+    // ── Helper ────────────────────────────────────────────────────────────────
+
+    private UniqueConstraint findConstraint(Class<?> entityClass, String name) {
+        Table table = entityClass.getAnnotation(Table.class);
+        return Arrays.stream(table.uniqueConstraints())
+                .filter(c -> c.name().equals(name))
+                .findFirst()
+                .orElseThrow(() -> new AssertionError("Constraint '" + name + "' not found on " + entityClass.getSimpleName()));
+    }
+}

--- a/backend/src/test/java/com/senior/spm/repository/AdvisorRequestRepositoryTest.java
+++ b/backend/src/test/java/com/senior/spm/repository/AdvisorRequestRepositoryTest.java
@@ -1,0 +1,177 @@
+package com.senior.spm.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.LocalDateTime;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.test.context.TestPropertySource;
+
+import com.senior.spm.entity.AdvisorRequest;
+import com.senior.spm.entity.AdvisorRequest.RequestStatus;
+import com.senior.spm.entity.ProjectGroup;
+import com.senior.spm.entity.StaffUser;
+
+/**
+ * Verifies AdvisorRequestRepository query methods.
+ *
+ * Critical methods under test:
+ *   findTopByGroupIdOrderBySentAtDesc  — P3 Rule 7: used for getAdvisorRequest/cancel (not findByGroupIdAndStatus)
+ *   bulkUpdateStatusForGroup           — exclude one ID (accept path: auto-reject competing requests)
+ *   bulkUpdateStatusByGroupId          — update ALL (sanitization + coordinator assign)
+ */
+@DataJpaTest
+@TestPropertySource(properties = "spring.sql.init.mode=never")
+class AdvisorRequestRepositoryTest extends RepositoryTestBase {
+
+    @Autowired
+    AdvisorRequestRepository repo;
+
+    // ── findTopByGroupIdOrderBySentAtDesc ─────────────────────────────────────
+    // P3 Rule 7: this is the primary lookup for getAdvisorRequest and cancelAdvisorRequest
+
+    @Test
+    void findTopByGroupIdOrderBySentAtDesc_returnsMostRecentRequest() {
+        StaffUser prof = makeProfessor("prof1@test.com");
+        ProjectGroup group = makeGroup("Group A", "2024-FALL", ProjectGroup.GroupStatus.TOOLS_BOUND);
+
+        LocalDateTime earlier = LocalDateTime.now().minusHours(2);
+        LocalDateTime later = LocalDateTime.now().minusHours(1);
+
+        AdvisorRequest old = makeAdvisorRequest(group, prof, RequestStatus.REJECTED, earlier);
+        AdvisorRequest recent = makeAdvisorRequest(group, prof, RequestStatus.PENDING, later);
+
+        var result = repo.findTopByGroupIdOrderBySentAtDesc(group.getId());
+
+        assertThat(result).isPresent();
+        assertThat(result.get().getId()).isEqualTo(recent.getId());
+    }
+
+    @Test
+    void findTopByGroupIdOrderBySentAtDesc_emptyWhenNoRequests() {
+        ProjectGroup group = makeGroup("Group A", "2024-FALL", ProjectGroup.GroupStatus.TOOLS_BOUND);
+
+        assertThat(repo.findTopByGroupIdOrderBySentAtDesc(group.getId())).isEmpty();
+    }
+
+    // ── bulkUpdateStatusForGroup (with excludeId) ─────────────────────────────
+    // Used on advisor ACCEPT: auto-reject all OTHER pending requests for same group, preserve accepted one
+
+    @Test
+    void bulkUpdateStatusForGroup_updatesAllPendingExceptExcluded() {
+        StaffUser prof1 = makeProfessor("prof2@test.com");
+        StaffUser prof2 = makeProfessor("prof3@test.com");
+        StaffUser prof3 = makeProfessor("prof4@test.com");
+        ProjectGroup group = makeGroup("Group A", "2024-FALL", ProjectGroup.GroupStatus.TOOLS_BOUND);
+
+        AdvisorRequest accepted = makeAdvisorRequest(group, prof1, RequestStatus.PENDING, LocalDateTime.now().minusMinutes(10));
+        AdvisorRequest other1 = makeAdvisorRequest(group, prof2, RequestStatus.PENDING, LocalDateTime.now().minusMinutes(5));
+        AdvisorRequest other2 = makeAdvisorRequest(group, prof3, RequestStatus.PENDING, LocalDateTime.now());
+
+        repo.bulkUpdateStatusForGroup(RequestStatus.AUTO_REJECTED, group.getId(), accepted.getId());
+        clearCache();
+
+        assertThat(repo.findById(accepted.getId()).get().getStatus()).isEqualTo(RequestStatus.PENDING);
+        assertThat(repo.findById(other1.getId()).get().getStatus()).isEqualTo(RequestStatus.AUTO_REJECTED);
+        assertThat(repo.findById(other2.getId()).get().getStatus()).isEqualTo(RequestStatus.AUTO_REJECTED);
+    }
+
+    @Test
+    void bulkUpdateStatusForGroup_doesNotAffectNonPendingRequests() {
+        StaffUser prof1 = makeProfessor("prof5@test.com");
+        StaffUser prof2 = makeProfessor("prof6@test.com");
+        ProjectGroup group = makeGroup("Group A", "2024-FALL", ProjectGroup.GroupStatus.TOOLS_BOUND);
+
+        AdvisorRequest accepted = makeAdvisorRequest(group, prof1, RequestStatus.PENDING, LocalDateTime.now().minusMinutes(5));
+        AdvisorRequest alreadyRejected = makeAdvisorRequest(group, prof2, RequestStatus.REJECTED, LocalDateTime.now());
+
+        repo.bulkUpdateStatusForGroup(RequestStatus.AUTO_REJECTED, group.getId(), accepted.getId());
+        clearCache();
+
+        // REJECTED should stay REJECTED, not changed to AUTO_REJECTED
+        assertThat(repo.findById(alreadyRejected.getId()).get().getStatus()).isEqualTo(RequestStatus.REJECTED);
+    }
+
+    // ── bulkUpdateStatusByGroupId (no excludeId) ──────────────────────────────
+    // Used by SanitizationService (seq 3.4) and coordinator assign (seq 3.5): update ALL pending
+
+    @Test
+    void bulkUpdateStatusByGroupId_updatesAllPendingRequestsForGroup() {
+        StaffUser prof1 = makeProfessor("prof7@test.com");
+        StaffUser prof2 = makeProfessor("prof8@test.com");
+        ProjectGroup group = makeGroup("Group A", "2024-FALL", ProjectGroup.GroupStatus.TOOLS_BOUND);
+
+        AdvisorRequest r1 = makeAdvisorRequest(group, prof1, RequestStatus.PENDING, LocalDateTime.now().minusMinutes(5));
+        AdvisorRequest r2 = makeAdvisorRequest(group, prof2, RequestStatus.PENDING, LocalDateTime.now());
+
+        repo.bulkUpdateStatusByGroupId(RequestStatus.AUTO_REJECTED, group.getId());
+        clearCache();
+
+        assertThat(repo.findById(r1.getId()).get().getStatus()).isEqualTo(RequestStatus.AUTO_REJECTED);
+        assertThat(repo.findById(r2.getId()).get().getStatus()).isEqualTo(RequestStatus.AUTO_REJECTED);
+    }
+
+    @Test
+    void bulkUpdateStatusByGroupId_doesNotAffectOtherGroups() {
+        StaffUser prof = makeProfessor("prof9@test.com");
+        ProjectGroup groupA = makeGroup("Group A", "2024-FALL", ProjectGroup.GroupStatus.TOOLS_BOUND);
+        ProjectGroup groupB = makeGroup("Group B", "2024-FALL", ProjectGroup.GroupStatus.TOOLS_BOUND);
+
+        makeAdvisorRequest(groupA, prof, RequestStatus.PENDING, LocalDateTime.now());
+        AdvisorRequest groupBRequest = makeAdvisorRequest(groupB, prof, RequestStatus.PENDING, LocalDateTime.now());
+
+        repo.bulkUpdateStatusByGroupId(RequestStatus.AUTO_REJECTED, groupA.getId());
+        clearCache();
+
+        // Group B's request must not be touched
+        assertThat(repo.findById(groupBRequest.getId()).get().getStatus()).isEqualTo(RequestStatus.PENDING);
+    }
+
+    // ── findByAdvisorIdAndStatus ──────────────────────────────────────────────
+    // Used by professor inbox (seq 3.2)
+
+    @Test
+    void findByAdvisorIdAndStatus_returnsPendingRequestsForAdvisor() {
+        StaffUser prof = makeProfessor("prof10@test.com");
+        StaffUser otherProf = makeProfessor("prof11@test.com");
+        ProjectGroup g1 = makeGroup("Group A", "2024-FALL", ProjectGroup.GroupStatus.TOOLS_BOUND);
+        ProjectGroup g2 = makeGroup("Group B", "2024-FALL", ProjectGroup.GroupStatus.TOOLS_BOUND);
+        ProjectGroup g3 = makeGroup("Group C", "2024-FALL", ProjectGroup.GroupStatus.TOOLS_BOUND);
+
+        makeAdvisorRequest(g1, prof, RequestStatus.PENDING, LocalDateTime.now());
+        makeAdvisorRequest(g2, prof, RequestStatus.REJECTED, LocalDateTime.now()); // not PENDING
+        makeAdvisorRequest(g3, otherProf, RequestStatus.PENDING, LocalDateTime.now()); // different advisor
+
+        var result = repo.findByAdvisorIdAndStatus(prof.getId(), RequestStatus.PENDING);
+
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).getGroup().getId()).isEqualTo(g1.getId());
+    }
+
+    // ── findByGroupIdAndStatus ────────────────────────────────────────────────
+    // Used for duplicate-request check in sendAdvisorRequest (seq 3.1)
+
+    @Test
+    void findByGroupIdAndStatus_returnsPendingRequestIfExists() {
+        StaffUser prof = makeProfessor("prof12@test.com");
+        ProjectGroup group = makeGroup("Group A", "2024-FALL", ProjectGroup.GroupStatus.TOOLS_BOUND);
+
+        AdvisorRequest pending = makeAdvisorRequest(group, prof, RequestStatus.PENDING, LocalDateTime.now());
+
+        var result = repo.findByGroupIdAndStatus(group.getId(), RequestStatus.PENDING);
+        assertThat(result).isPresent();
+        assertThat(result.get().getId()).isEqualTo(pending.getId());
+    }
+
+    @Test
+    void findByGroupIdAndStatus_emptyWhenNoPendingRequest() {
+        StaffUser prof = makeProfessor("prof13@test.com");
+        ProjectGroup group = makeGroup("Group A", "2024-FALL", ProjectGroup.GroupStatus.TOOLS_BOUND);
+
+        makeAdvisorRequest(group, prof, RequestStatus.REJECTED, LocalDateTime.now());
+
+        assertThat(repo.findByGroupIdAndStatus(group.getId(), RequestStatus.PENDING)).isEmpty();
+    }
+}

--- a/backend/src/test/java/com/senior/spm/repository/GroupInvitationRepositoryTest.java
+++ b/backend/src/test/java/com/senior/spm/repository/GroupInvitationRepositoryTest.java
@@ -1,0 +1,226 @@
+package com.senior.spm.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.test.context.TestPropertySource;
+
+import com.senior.spm.entity.GroupInvitation;
+import com.senior.spm.entity.GroupInvitation.InvitationStatus;
+import com.senior.spm.entity.ProjectGroup;
+import com.senior.spm.entity.Student;
+
+/**
+ * Verifies GroupInvitationRepository query methods.
+ *
+ * Critical methods under test:
+ *   countByGroupIdAndStatus           — used for max-team-size check (seq 2.2, 2.3)
+ *   autoDenyOtherPendingInvitations   — on accept: deny invitations from OTHER groups (seq 2.3)
+ *   autoDenyAllPendingByGroupId       — on disband: deny all outbound pending invites (seq 2.6)
+ */
+@DataJpaTest
+@TestPropertySource(properties = "spring.sql.init.mode=never")
+class GroupInvitationRepositoryTest extends RepositoryTestBase {
+
+    @Autowired
+    GroupInvitationRepository repo;
+
+    // ── countByGroupIdAndStatus ────────────────────────────────────────────────
+    // Max-team-size check: count = current members + pending outbound invitations
+
+    @Test
+    void countByGroupIdAndStatus_countsPendingInvitationsOnly() {
+        Student s1 = makeStudent("23070000101");
+        Student s2 = makeStudent("23070000102");
+        Student s3 = makeStudent("23070000103");
+        ProjectGroup group = makeGroup("Group A", "2024-FALL", ProjectGroup.GroupStatus.FORMING);
+
+        makeInvitation(group, s1, InvitationStatus.PENDING);
+        makeInvitation(group, s2, InvitationStatus.PENDING);
+        makeInvitation(group, s3, InvitationStatus.DECLINED); // not PENDING
+
+        long count = repo.countByGroupIdAndStatus(group.getId(), InvitationStatus.PENDING);
+
+        assertThat(count).isEqualTo(2);
+    }
+
+    @Test
+    void countByGroupIdAndStatus_returnsZeroWhenNoPendingInvitations() {
+        ProjectGroup group = makeGroup("Group A", "2024-FALL", ProjectGroup.GroupStatus.FORMING);
+
+        assertThat(repo.countByGroupIdAndStatus(group.getId(), InvitationStatus.PENDING)).isEqualTo(0);
+    }
+
+    @Test
+    void countByGroupIdAndStatus_doesNotCountOtherGroupsInvitations() {
+        Student s1 = makeStudent("23070000104");
+        Student s2 = makeStudent("23070000105");
+        ProjectGroup groupA = makeGroup("Group A", "2024-FALL", ProjectGroup.GroupStatus.FORMING);
+        ProjectGroup groupB = makeGroup("Group B", "2024-FALL", ProjectGroup.GroupStatus.FORMING);
+
+        makeInvitation(groupA, s1, InvitationStatus.PENDING);
+        makeInvitation(groupB, s2, InvitationStatus.PENDING);
+
+        assertThat(repo.countByGroupIdAndStatus(groupA.getId(), InvitationStatus.PENDING)).isEqualTo(1);
+    }
+
+    // ── autoDenyOtherPendingInvitations ───────────────────────────────────────
+    // On accept: AUTO_DENY all pending invitations for this student from OTHER groups,
+    //            but NOT the accepted group's invitation.
+
+    @Test
+    void autoDenyOtherPendingInvitations_deniesInvitationsFromOtherGroups() {
+        Student student = makeStudent("23070000106");
+        ProjectGroup accepted = makeGroup("Accepted Group", "2024-FALL", ProjectGroup.GroupStatus.FORMING);
+        ProjectGroup other1 = makeGroup("Other Group 1", "2024-FALL", ProjectGroup.GroupStatus.FORMING);
+        ProjectGroup other2 = makeGroup("Other Group 2", "2024-FALL", ProjectGroup.GroupStatus.FORMING);
+
+        GroupInvitation acceptedInv = makeInvitation(accepted, student, InvitationStatus.ACCEPTED);
+        GroupInvitation pending1 = makeInvitation(other1, student, InvitationStatus.PENDING);
+        GroupInvitation pending2 = makeInvitation(other2, student, InvitationStatus.PENDING);
+
+        repo.autoDenyOtherPendingInvitations(student.getId(), accepted.getId());
+        clearCache();
+
+        assertThat(repo.findById(acceptedInv.getId()).get().getStatus()).isEqualTo(InvitationStatus.ACCEPTED);
+        assertThat(repo.findById(pending1.getId()).get().getStatus()).isEqualTo(InvitationStatus.AUTO_DENIED);
+        assertThat(repo.findById(pending2.getId()).get().getStatus()).isEqualTo(InvitationStatus.AUTO_DENIED);
+    }
+
+    @Test
+    void autoDenyOtherPendingInvitations_doesNotDenyNonPendingInvitations() {
+        Student student = makeStudent("23070000107");
+        ProjectGroup accepted = makeGroup("Accepted Group", "2024-FALL", ProjectGroup.GroupStatus.FORMING);
+        ProjectGroup other = makeGroup("Other Group", "2024-FALL", ProjectGroup.GroupStatus.FORMING);
+
+        makeInvitation(accepted, student, InvitationStatus.ACCEPTED);
+        GroupInvitation declined = makeInvitation(other, student, InvitationStatus.DECLINED);
+
+        repo.autoDenyOtherPendingInvitations(student.getId(), accepted.getId());
+        clearCache();
+
+        // DECLINED should not be changed to AUTO_DENIED
+        assertThat(repo.findById(declined.getId()).get().getStatus()).isEqualTo(InvitationStatus.DECLINED);
+    }
+
+    @Test
+    void autoDenyOtherPendingInvitations_doesNotAffectOtherStudents() {
+        Student student = makeStudent("23070000108");
+        Student otherStudent = makeStudent("23070000109");
+        ProjectGroup accepted = makeGroup("Accepted Group", "2024-FALL", ProjectGroup.GroupStatus.FORMING);
+        ProjectGroup other = makeGroup("Other Group", "2024-FALL", ProjectGroup.GroupStatus.FORMING);
+
+        makeInvitation(accepted, student, InvitationStatus.ACCEPTED);
+        GroupInvitation otherStudentInv = makeInvitation(other, otherStudent, InvitationStatus.PENDING);
+
+        repo.autoDenyOtherPendingInvitations(student.getId(), accepted.getId());
+        clearCache();
+
+        // Other student's invitation must not be touched
+        assertThat(repo.findById(otherStudentInv.getId()).get().getStatus()).isEqualTo(InvitationStatus.PENDING);
+    }
+
+    // ── autoDenyAllPendingByGroupId ───────────────────────────────────────────
+    // On group disband: AUTO_DENY all pending outbound invitations from the disbanded group
+
+    @Test
+    void autoDenyAllPendingByGroupId_deniesAllPendingForGroup() {
+        Student s1 = makeStudent("23070000110");
+        Student s2 = makeStudent("23070000111");
+        ProjectGroup group = makeGroup("Group A", "2024-FALL", ProjectGroup.GroupStatus.FORMING);
+
+        GroupInvitation inv1 = makeInvitation(group, s1, InvitationStatus.PENDING);
+        GroupInvitation inv2 = makeInvitation(group, s2, InvitationStatus.PENDING);
+
+        repo.autoDenyAllPendingByGroupId(group.getId());
+        clearCache();
+
+        assertThat(repo.findById(inv1.getId()).get().getStatus()).isEqualTo(InvitationStatus.AUTO_DENIED);
+        assertThat(repo.findById(inv2.getId()).get().getStatus()).isEqualTo(InvitationStatus.AUTO_DENIED);
+    }
+
+    @Test
+    void autoDenyAllPendingByGroupId_doesNotAffectOtherGroups() {
+        Student s1 = makeStudent("23070000112");
+        Student s2 = makeStudent("23070000113");
+        ProjectGroup disbanded = makeGroup("Disbanded", "2024-FALL", ProjectGroup.GroupStatus.DISBANDED);
+        ProjectGroup active = makeGroup("Active", "2024-FALL", ProjectGroup.GroupStatus.FORMING);
+
+        makeInvitation(disbanded, s1, InvitationStatus.PENDING);
+        GroupInvitation activeInv = makeInvitation(active, s2, InvitationStatus.PENDING);
+
+        repo.autoDenyAllPendingByGroupId(disbanded.getId());
+        clearCache();
+
+        // Active group's invitations must not be touched
+        assertThat(repo.findById(activeInv.getId()).get().getStatus()).isEqualTo(InvitationStatus.PENDING);
+    }
+
+    @Test
+    void autoDenyAllPendingByGroupId_doesNotTouchNonPendingInvitations() {
+        Student s1 = makeStudent("23070000114");
+        ProjectGroup group = makeGroup("Group A", "2024-FALL", ProjectGroup.GroupStatus.FORMING);
+
+        GroupInvitation declined = makeInvitation(group, s1, InvitationStatus.DECLINED);
+
+        repo.autoDenyAllPendingByGroupId(group.getId());
+        clearCache();
+
+        assertThat(repo.findById(declined.getId()).get().getStatus()).isEqualTo(InvitationStatus.DECLINED);
+    }
+
+    // ── findByInviteeIdAndStatus ──────────────────────────────────────────────
+    // Used for student's pending invitations inbox (seq 2.3)
+
+    @Test
+    void findByInviteeIdAndStatus_returnsStudentsPendingInvitations() {
+        Student student = makeStudent("23070000115");
+        Student other = makeStudent("23070000116");
+        ProjectGroup g1 = makeGroup("Group A", "2024-FALL", ProjectGroup.GroupStatus.FORMING);
+        ProjectGroup g2 = makeGroup("Group B", "2024-FALL", ProjectGroup.GroupStatus.FORMING);
+        ProjectGroup g3 = makeGroup("Group C", "2024-FALL", ProjectGroup.GroupStatus.FORMING);
+
+        makeInvitation(g1, student, InvitationStatus.PENDING);
+        makeInvitation(g2, student, InvitationStatus.DECLINED); // not PENDING
+        makeInvitation(g3, other, InvitationStatus.PENDING);    // different student
+
+        var result = repo.findByInviteeIdAndStatus(student.getId(), InvitationStatus.PENDING);
+
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).getGroup().getId()).isEqualTo(g1.getId());
+    }
+
+    // ── existsByGroupIdAndInviteeIdAndStatus ──────────────────────────────────
+    // Duplicate-invite check (seq 2.2)
+
+    @Test
+    void existsByGroupIdAndInviteeIdAndStatus_trueWhenPendingInviteExists() {
+        Student student = makeStudent("23070000117");
+        ProjectGroup group = makeGroup("Group A", "2024-FALL", ProjectGroup.GroupStatus.FORMING);
+        makeInvitation(group, student, InvitationStatus.PENDING);
+
+        assertThat(repo.existsByGroupIdAndInviteeIdAndStatus(
+                group.getId(), student.getId(), InvitationStatus.PENDING)).isTrue();
+    }
+
+    @Test
+    void existsByGroupIdAndInviteeIdAndStatus_falseWhenNoInvite() {
+        Student student = makeStudent("23070000118");
+        ProjectGroup group = makeGroup("Group A", "2024-FALL", ProjectGroup.GroupStatus.FORMING);
+
+        assertThat(repo.existsByGroupIdAndInviteeIdAndStatus(
+                group.getId(), student.getId(), InvitationStatus.PENDING)).isFalse();
+    }
+
+    @Test
+    void existsByGroupIdAndInviteeIdAndStatus_falseWhenInviteIsNotPending() {
+        Student student = makeStudent("23070000119");
+        ProjectGroup group = makeGroup("Group A", "2024-FALL", ProjectGroup.GroupStatus.FORMING);
+        makeInvitation(group, student, InvitationStatus.DECLINED);
+
+        assertThat(repo.existsByGroupIdAndInviteeIdAndStatus(
+                group.getId(), student.getId(), InvitationStatus.PENDING)).isFalse();
+    }
+}

--- a/backend/src/test/java/com/senior/spm/repository/GroupMembershipRepositoryTest.java
+++ b/backend/src/test/java/com/senior/spm/repository/GroupMembershipRepositoryTest.java
@@ -1,0 +1,185 @@
+package com.senior.spm.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.time.LocalDateTime;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.test.context.TestPropertySource;
+
+import com.senior.spm.entity.GroupMembership;
+import com.senior.spm.entity.ProjectGroup;
+import com.senior.spm.entity.Student;
+
+/**
+ * Verifies GroupMembership repository + DB-level unique constraints.
+ *
+ * Key constraints under test:
+ *   uq_gm_group_student (group_id, student_id) — no duplicate row for same pair
+ *   uq_gm_student (student_id)               — a student can only be in ONE group
+ */
+@DataJpaTest
+@TestPropertySource(properties = "spring.sql.init.mode=never")
+class GroupMembershipRepositoryTest extends RepositoryTestBase {
+
+    @Autowired
+    GroupMembershipRepository repo;
+
+    // ── uq_gm_student: student can only be in one group ──────────────────────
+    // Uses repo.saveAndFlush() so Spring Data translates PersistenceException → DataIntegrityViolationException
+
+    @Test
+    void uq_gm_student_preventsStudentInTwoGroups() {
+        Student student = makeStudent("23070000001");
+        ProjectGroup g1 = makeGroup("Group A", "2024-FALL", ProjectGroup.GroupStatus.FORMING);
+        ProjectGroup g2 = makeGroup("Group B", "2024-FALL", ProjectGroup.GroupStatus.FORMING);
+
+        GroupMembership first = new GroupMembership();
+        first.setGroup(g1); first.setStudent(student);
+        first.setRole(GroupMembership.MemberRole.TEAM_LEADER); first.setJoinedAt(LocalDateTime.now());
+        repo.saveAndFlush(first);
+
+        assertThatThrownBy(() -> {
+            GroupMembership second = new GroupMembership();
+            second.setGroup(g2); second.setStudent(student);
+            second.setRole(GroupMembership.MemberRole.MEMBER); second.setJoinedAt(LocalDateTime.now());
+            repo.saveAndFlush(second);
+        }).isInstanceOf(DataIntegrityViolationException.class);
+    }
+
+    // ── uq_gm_group_student: no duplicate (group, student) row ───────────────
+
+    @Test
+    void uq_gm_group_student_preventsDuplicateMembershipSameGroupSameStudent() {
+        Student student = makeStudent("23070000002");
+        ProjectGroup group = makeGroup("Group A", "2024-FALL", ProjectGroup.GroupStatus.FORMING);
+
+        GroupMembership first = new GroupMembership();
+        first.setGroup(group); first.setStudent(student);
+        first.setRole(GroupMembership.MemberRole.TEAM_LEADER); first.setJoinedAt(LocalDateTime.now());
+        repo.saveAndFlush(first);
+
+        assertThatThrownBy(() -> {
+            GroupMembership second = new GroupMembership();
+            second.setGroup(group); second.setStudent(student);
+            second.setRole(GroupMembership.MemberRole.MEMBER); second.setJoinedAt(LocalDateTime.now());
+            repo.saveAndFlush(second);
+        }).isInstanceOf(DataIntegrityViolationException.class);
+    }
+
+    // ── Two different students can be in the same group ───────────────────────
+
+    @Test
+    void twoDifferentStudents_canJoinSameGroup() {
+        Student s1 = makeStudent("23070000003");
+        Student s2 = makeStudent("23070000004");
+        ProjectGroup group = makeGroup("Group A", "2024-FALL", ProjectGroup.GroupStatus.FORMING);
+
+        makeMembership(group, s1, GroupMembership.MemberRole.TEAM_LEADER);
+        makeMembership(group, s2, GroupMembership.MemberRole.MEMBER);
+
+        assertThat(repo.countByGroupId(group.getId())).isEqualTo(2);
+    }
+
+    // ── existsByStudentId ─────────────────────────────────────────────────────
+
+    @Test
+    void existsByStudentId_trueWhenMemberExists() {
+        Student student = makeStudent("23070000005");
+        ProjectGroup group = makeGroup("Group A", "2024-FALL", ProjectGroup.GroupStatus.FORMING);
+        makeMembership(group, student, GroupMembership.MemberRole.TEAM_LEADER);
+
+        assertThat(repo.existsByStudentId(student.getId())).isTrue();
+    }
+
+    @Test
+    void existsByStudentId_falseWhenNoMembership() {
+        Student student = makeStudent("23070000006");
+
+        assertThat(repo.existsByStudentId(student.getId())).isFalse();
+    }
+
+    // ── findByGroupId ─────────────────────────────────────────────────────────
+
+    @Test
+    void findByGroupId_returnsAllMembersOfGroup() {
+        Student s1 = makeStudent("23070000007");
+        Student s2 = makeStudent("23070000008");
+        ProjectGroup group = makeGroup("Group A", "2024-FALL", ProjectGroup.GroupStatus.FORMING);
+        ProjectGroup other = makeGroup("Group B", "2024-FALL", ProjectGroup.GroupStatus.FORMING);
+
+        makeMembership(group, s1, GroupMembership.MemberRole.TEAM_LEADER);
+        makeMembership(group, s2, GroupMembership.MemberRole.MEMBER);
+        makeStudent("23070000009"); // student in other group
+        makeMembership(other, makeStudent("23070000010"), GroupMembership.MemberRole.TEAM_LEADER);
+
+        assertThat(repo.findByGroupId(group.getId())).hasSize(2);
+    }
+
+    // ── countByGroupId ────────────────────────────────────────────────────────
+
+    @Test
+    void countByGroupId_returnsCorrectMemberCount() {
+        Student s1 = makeStudent("23070000011");
+        Student s2 = makeStudent("23070000012");
+        Student s3 = makeStudent("23070000013");
+        ProjectGroup group = makeGroup("Group A", "2024-FALL", ProjectGroup.GroupStatus.FORMING);
+
+        makeMembership(group, s1, GroupMembership.MemberRole.TEAM_LEADER);
+        makeMembership(group, s2, GroupMembership.MemberRole.MEMBER);
+        makeMembership(group, s3, GroupMembership.MemberRole.MEMBER);
+
+        assertThat(repo.countByGroupId(group.getId())).isEqualTo(3);
+    }
+
+    // ── deleteByGroupId ───────────────────────────────────────────────────────
+
+    @Test
+    void deleteByGroupId_removesAllMembershipsForGroup() {
+        Student s1 = makeStudent("23070000014");
+        Student s2 = makeStudent("23070000015");
+        ProjectGroup group = makeGroup("Group A", "2024-FALL", ProjectGroup.GroupStatus.FORMING);
+
+        makeMembership(group, s1, GroupMembership.MemberRole.TEAM_LEADER);
+        makeMembership(group, s2, GroupMembership.MemberRole.MEMBER);
+
+        repo.deleteByGroupId(group.getId());
+        clearCache();
+
+        assertThat(repo.countByGroupId(group.getId())).isEqualTo(0);
+        // students themselves should still exist
+        assertThat(em.find(com.senior.spm.entity.Student.class, s1.getId())).isNotNull();
+    }
+
+    // ── findByGroupIdAndRole ──────────────────────────────────────────────────
+
+    @Test
+    void findByGroupIdAndRole_returnsTeamLeader() {
+        Student leader = makeStudent("23070000016");
+        Student member = makeStudent("23070000017");
+        ProjectGroup group = makeGroup("Group A", "2024-FALL", ProjectGroup.GroupStatus.FORMING);
+
+        makeMembership(group, leader, GroupMembership.MemberRole.TEAM_LEADER);
+        makeMembership(group, member, GroupMembership.MemberRole.MEMBER);
+
+        var result = repo.findByGroupIdAndRole(group.getId(), GroupMembership.MemberRole.TEAM_LEADER);
+        assertThat(result).isPresent();
+        assertThat(result.get().getStudent().getId()).isEqualTo(leader.getId());
+    }
+
+    // ── findByGroupIdAndStudentId ─────────────────────────────────────────────
+
+    @Test
+    void findByGroupIdAndStudentId_returnsCorrectMembership() {
+        Student student = makeStudent("23070000018");
+        ProjectGroup group = makeGroup("Group A", "2024-FALL", ProjectGroup.GroupStatus.FORMING);
+        makeMembership(group, student, GroupMembership.MemberRole.TEAM_LEADER);
+
+        var result = repo.findByGroupIdAndStudentId(group.getId(), student.getId());
+        assertThat(result).isPresent();
+    }
+}

--- a/backend/src/test/java/com/senior/spm/repository/ProjectGroupRepositoryTest.java
+++ b/backend/src/test/java/com/senior/spm/repository/ProjectGroupRepositoryTest.java
@@ -1,0 +1,167 @@
+package com.senior.spm.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.test.context.TestPropertySource;
+
+import com.senior.spm.entity.ProjectGroup;
+import com.senior.spm.entity.StaffUser;
+
+/**
+ * Verifies ProjectGroupRepository query methods.
+ *
+ * Critical methods under test:
+ *   countByAdvisorIdAndTermIdAndStatusNot — must EXCLUDE disbanded groups (P3 Rule 1)
+ *   findByTermIdAndStatusNotAndAdvisorIsNull — used by SanitizationService (seq 3.4)
+ */
+@DataJpaTest
+@TestPropertySource(properties = "spring.sql.init.mode=never")
+class ProjectGroupRepositoryTest extends RepositoryTestBase {
+
+    @Autowired
+    ProjectGroupRepository repo;
+
+    // ── existsByGroupNameAndTermId ────────────────────────────────────────────
+
+    @Test
+    void existsByGroupNameAndTermId_trueForDuplicateNameInSameTerm() {
+        makeGroup("Team Alpha", "2024-FALL", ProjectGroup.GroupStatus.FORMING);
+
+        assertThat(repo.existsByGroupNameAndTermId("Team Alpha", "2024-FALL")).isTrue();
+    }
+
+    @Test
+    void existsByGroupNameAndTermId_falseForSameNameDifferentTerm() {
+        makeGroup("Team Alpha", "2024-FALL", ProjectGroup.GroupStatus.FORMING);
+
+        assertThat(repo.existsByGroupNameAndTermId("Team Alpha", "2025-SPRING")).isFalse();
+    }
+
+    @Test
+    void existsByGroupNameAndTermId_falseForDifferentName() {
+        makeGroup("Team Alpha", "2024-FALL", ProjectGroup.GroupStatus.FORMING);
+
+        assertThat(repo.existsByGroupNameAndTermId("Team Beta", "2024-FALL")).isFalse();
+    }
+
+    // ── countByAdvisorIdAndTermIdAndStatusNot ─────────────────────────────────
+    // SPEC: must exclude DISBANDED groups — plain countByAdvisorIdAndTermId inflates load
+
+    @Test
+    void countByAdvisorIdAndTermIdAndStatusNot_countsActiveGroupsForAdvisor() {
+        StaffUser prof = makeProfessor("prof1@test.com");
+
+        makeGroupWithAdvisor("Group A", "2024-FALL", ProjectGroup.GroupStatus.ADVISOR_ASSIGNED, prof);
+        makeGroupWithAdvisor("Group B", "2024-FALL", ProjectGroup.GroupStatus.ADVISOR_ASSIGNED, prof);
+
+        long count = repo.countByAdvisorIdAndTermIdAndStatusNot(
+                prof.getId(), "2024-FALL", ProjectGroup.GroupStatus.DISBANDED);
+
+        assertThat(count).isEqualTo(2);
+    }
+
+    @Test
+    void countByAdvisorIdAndTermIdAndStatusNot_excludesDisbandedGroups() {
+        StaffUser prof = makeProfessor("prof2@test.com");
+
+        makeGroupWithAdvisor("Group A", "2024-FALL", ProjectGroup.GroupStatus.ADVISOR_ASSIGNED, prof);
+        makeGroupWithAdvisor("Group Disbanded", "2024-FALL", ProjectGroup.GroupStatus.DISBANDED, prof);
+
+        long count = repo.countByAdvisorIdAndTermIdAndStatusNot(
+                prof.getId(), "2024-FALL", ProjectGroup.GroupStatus.DISBANDED);
+
+        assertThat(count).isEqualTo(1); // disbanded group must NOT be counted
+    }
+
+    @Test
+    void countByAdvisorIdAndTermIdAndStatusNot_doesNotCountOtherAdvisorsGroups() {
+        StaffUser prof1 = makeProfessor("prof3@test.com");
+        StaffUser prof2 = makeProfessor("prof4@test.com");
+
+        makeGroupWithAdvisor("Group A", "2024-FALL", ProjectGroup.GroupStatus.ADVISOR_ASSIGNED, prof1);
+        makeGroupWithAdvisor("Group B", "2024-FALL", ProjectGroup.GroupStatus.ADVISOR_ASSIGNED, prof2);
+
+        long count = repo.countByAdvisorIdAndTermIdAndStatusNot(
+                prof1.getId(), "2024-FALL", ProjectGroup.GroupStatus.DISBANDED);
+
+        assertThat(count).isEqualTo(1);
+    }
+
+    @Test
+    void countByAdvisorIdAndTermIdAndStatusNot_doesNotCountOtherTermGroups() {
+        StaffUser prof = makeProfessor("prof5@test.com");
+
+        makeGroupWithAdvisor("Group A", "2024-FALL", ProjectGroup.GroupStatus.ADVISOR_ASSIGNED, prof);
+        makeGroupWithAdvisor("Group B", "2025-SPRING", ProjectGroup.GroupStatus.ADVISOR_ASSIGNED, prof);
+
+        long count = repo.countByAdvisorIdAndTermIdAndStatusNot(
+                prof.getId(), "2024-FALL", ProjectGroup.GroupStatus.DISBANDED);
+
+        assertThat(count).isEqualTo(1);
+    }
+
+    // ── findByTermIdAndStatusNotAndAdvisorIsNull ──────────────────────────────
+    // Used by SanitizationService to find groups without advisor that need disbanding
+
+    @Test
+    void findByTermIdAndStatusNotAndAdvisorIsNull_returnsGroupsWithNoAdvisor() {
+        ProjectGroup noAdvisor = makeGroup("No Advisor", "2024-FALL", ProjectGroup.GroupStatus.TOOLS_BOUND);
+        StaffUser prof = makeProfessor("prof6@test.com");
+        makeGroupWithAdvisor("Has Advisor", "2024-FALL", ProjectGroup.GroupStatus.ADVISOR_ASSIGNED, prof);
+
+        var result = repo.findByTermIdAndStatusNotAndAdvisorIsNull("2024-FALL", ProjectGroup.GroupStatus.DISBANDED);
+
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).getId()).isEqualTo(noAdvisor.getId());
+    }
+
+    @Test
+    void findByTermIdAndStatusNotAndAdvisorIsNull_excludesAlreadyDisbandedGroups() {
+        makeGroup("Active", "2024-FALL", ProjectGroup.GroupStatus.FORMING);
+        makeGroup("Already Disbanded", "2024-FALL", ProjectGroup.GroupStatus.DISBANDED);
+
+        var result = repo.findByTermIdAndStatusNotAndAdvisorIsNull("2024-FALL", ProjectGroup.GroupStatus.DISBANDED);
+
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).getGroupName()).isEqualTo("Active");
+    }
+
+    @Test
+    void findByTermIdAndStatusNotAndAdvisorIsNull_excludesOtherTerms() {
+        makeGroup("Fall Group", "2024-FALL", ProjectGroup.GroupStatus.FORMING);
+        makeGroup("Spring Group", "2025-SPRING", ProjectGroup.GroupStatus.FORMING);
+
+        var result = repo.findByTermIdAndStatusNotAndAdvisorIsNull("2024-FALL", ProjectGroup.GroupStatus.DISBANDED);
+
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).getGroupName()).isEqualTo("Fall Group");
+    }
+
+    // ── findByTermId ──────────────────────────────────────────────────────────
+
+    @Test
+    void findByTermId_returnsAllGroupsForTerm() {
+        makeGroup("Group A", "2024-FALL", ProjectGroup.GroupStatus.FORMING);
+        makeGroup("Group B", "2024-FALL", ProjectGroup.GroupStatus.FORMING);
+        makeGroup("Group C", "2025-SPRING", ProjectGroup.GroupStatus.FORMING);
+
+        assertThat(repo.findByTermId("2024-FALL")).hasSize(2);
+    }
+
+    // ── findByTermIdAndStatus ─────────────────────────────────────────────────
+
+    @Test
+    void findByTermIdAndStatus_returnsOnlyMatchingStatus() {
+        makeGroup("Forming", "2024-FALL", ProjectGroup.GroupStatus.FORMING);
+        makeGroup("Tools Bound", "2024-FALL", ProjectGroup.GroupStatus.TOOLS_BOUND);
+        makeGroup("Disbanded", "2024-FALL", ProjectGroup.GroupStatus.DISBANDED);
+
+        var result = repo.findByTermIdAndStatus("2024-FALL", ProjectGroup.GroupStatus.FORMING);
+
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).getGroupName()).isEqualTo("Forming");
+    }
+}

--- a/backend/src/test/java/com/senior/spm/repository/RepositoryTestBase.java
+++ b/backend/src/test/java/com/senior/spm/repository/RepositoryTestBase.java
@@ -1,0 +1,104 @@
+package com.senior.spm.repository;
+
+import java.time.LocalDateTime;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+
+import com.senior.spm.entity.AdvisorRequest;
+import com.senior.spm.entity.GroupInvitation;
+import com.senior.spm.entity.GroupMembership;
+import com.senior.spm.entity.ProjectGroup;
+import com.senior.spm.entity.ScheduleWindow;
+import com.senior.spm.entity.StaffUser;
+import com.senior.spm.entity.Student;
+
+/**
+ * Shared factory methods for building test entities.
+ * All data is in-memory (H2); each test rolls back after completion.
+ */
+abstract class RepositoryTestBase {
+
+    @Autowired
+    TestEntityManager em;
+
+    protected Student makeStudent(String studentId) {
+        Student s = new Student();
+        s.setStudentId(studentId);
+        return em.persistAndFlush(s);
+    }
+
+    protected StaffUser makeProfessor(String mail) {
+        StaffUser u = new StaffUser();
+        u.setMail(mail);
+        u.setPasswordHash("hash");
+        u.setRole(StaffUser.Role.Professor);
+        return em.persistAndFlush(u);
+    }
+
+    protected ProjectGroup makeGroup(String name, String termId, ProjectGroup.GroupStatus status) {
+        ProjectGroup g = new ProjectGroup();
+        g.setGroupName(name);
+        g.setTermId(termId);
+        g.setStatus(status);
+        g.setCreatedAt(LocalDateTime.now());
+        return em.persistAndFlush(g);
+    }
+
+    protected ProjectGroup makeGroupWithAdvisor(String name, String termId,
+            ProjectGroup.GroupStatus status, StaffUser advisor) {
+        ProjectGroup g = new ProjectGroup();
+        g.setGroupName(name);
+        g.setTermId(termId);
+        g.setStatus(status);
+        g.setCreatedAt(LocalDateTime.now());
+        g.setAdvisor(advisor);
+        return em.persistAndFlush(g);
+    }
+
+    protected GroupMembership makeMembership(ProjectGroup group, Student student,
+            GroupMembership.MemberRole role) {
+        GroupMembership m = new GroupMembership();
+        m.setGroup(group);
+        m.setStudent(student);
+        m.setRole(role);
+        m.setJoinedAt(LocalDateTime.now());
+        return em.persistAndFlush(m);
+    }
+
+    protected GroupInvitation makeInvitation(ProjectGroup group, Student invitee,
+            GroupInvitation.InvitationStatus status) {
+        GroupInvitation inv = new GroupInvitation();
+        inv.setGroup(group);
+        inv.setInvitee(invitee);
+        inv.setStatus(status);
+        inv.setSentAt(LocalDateTime.now());
+        return em.persistAndFlush(inv);
+    }
+
+    protected AdvisorRequest makeAdvisorRequest(ProjectGroup group, StaffUser advisor,
+            AdvisorRequest.RequestStatus status, LocalDateTime sentAt) {
+        AdvisorRequest req = new AdvisorRequest();
+        req.setGroup(group);
+        req.setAdvisor(advisor);
+        req.setStatus(status);
+        req.setSentAt(sentAt);
+        return em.persistAndFlush(req);
+    }
+
+    protected ScheduleWindow makeScheduleWindow(String termId, ScheduleWindow.WindowType type,
+            LocalDateTime opens, LocalDateTime closes) {
+        ScheduleWindow sw = new ScheduleWindow();
+        sw.setTermId(termId);
+        sw.setType(type);
+        sw.setOpensAt(opens);
+        sw.setClosesAt(closes);
+        return em.persistAndFlush(sw);
+    }
+
+    /** Clears the 1st-level cache so JPQL bulk updates are visible on re-fetch. */
+    protected void clearCache() {
+        em.flush();
+        em.getEntityManager().clear();
+    }
+}

--- a/backend/src/test/java/com/senior/spm/service/AdvisorServiceTest.java
+++ b/backend/src/test/java/com/senior/spm/service/AdvisorServiceTest.java
@@ -1,0 +1,545 @@
+package com.senior.spm.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.senior.spm.entity.AdvisorRequest;
+import com.senior.spm.entity.AdvisorRequest.RequestStatus;
+import com.senior.spm.entity.GroupMembership;
+import com.senior.spm.entity.GroupMembership.MemberRole;
+import com.senior.spm.entity.ProjectGroup;
+import com.senior.spm.entity.ProjectGroup.GroupStatus;
+import com.senior.spm.entity.StaffUser;
+import com.senior.spm.entity.Student;
+import com.senior.spm.exception.AdvisorAtCapacityException;
+import com.senior.spm.exception.ForbiddenException;
+import com.senior.spm.exception.RequestNotFoundException;
+import com.senior.spm.exception.RequestNotPendingException;
+import com.senior.spm.repository.AdvisorRequestRepository;
+import com.senior.spm.repository.ProjectGroupRepository;
+import com.senior.spm.repository.GroupMembershipRepository;
+import com.senior.spm.service.dto.AdvisorRequestDetail;
+import com.senior.spm.service.dto.AdvisorRequestSummary;
+import com.senior.spm.service.dto.AdvisorRespondResponse;
+
+@ExtendWith(MockitoExtension.class)
+class AdvisorServiceTest {
+
+    @Mock private AdvisorRequestRepository advisorRequestRepository;
+    @Mock private ProjectGroupRepository projectGroupRepository;
+    @Mock private GroupMembershipRepository groupMembershipRepository;
+    @Mock private TermConfigService termConfigService;
+
+    @InjectMocks
+    private AdvisorService advisorService;
+
+    // ── constants ──────────────────────────────────────────────────────────────
+
+    private static final String TERM_ID         = "2024-FALL";
+    private static final int    CAPACITY        = 5;
+    private static final UUID   PROFESSOR_ID    = UUID.randomUUID();
+    private static final UUID   OTHER_PROF_ID   = UUID.randomUUID();
+    private static final UUID   REQUEST_ID      = UUID.randomUUID();
+    private static final UUID   GROUP_ID        = UUID.randomUUID();
+
+    // ── shared fixtures ────────────────────────────────────────────────────────
+
+    private StaffUser professor;
+    private ProjectGroup group;
+    private AdvisorRequest pendingRequest;
+
+    @BeforeEach
+    void setUp() {
+        professor = new StaffUser();
+        professor.setId(PROFESSOR_ID);
+        professor.setAdvisorCapacity(CAPACITY);
+
+        group = new ProjectGroup();
+        group.setId(GROUP_ID);
+        group.setGroupName("TeamAlpha");
+        group.setTermId(TERM_ID);
+        group.setStatus(GroupStatus.TOOLS_BOUND);
+        group.setCreatedAt(LocalDateTime.now().minusDays(1));
+        group.setVersion(0L);
+        group.setMembers(List.of());
+
+        pendingRequest = new AdvisorRequest();
+        pendingRequest.setId(REQUEST_ID);
+        pendingRequest.setAdvisor(professor);
+        pendingRequest.setGroup(group);
+        pendingRequest.setStatus(RequestStatus.PENDING);
+        pendingRequest.setSentAt(LocalDateTime.now().minusHours(2));
+    }
+
+    // ══════════════════════════════════════════════════════════════════════════
+    //  getPendingRequestsForAdvisor
+    // ══════════════════════════════════════════════════════════════════════════
+
+    @Test
+    void getPendingRequests_twoRequests_returnsMappedSummaries() {
+        AdvisorRequest req2 = buildPendingRequest(UUID.randomUUID(), buildGroup(UUID.randomUUID(), "TeamBeta", 2));
+        when(advisorRequestRepository.findByAdvisorIdAndStatus(PROFESSOR_ID, RequestStatus.PENDING))
+                .thenReturn(List.of(pendingRequest, req2));
+
+        List<AdvisorRequestSummary> result = advisorService.getPendingRequestsForAdvisor(PROFESSOR_ID);
+
+        assertThat(result).hasSize(2);
+        AdvisorRequestSummary first = result.get(0);
+        assertThat(first.getRequestId()).isEqualTo(REQUEST_ID);
+        assertThat(first.getGroupId()).isEqualTo(GROUP_ID);
+        assertThat(first.getGroupName()).isEqualTo("TeamAlpha");
+        assertThat(first.getTermId()).isEqualTo(TERM_ID);
+        assertThat(first.getMemberCount()).isEqualTo(0);
+        assertThat(first.getSentAt()).isEqualTo(pendingRequest.getSentAt());
+    }
+
+    @Test
+    void getPendingRequests_noPendingRequests_returnsEmptyList() {
+        when(advisorRequestRepository.findByAdvisorIdAndStatus(PROFESSOR_ID, RequestStatus.PENDING))
+                .thenReturn(List.of());
+
+        List<AdvisorRequestSummary> result = advisorService.getPendingRequestsForAdvisor(PROFESSOR_ID);
+
+        assertThat(result).isNotNull().isEmpty();
+    }
+
+    @Test
+    void getPendingRequests_groupWithThreeMembers_memberCountIsThree() {
+        group.setMembers(List.of(
+                buildMembership(MemberRole.TEAM_LEADER),
+                buildMembership(MemberRole.MEMBER),
+                buildMembership(MemberRole.MEMBER)
+        ));
+        when(advisorRequestRepository.findByAdvisorIdAndStatus(PROFESSOR_ID, RequestStatus.PENDING))
+                .thenReturn(List.of(pendingRequest));
+        when(groupMembershipRepository.countByGroupId(GROUP_ID)).thenReturn(3L);
+
+        List<AdvisorRequestSummary> result = advisorService.getPendingRequestsForAdvisor(PROFESSOR_ID);
+
+        assertThat(result.get(0).getMemberCount()).isEqualTo(3);
+    }
+
+    // ══════════════════════════════════════════════════════════════════════════
+    //  getRequestDetail
+    // ══════════════════════════════════════════════════════════════════════════
+
+    @Test
+    void getRequestDetail_success_returnsDetailWithGroupAndMembers() {
+        Student student = buildStudent("22070006001");
+        GroupMembership membership = buildMembershipForStudent(student, MemberRole.TEAM_LEADER);
+        group.setMembers(List.of(membership));
+        when(advisorRequestRepository.findById(REQUEST_ID)).thenReturn(Optional.of(pendingRequest));
+
+        AdvisorRequestDetail result = advisorService.getRequestDetail(REQUEST_ID, PROFESSOR_ID);
+
+        assertThat(result.getRequestId()).isEqualTo(REQUEST_ID);
+        assertThat(result.getSentAt()).isEqualTo(pendingRequest.getSentAt());
+        assertThat(result.getGroup().getId()).isEqualTo(GROUP_ID);
+        assertThat(result.getGroup().getGroupName()).isEqualTo("TeamAlpha");
+        assertThat(result.getGroup().getTermId()).isEqualTo(TERM_ID);
+        assertThat(result.getGroup().getStatus()).isEqualTo(GroupStatus.TOOLS_BOUND);
+        assertThat(result.getGroup().getMembers()).hasSize(1);
+        assertThat(result.getGroup().getMembers().get(0).getStudentId()).isEqualTo("22070006001");
+        assertThat(result.getGroup().getMembers().get(0).getRole()).isEqualTo("TEAM_LEADER");
+    }
+
+    @Test
+    void getRequestDetail_requestNotFound_throwsRequestNotFoundException() {
+        when(advisorRequestRepository.findById(REQUEST_ID)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> advisorService.getRequestDetail(REQUEST_ID, PROFESSOR_ID))
+                .isInstanceOf(RequestNotFoundException.class)
+                .hasMessageContaining("not found");
+    }
+
+    @Test
+    void getRequestDetail_wrongProfessor_throwsForbiddenException() {
+        when(advisorRequestRepository.findById(REQUEST_ID)).thenReturn(Optional.of(pendingRequest));
+
+        assertThatThrownBy(() -> advisorService.getRequestDetail(REQUEST_ID, OTHER_PROF_ID))
+                .isInstanceOf(ForbiddenException.class)
+                .hasMessageContaining("not addressed to you");
+    }
+
+    @Test
+    void getRequestDetail_notFoundCheckFiresBeforeOwnershipCheck() {
+        // When the request doesn't exist, must get 404 regardless of professor ID
+        when(advisorRequestRepository.findById(REQUEST_ID)).thenReturn(Optional.empty());
+
+        // Use OTHER_PROF_ID — should still get RequestNotFoundException, not ForbiddenException
+        assertThatThrownBy(() -> advisorService.getRequestDetail(REQUEST_ID, OTHER_PROF_ID))
+                .isInstanceOf(RequestNotFoundException.class);
+    }
+
+    // ══════════════════════════════════════════════════════════════════════════
+    //  respondToRequest — REJECT path
+    // ══════════════════════════════════════════════════════════════════════════
+
+    @Test
+    void respondToRequest_reject_setsStatusRejectedAndRespondedAt() {
+        when(advisorRequestRepository.findById(REQUEST_ID)).thenReturn(Optional.of(pendingRequest));
+
+        advisorService.respondToRequest(REQUEST_ID, PROFESSOR_ID, false);
+
+        ArgumentCaptor<AdvisorRequest> captor = ArgumentCaptor.forClass(AdvisorRequest.class);
+        verify(advisorRequestRepository).save(captor.capture());
+        assertThat(captor.getValue().getStatus()).isEqualTo(RequestStatus.REJECTED);
+        assertThat(captor.getValue().getRespondedAt()).isNotNull();
+    }
+
+    @Test
+    void respondToRequest_reject_doesNotModifyGroupStatus() {
+        when(advisorRequestRepository.findById(REQUEST_ID)).thenReturn(Optional.of(pendingRequest));
+
+        advisorService.respondToRequest(REQUEST_ID, PROFESSOR_ID, false);
+
+        verify(projectGroupRepository, never()).save(any());
+        assertThat(group.getStatus()).isEqualTo(GroupStatus.TOOLS_BOUND);
+    }
+
+    @Test
+    void respondToRequest_reject_doesNotCallBulkUpdateStatusForGroup() {
+        when(advisorRequestRepository.findById(REQUEST_ID)).thenReturn(Optional.of(pendingRequest));
+
+        advisorService.respondToRequest(REQUEST_ID, PROFESSOR_ID, false);
+
+        verify(advisorRequestRepository, never()).bulkUpdateStatusForGroup(any(), any(), any());
+    }
+
+    @Test
+    void respondToRequest_reject_returnsDtoWithRejectedStatus() {
+        when(advisorRequestRepository.findById(REQUEST_ID)).thenReturn(Optional.of(pendingRequest));
+
+        AdvisorRespondResponse response = advisorService.respondToRequest(REQUEST_ID, PROFESSOR_ID, false);
+
+        assertThat(response.getRequestId()).isEqualTo(REQUEST_ID);
+        assertThat(response.getStatus()).isEqualTo(RequestStatus.REJECTED);
+        assertThat(response.getGroupId()).isNull();
+        assertThat(response.getGroupStatus()).isNull();
+    }
+
+    // ══════════════════════════════════════════════════════════════════════════
+    //  respondToRequest — shared guards (fire for both accept and reject)
+    // ══════════════════════════════════════════════════════════════════════════
+
+    @Test
+    void respondToRequest_requestNotFound_throwsRequestNotFoundException() {
+        when(advisorRequestRepository.findById(REQUEST_ID)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> advisorService.respondToRequest(REQUEST_ID, PROFESSOR_ID, true))
+                .isInstanceOf(RequestNotFoundException.class)
+                .hasMessageContaining("not found");
+
+        verify(advisorRequestRepository, never()).save(any());
+        verify(projectGroupRepository, never()).save(any());
+    }
+
+    @Test
+    void respondToRequest_wrongProfessor_throwsForbiddenException() {
+        when(advisorRequestRepository.findById(REQUEST_ID)).thenReturn(Optional.of(pendingRequest));
+
+        assertThatThrownBy(() -> advisorService.respondToRequest(REQUEST_ID, OTHER_PROF_ID, true))
+                .isInstanceOf(ForbiddenException.class)
+                .hasMessageContaining("not addressed to you");
+
+        verify(advisorRequestRepository, never()).save(any());
+        verify(projectGroupRepository, never()).save(any());
+    }
+
+    @Test
+    void respondToRequest_ownershipCheckFiresBeforeStatusCheck() {
+        // Set request to non-PENDING state AND wrong professor
+        // Must get ForbiddenException (ownership), NOT RequestNotPendingException
+        pendingRequest.setStatus(RequestStatus.REJECTED);
+        when(advisorRequestRepository.findById(REQUEST_ID)).thenReturn(Optional.of(pendingRequest));
+
+        assertThatThrownBy(() -> advisorService.respondToRequest(REQUEST_ID, OTHER_PROF_ID, true))
+                .isInstanceOf(ForbiddenException.class);
+    }
+
+    @Test
+    void respondToRequest_requestAlreadyRejected_throwsRequestNotPendingException() {
+        pendingRequest.setStatus(RequestStatus.REJECTED);
+        when(advisorRequestRepository.findById(REQUEST_ID)).thenReturn(Optional.of(pendingRequest));
+
+        assertThatThrownBy(() -> advisorService.respondToRequest(REQUEST_ID, PROFESSOR_ID, true))
+                .isInstanceOf(RequestNotPendingException.class)
+                .hasMessageContaining("no longer pending");
+    }
+
+    @Test
+    void respondToRequest_requestAutoRejected_throwsRequestNotPendingException() {
+        pendingRequest.setStatus(RequestStatus.AUTO_REJECTED);
+        when(advisorRequestRepository.findById(REQUEST_ID)).thenReturn(Optional.of(pendingRequest));
+
+        assertThatThrownBy(() -> advisorService.respondToRequest(REQUEST_ID, PROFESSOR_ID, true))
+                .isInstanceOf(RequestNotPendingException.class);
+    }
+
+    @Test
+    void respondToRequest_requestAlreadyAccepted_throwsRequestNotPendingException() {
+        pendingRequest.setStatus(RequestStatus.ACCEPTED);
+        when(advisorRequestRepository.findById(REQUEST_ID)).thenReturn(Optional.of(pendingRequest));
+
+        assertThatThrownBy(() -> advisorService.respondToRequest(REQUEST_ID, PROFESSOR_ID, true))
+                .isInstanceOf(RequestNotPendingException.class);
+    }
+
+    @Test
+    void respondToRequest_requestCancelled_throwsRequestNotPendingException() {
+        pendingRequest.setStatus(RequestStatus.CANCELLED);
+        when(advisorRequestRepository.findById(REQUEST_ID)).thenReturn(Optional.of(pendingRequest));
+
+        assertThatThrownBy(() -> advisorService.respondToRequest(REQUEST_ID, PROFESSOR_ID, true))
+                .isInstanceOf(RequestNotPendingException.class);
+    }
+
+    // ══════════════════════════════════════════════════════════════════════════
+    //  respondToRequest — ACCEPT path: capacity guard
+    // ══════════════════════════════════════════════════════════════════════════
+
+    @Test
+    void respondToRequest_accept_advisorAtExactCapacity_throwsAdvisorAtCapacityException() {
+        // capacity = 5, current = 5 → at limit
+        when(advisorRequestRepository.findById(REQUEST_ID)).thenReturn(Optional.of(pendingRequest));
+        when(termConfigService.getActiveTermId()).thenReturn(TERM_ID);
+        when(projectGroupRepository.countByAdvisorIdAndTermIdAndStatusNot(PROFESSOR_ID, TERM_ID, GroupStatus.DISBANDED))
+                .thenReturn((long) CAPACITY); // 5 >= 5
+
+        assertThatThrownBy(() -> advisorService.respondToRequest(REQUEST_ID, PROFESSOR_ID, true))
+                .isInstanceOf(AdvisorAtCapacityException.class)
+                .hasMessageContaining("maximum group capacity");
+    }
+
+    @Test
+    void respondToRequest_accept_advisorOverCapacity_throwsAdvisorAtCapacityException() {
+        // capacity = 5, current = 6 → over limit (edge case overflow)
+        when(advisorRequestRepository.findById(REQUEST_ID)).thenReturn(Optional.of(pendingRequest));
+        when(termConfigService.getActiveTermId()).thenReturn(TERM_ID);
+        when(projectGroupRepository.countByAdvisorIdAndTermIdAndStatusNot(PROFESSOR_ID, TERM_ID, GroupStatus.DISBANDED))
+                .thenReturn((long) CAPACITY + 1);
+
+        assertThatThrownBy(() -> advisorService.respondToRequest(REQUEST_ID, PROFESSOR_ID, true))
+                .isInstanceOf(AdvisorAtCapacityException.class);
+    }
+
+    @Test
+    void respondToRequest_accept_atCapacity_requestStaysPending() {
+        // P3 rule #1: request must NOT be auto-rejected when advisor is at capacity
+        when(advisorRequestRepository.findById(REQUEST_ID)).thenReturn(Optional.of(pendingRequest));
+        when(termConfigService.getActiveTermId()).thenReturn(TERM_ID);
+        when(projectGroupRepository.countByAdvisorIdAndTermIdAndStatusNot(PROFESSOR_ID, TERM_ID, GroupStatus.DISBANDED))
+                .thenReturn((long) CAPACITY);
+
+        assertThatThrownBy(() -> advisorService.respondToRequest(REQUEST_ID, PROFESSOR_ID, true))
+                .isInstanceOf(AdvisorAtCapacityException.class);
+
+        // Request must not be saved (stays PENDING — advisor can accept later if load drops)
+        verify(advisorRequestRepository, never()).save(any());
+        verify(projectGroupRepository, never()).save(any());
+    }
+
+    @Test
+    void respondToRequest_accept_atCapacity_groupNotModified() {
+        when(advisorRequestRepository.findById(REQUEST_ID)).thenReturn(Optional.of(pendingRequest));
+        when(termConfigService.getActiveTermId()).thenReturn(TERM_ID);
+        when(projectGroupRepository.countByAdvisorIdAndTermIdAndStatusNot(PROFESSOR_ID, TERM_ID, GroupStatus.DISBANDED))
+                .thenReturn((long) CAPACITY);
+
+        assertThatThrownBy(() -> advisorService.respondToRequest(REQUEST_ID, PROFESSOR_ID, true))
+                .isInstanceOf(AdvisorAtCapacityException.class);
+
+        assertThat(group.getStatus()).isEqualTo(GroupStatus.TOOLS_BOUND);
+        assertThat(group.getAdvisor()).isNull();
+    }
+
+    @Test
+    void respondToRequest_accept_oneBelowCapacity_succeeds() {
+        // capacity = 5, current = 4 → one slot available
+        when(advisorRequestRepository.findById(REQUEST_ID)).thenReturn(Optional.of(pendingRequest));
+        when(termConfigService.getActiveTermId()).thenReturn(TERM_ID);
+        when(projectGroupRepository.countByAdvisorIdAndTermIdAndStatusNot(PROFESSOR_ID, TERM_ID, GroupStatus.DISBANDED))
+                .thenReturn((long) CAPACITY - 1); // 4 < 5
+
+        advisorService.respondToRequest(REQUEST_ID, PROFESSOR_ID, true);
+
+        verify(projectGroupRepository).save(group);
+    }
+
+    @Test
+    void respondToRequest_accept_capacityQueryExcludesDisbandedGroups() {
+        // The query MUST use StatusNot(DISBANDED), not plain countByAdvisorIdAndTermId
+        when(advisorRequestRepository.findById(REQUEST_ID)).thenReturn(Optional.of(pendingRequest));
+        when(termConfigService.getActiveTermId()).thenReturn(TERM_ID);
+        when(projectGroupRepository.countByAdvisorIdAndTermIdAndStatusNot(PROFESSOR_ID, TERM_ID, GroupStatus.DISBANDED))
+                .thenReturn(0L);
+
+        advisorService.respondToRequest(REQUEST_ID, PROFESSOR_ID, true);
+
+        verify(projectGroupRepository).countByAdvisorIdAndTermIdAndStatusNot(
+                PROFESSOR_ID, TERM_ID, GroupStatus.DISBANDED);
+    }
+
+    @Test
+    void respondToRequest_accept_capacityQueryUsesActiveTermFromTermConfigService() {
+        String differentTerm = "2025-SPRING";
+        when(advisorRequestRepository.findById(REQUEST_ID)).thenReturn(Optional.of(pendingRequest));
+        when(termConfigService.getActiveTermId()).thenReturn(differentTerm);
+        when(projectGroupRepository.countByAdvisorIdAndTermIdAndStatusNot(PROFESSOR_ID, differentTerm, GroupStatus.DISBANDED))
+                .thenReturn(0L);
+
+        advisorService.respondToRequest(REQUEST_ID, PROFESSOR_ID, true);
+
+        verify(termConfigService).getActiveTermId();
+        verify(projectGroupRepository).countByAdvisorIdAndTermIdAndStatusNot(
+                eq(PROFESSOR_ID), eq(differentTerm), eq(GroupStatus.DISBANDED));
+    }
+
+    // ══════════════════════════════════════════════════════════════════════════
+    //  respondToRequest — ACCEPT path: happy path writes
+    // ══════════════════════════════════════════════════════════════════════════
+
+    @Test
+    void respondToRequest_accept_setsRequestStatusAcceptedAndRespondedAt() {
+        stubAcceptPrereqs();
+
+        advisorService.respondToRequest(REQUEST_ID, PROFESSOR_ID, true);
+
+        ArgumentCaptor<AdvisorRequest> captor = ArgumentCaptor.forClass(AdvisorRequest.class);
+        verify(advisorRequestRepository).save(captor.capture());
+        assertThat(captor.getValue().getStatus()).isEqualTo(RequestStatus.ACCEPTED);
+        assertThat(captor.getValue().getRespondedAt()).isNotNull();
+    }
+
+    @Test
+    void respondToRequest_accept_setsGroupAdvisorToProfessor() {
+        stubAcceptPrereqs();
+
+        advisorService.respondToRequest(REQUEST_ID, PROFESSOR_ID, true);
+
+        ArgumentCaptor<ProjectGroup> captor = ArgumentCaptor.forClass(ProjectGroup.class);
+        verify(projectGroupRepository).save(captor.capture());
+        assertThat(captor.getValue().getAdvisor()).isEqualTo(professor);
+    }
+
+    @Test
+    void respondToRequest_accept_setsGroupStatusToAdvisorAssigned() {
+        stubAcceptPrereqs();
+
+        advisorService.respondToRequest(REQUEST_ID, PROFESSOR_ID, true);
+
+        ArgumentCaptor<ProjectGroup> captor = ArgumentCaptor.forClass(ProjectGroup.class);
+        verify(projectGroupRepository).save(captor.capture());
+        assertThat(captor.getValue().getStatus()).isEqualTo(GroupStatus.ADVISOR_ASSIGNED);
+    }
+
+    @Test
+    void respondToRequest_accept_bulkAutoRejectsOtherPendingRequestsForSameGroup() {
+        stubAcceptPrereqs();
+
+        advisorService.respondToRequest(REQUEST_ID, PROFESSOR_ID, true);
+
+        // Must pass AUTO_REJECTED, group's ID, and exclude the accepted request
+        verify(advisorRequestRepository).bulkUpdateStatusForGroup(
+                eq(RequestStatus.AUTO_REJECTED),
+                eq(GROUP_ID),
+                eq(REQUEST_ID)
+        );
+    }
+
+    @Test
+    void respondToRequest_accept_returnsCorrectDto() {
+        stubAcceptPrereqs();
+
+        AdvisorRespondResponse response = advisorService.respondToRequest(REQUEST_ID, PROFESSOR_ID, true);
+
+        assertThat(response.getRequestId()).isEqualTo(REQUEST_ID);
+        assertThat(response.getStatus()).isEqualTo(RequestStatus.ACCEPTED);
+        assertThat(response.getGroupId()).isEqualTo(GROUP_ID);
+        assertThat(response.getGroupStatus()).isEqualTo(GroupStatus.ADVISOR_ASSIGNED);
+    }
+
+    // ══════════════════════════════════════════════════════════════════════════
+    //  helpers
+    // ══════════════════════════════════════════════════════════════════════════
+
+    /** Stubs the happy-path prerequisites for an accept (capacity = 0 active groups). */
+    private void stubAcceptPrereqs() {
+        when(advisorRequestRepository.findById(REQUEST_ID)).thenReturn(Optional.of(pendingRequest));
+        when(termConfigService.getActiveTermId()).thenReturn(TERM_ID);
+        when(projectGroupRepository.countByAdvisorIdAndTermIdAndStatusNot(PROFESSOR_ID, TERM_ID, GroupStatus.DISBANDED))
+                .thenReturn(0L);
+    }
+
+    private ProjectGroup buildGroup(UUID id, String name, int memberCount) {
+        ProjectGroup g = new ProjectGroup();
+        g.setId(id);
+        g.setGroupName(name);
+        g.setTermId(TERM_ID);
+        g.setStatus(GroupStatus.TOOLS_BOUND);
+        g.setCreatedAt(LocalDateTime.now().minusDays(1));
+        g.setVersion(0L);
+        List<GroupMembership> members = new java.util.ArrayList<>();
+        for (int i = 0; i < memberCount; i++) {
+            members.add(buildMembership(MemberRole.MEMBER));
+        }
+        g.setMembers(members);
+        return g;
+    }
+
+    private AdvisorRequest buildPendingRequest(UUID requestId, ProjectGroup g) {
+        AdvisorRequest r = new AdvisorRequest();
+        r.setId(requestId);
+        r.setAdvisor(professor);
+        r.setGroup(g);
+        r.setStatus(RequestStatus.PENDING);
+        r.setSentAt(LocalDateTime.now().minusHours(1));
+        return r;
+    }
+
+    private GroupMembership buildMembership(MemberRole role) {
+        GroupMembership m = new GroupMembership();
+        m.setId(UUID.randomUUID());
+        m.setRole(role);
+        m.setJoinedAt(LocalDateTime.now().minusDays(1));
+        Student s = new Student();
+        s.setId(UUID.randomUUID());
+        s.setStudentId("2207000" + UUID.randomUUID().toString().substring(0, 4));
+        m.setStudent(s);
+        return m;
+    }
+
+    private GroupMembership buildMembershipForStudent(Student student, MemberRole role) {
+        GroupMembership m = new GroupMembership();
+        m.setId(UUID.randomUUID());
+        m.setRole(role);
+        m.setJoinedAt(LocalDateTime.now().minusDays(1));
+        m.setStudent(student);
+        return m;
+    }
+
+    private Student buildStudent(String studentId) {
+        Student s = new Student();
+        s.setId(UUID.randomUUID());
+        s.setStudentId(studentId);
+        return s;
+    }
+}

--- a/backend/src/test/java/com/senior/spm/service/GitHubValidationServiceTest.java
+++ b/backend/src/test/java/com/senior/spm/service/GitHubValidationServiceTest.java
@@ -1,0 +1,175 @@
+package com.senior.spm.service;
+
+import static org.assertj.core.api.Assertions.assertThatNoException;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.client.ResourceAccessException;
+import org.springframework.web.client.RestTemplate;
+
+import com.senior.spm.exception.ExternalToolValidationException;
+import com.senior.spm.exception.GitHubValidationException;
+
+@ExtendWith(MockitoExtension.class)
+class GitHubValidationServiceTest {
+
+    @Mock
+    private RestTemplate restTemplate;
+
+    @InjectMocks
+    private GitHubValidationService service;
+
+    private static final String ORG_NAME = "my-org";
+    private static final String PAT = "ghp_testtoken";
+    private static final String STEP1_URL = "https://api.github.com/orgs/" + ORG_NAME;
+    private static final String STEP2_URL = "https://api.github.com/orgs/" + ORG_NAME + "/repos?per_page=1";
+
+    // ── Happy path ───────────────────────────────────────────────────────────
+
+    @Test
+    void validate_success_whenBothCallsReturn200() {
+        when(restTemplate.exchange(eq(STEP1_URL), eq(HttpMethod.GET), any(HttpEntity.class), eq(Void.class)))
+                .thenReturn(new ResponseEntity<>(HttpStatus.OK));
+        when(restTemplate.exchange(eq(STEP2_URL), eq(HttpMethod.GET), any(HttpEntity.class), eq(Void.class)))
+                .thenReturn(new ResponseEntity<>(HttpStatus.OK));
+
+        assertThatNoException().isThrownBy(() -> service.validate(ORG_NAME, PAT));
+
+        verify(restTemplate).exchange(eq(STEP1_URL), eq(HttpMethod.GET), any(HttpEntity.class), eq(Void.class));
+        verify(restTemplate).exchange(eq(STEP2_URL), eq(HttpMethod.GET), any(HttpEntity.class), eq(Void.class));
+    }
+
+    // ── Step 1 failures — fail-fast: Step 2 must never be called ─────────
+
+    @Test
+    void validate_throwsInvalidPat_whenStep1Returns401() {
+        when(restTemplate.exchange(eq(STEP1_URL), eq(HttpMethod.GET), any(HttpEntity.class), eq(Void.class)))
+                .thenThrow(new HttpClientErrorException(HttpStatus.UNAUTHORIZED));
+
+        assertThatThrownBy(() -> service.validate(ORG_NAME, PAT))
+                .isInstanceOf(GitHubValidationException.class)
+                .hasMessage("GitHub validation failed: PAT is invalid or expired");
+
+        verify(restTemplate, never()).exchange(eq(STEP2_URL), eq(HttpMethod.GET), any(HttpEntity.class), eq(Void.class));
+    }
+
+    @Test
+    void validate_throwsOrgNotFound_whenStep1Returns404() {
+        when(restTemplate.exchange(eq(STEP1_URL), eq(HttpMethod.GET), any(HttpEntity.class), eq(Void.class)))
+                .thenThrow(new HttpClientErrorException(HttpStatus.NOT_FOUND));
+
+        assertThatThrownBy(() -> service.validate(ORG_NAME, PAT))
+                .isInstanceOf(GitHubValidationException.class)
+                .hasMessage("GitHub validation failed: Organization 'my-org' not found");
+
+        verify(restTemplate, never()).exchange(eq(STEP2_URL), eq(HttpMethod.GET), any(HttpEntity.class), eq(Void.class));
+    }
+
+    @Test
+    void validate_throwsInvalidPat_whenStep1ReturnsOther4xx() {
+        when(restTemplate.exchange(eq(STEP1_URL), eq(HttpMethod.GET), any(HttpEntity.class), eq(Void.class)))
+                .thenThrow(new HttpClientErrorException(HttpStatus.BAD_REQUEST));
+
+        assertThatThrownBy(() -> service.validate(ORG_NAME, PAT))
+                .isInstanceOf(GitHubValidationException.class)
+                .hasMessage("GitHub validation failed: PAT is invalid or expired");
+
+        verify(restTemplate, never()).exchange(eq(STEP2_URL), eq(HttpMethod.GET), any(HttpEntity.class), eq(Void.class));
+    }
+
+    @Test
+    void validate_throwsInvalidPat_whenStep1TimesOut() {
+        when(restTemplate.exchange(eq(STEP1_URL), eq(HttpMethod.GET), any(HttpEntity.class), eq(Void.class)))
+                .thenThrow(new ResourceAccessException("Connection timed out"));
+
+        assertThatThrownBy(() -> service.validate(ORG_NAME, PAT))
+                .isInstanceOf(GitHubValidationException.class)
+                .hasMessage("GitHub validation failed: PAT is invalid or expired");
+
+        verify(restTemplate, never()).exchange(eq(STEP2_URL), eq(HttpMethod.GET), any(HttpEntity.class), eq(Void.class));
+    }
+
+    // ── Step 2 failures (Step 1 always succeeds) ─────────────────────────
+
+    @Test
+    void validate_throwsLacksRepoScope_whenStep2Returns403() {
+        when(restTemplate.exchange(eq(STEP1_URL), eq(HttpMethod.GET), any(HttpEntity.class), eq(Void.class)))
+                .thenReturn(new ResponseEntity<>(HttpStatus.OK));
+        when(restTemplate.exchange(eq(STEP2_URL), eq(HttpMethod.GET), any(HttpEntity.class), eq(Void.class)))
+                .thenThrow(new HttpClientErrorException(HttpStatus.FORBIDDEN));
+
+        assertThatThrownBy(() -> service.validate(ORG_NAME, PAT))
+                .isInstanceOf(GitHubValidationException.class)
+                .hasMessage("GitHub validation failed: PAT lacks required 'repo' scope");
+    }
+
+    @Test
+    void validate_throwsLacksRepoScope_whenStep2ReturnsOther4xx() {
+        when(restTemplate.exchange(eq(STEP1_URL), eq(HttpMethod.GET), any(HttpEntity.class), eq(Void.class)))
+                .thenReturn(new ResponseEntity<>(HttpStatus.OK));
+        when(restTemplate.exchange(eq(STEP2_URL), eq(HttpMethod.GET), any(HttpEntity.class), eq(Void.class)))
+                .thenThrow(new HttpClientErrorException(HttpStatus.BAD_REQUEST));
+
+        assertThatThrownBy(() -> service.validate(ORG_NAME, PAT))
+                .isInstanceOf(GitHubValidationException.class)
+                .hasMessage("GitHub validation failed: PAT lacks required 'repo' scope");
+    }
+
+    @Test
+    void validate_throwsLacksRepoScope_whenStep2TimesOut() {
+        when(restTemplate.exchange(eq(STEP1_URL), eq(HttpMethod.GET), any(HttpEntity.class), eq(Void.class)))
+                .thenReturn(new ResponseEntity<>(HttpStatus.OK));
+        when(restTemplate.exchange(eq(STEP2_URL), eq(HttpMethod.GET), any(HttpEntity.class), eq(Void.class)))
+                .thenThrow(new ResourceAccessException("Connection timed out"));
+
+        assertThatThrownBy(() -> service.validate(ORG_NAME, PAT))
+                .isInstanceOf(GitHubValidationException.class)
+                .hasMessage("GitHub validation failed: PAT lacks required 'repo' scope");
+    }
+
+    // ── Exception hierarchy — GlobalExceptionHandler relies on this ───────
+
+    @Test
+    void validate_throwsExternalToolValidationException_onFailure() {
+        // GitHubValidationException must extend ExternalToolValidationException so that
+        // GlobalExceptionHandler.handleExternalToolValidation() catches it and returns 422.
+        when(restTemplate.exchange(eq(STEP1_URL), eq(HttpMethod.GET), any(HttpEntity.class), eq(Void.class)))
+                .thenThrow(new HttpClientErrorException(HttpStatus.UNAUTHORIZED));
+
+        assertThatThrownBy(() -> service.validate(ORG_NAME, PAT))
+                .isInstanceOf(ExternalToolValidationException.class);
+    }
+
+    // ── Authorization header ──────────────────────────────────────────────
+
+    @SuppressWarnings("unchecked")
+    @Test
+    void validate_setsBearerHeader() {
+        when(restTemplate.exchange(eq(STEP1_URL), eq(HttpMethod.GET), any(HttpEntity.class), eq(Void.class)))
+                .thenReturn(new ResponseEntity<>(HttpStatus.OK));
+        when(restTemplate.exchange(eq(STEP2_URL), eq(HttpMethod.GET), any(HttpEntity.class), eq(Void.class)))
+                .thenReturn(new ResponseEntity<>(HttpStatus.OK));
+
+        service.validate(ORG_NAME, PAT);
+
+        ArgumentCaptor<HttpEntity<Void>> captor = ArgumentCaptor.forClass(HttpEntity.class);
+        verify(restTemplate).exchange(eq(STEP1_URL), eq(HttpMethod.GET), captor.capture(), eq(Void.class));
+        String authHeader = captor.getValue().getHeaders().getFirst("Authorization");
+        org.assertj.core.api.Assertions.assertThat(authHeader).isEqualTo("Bearer " + PAT);
+    }
+}

--- a/backend/src/test/java/com/senior/spm/service/GroupServiceTest.java
+++ b/backend/src/test/java/com/senior/spm/service/GroupServiceTest.java
@@ -1,0 +1,232 @@
+package com.senior.spm.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.senior.spm.controller.dto.GroupDetailResponse;
+import com.senior.spm.entity.GroupMembership;
+import com.senior.spm.entity.GroupMembership.MemberRole;
+import com.senior.spm.entity.ProjectGroup;
+import com.senior.spm.entity.ProjectGroup.GroupStatus;
+import com.senior.spm.entity.ScheduleWindow;
+import com.senior.spm.entity.ScheduleWindow.WindowType;
+import com.senior.spm.entity.Student;
+import com.senior.spm.exception.AlreadyInGroupException;
+import com.senior.spm.exception.DuplicateGroupNameException;
+import com.senior.spm.exception.ScheduleWindowClosedException;
+import com.senior.spm.repository.GroupMembershipRepository;
+import com.senior.spm.repository.ProjectGroupRepository;
+import com.senior.spm.repository.ScheduleWindowRepository;
+import com.senior.spm.repository.StudentRepository;
+
+@ExtendWith(MockitoExtension.class)
+class GroupServiceTest {
+
+    @Mock private ScheduleWindowRepository scheduleWindowRepository;
+    @Mock private ProjectGroupRepository projectGroupRepository;
+    @Mock private GroupMembershipRepository groupMembershipRepository;
+    @Mock private StudentRepository studentRepository;
+    @Mock private TermConfigService termConfigService;
+
+    @InjectMocks
+    private GroupService groupService;
+
+    private static final String TERM_ID = "2024-FALL";
+    private static final UUID STUDENT_ID = UUID.randomUUID();
+    private static final String GROUP_NAME = "TeamAlpha";
+
+    private ScheduleWindow openWindow;
+    private Student student;
+    private ProjectGroup savedGroup;
+
+    @BeforeEach
+    void setUp() {
+        openWindow = new ScheduleWindow();
+        openWindow.setId(UUID.randomUUID());
+        openWindow.setType(WindowType.GROUP_CREATION);
+        openWindow.setTermId(TERM_ID);
+        openWindow.setOpensAt(LocalDateTime.now().minusDays(1));
+        openWindow.setClosesAt(LocalDateTime.now().plusDays(1));
+
+        student = new Student();
+        student.setId(STUDENT_ID);
+
+        savedGroup = new ProjectGroup();
+        savedGroup.setId(UUID.randomUUID());
+        savedGroup.setGroupName(GROUP_NAME);
+        savedGroup.setTermId(TERM_ID);
+        savedGroup.setStatus(GroupStatus.FORMING);
+        savedGroup.setCreatedAt(LocalDateTime.now());
+    }
+
+    // ── createGroup ────────────────────────────────────────────────────────────
+
+    @Test
+    void createGroup_success_returnsGroupDetailResponse() {
+        when(termConfigService.getActiveTermId()).thenReturn(TERM_ID);
+        when(scheduleWindowRepository.findByTermIdAndType(TERM_ID, WindowType.GROUP_CREATION))
+                .thenReturn(Optional.of(openWindow));
+        when(groupMembershipRepository.existsByStudentId(STUDENT_ID)).thenReturn(false);
+        when(projectGroupRepository.existsByGroupNameAndTermId(GROUP_NAME, TERM_ID)).thenReturn(false);
+        when(projectGroupRepository.save(any())).thenReturn(savedGroup);
+        when(studentRepository.findById(STUDENT_ID)).thenReturn(Optional.of(student));
+        when(groupMembershipRepository.save(any())).thenReturn(new GroupMembership());
+        when(groupMembershipRepository.findByGroupId(savedGroup.getId())).thenReturn(List.of());
+
+        GroupDetailResponse response = groupService.createGroup(GROUP_NAME, STUDENT_ID);
+
+        assertThat(response.getGroupName()).isEqualTo(GROUP_NAME);
+        assertThat(response.getTermId()).isEqualTo(TERM_ID);
+        assertThat(response.getStatus()).isEqualTo("FORMING");
+    }
+
+    @Test
+    void createGroup_savesGroupWithFormingStatus() {
+        when(termConfigService.getActiveTermId()).thenReturn(TERM_ID);
+        when(scheduleWindowRepository.findByTermIdAndType(TERM_ID, WindowType.GROUP_CREATION))
+                .thenReturn(Optional.of(openWindow));
+        when(groupMembershipRepository.existsByStudentId(STUDENT_ID)).thenReturn(false);
+        when(projectGroupRepository.existsByGroupNameAndTermId(GROUP_NAME, TERM_ID)).thenReturn(false);
+        when(projectGroupRepository.save(any())).thenReturn(savedGroup);
+        when(studentRepository.findById(STUDENT_ID)).thenReturn(Optional.of(student));
+        when(groupMembershipRepository.save(any())).thenReturn(new GroupMembership());
+        when(groupMembershipRepository.findByGroupId(any())).thenReturn(List.of());
+
+        groupService.createGroup(GROUP_NAME, STUDENT_ID);
+
+        ArgumentCaptor<ProjectGroup> captor = ArgumentCaptor.forClass(ProjectGroup.class);
+        verify(projectGroupRepository).save(captor.capture());
+        assertThat(captor.getValue().getStatus()).isEqualTo(GroupStatus.FORMING);
+        assertThat(captor.getValue().getGroupName()).isEqualTo(GROUP_NAME);
+        assertThat(captor.getValue().getTermId()).isEqualTo(TERM_ID);
+    }
+
+    @Test
+    void createGroup_savesTeamLeaderMembership() {
+        when(termConfigService.getActiveTermId()).thenReturn(TERM_ID);
+        when(scheduleWindowRepository.findByTermIdAndType(TERM_ID, WindowType.GROUP_CREATION))
+                .thenReturn(Optional.of(openWindow));
+        when(groupMembershipRepository.existsByStudentId(STUDENT_ID)).thenReturn(false);
+        when(projectGroupRepository.existsByGroupNameAndTermId(GROUP_NAME, TERM_ID)).thenReturn(false);
+        when(projectGroupRepository.save(any())).thenReturn(savedGroup);
+        when(studentRepository.findById(STUDENT_ID)).thenReturn(Optional.of(student));
+        when(groupMembershipRepository.save(any())).thenReturn(new GroupMembership());
+        when(groupMembershipRepository.findByGroupId(any())).thenReturn(List.of());
+
+        groupService.createGroup(GROUP_NAME, STUDENT_ID);
+
+        ArgumentCaptor<GroupMembership> captor = ArgumentCaptor.forClass(GroupMembership.class);
+        verify(groupMembershipRepository).save(captor.capture());
+        assertThat(captor.getValue().getRole()).isEqualTo(MemberRole.TEAM_LEADER);
+        assertThat(captor.getValue().getStudent()).isEqualTo(student);
+    }
+
+    @Test
+    void createGroup_windowNotFound_throwsScheduleWindowClosedException() {
+        when(termConfigService.getActiveTermId()).thenReturn(TERM_ID);
+        when(scheduleWindowRepository.findByTermIdAndType(TERM_ID, WindowType.GROUP_CREATION))
+                .thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> groupService.createGroup(GROUP_NAME, STUDENT_ID))
+                .isInstanceOf(ScheduleWindowClosedException.class)
+                .hasMessageContaining("not currently active");
+
+        verify(projectGroupRepository, never()).save(any());
+    }
+
+    @Test
+    void createGroup_windowExpired_throwsScheduleWindowClosedException() {
+        openWindow.setClosesAt(LocalDateTime.now().minusHours(1)); // already closed
+
+        when(termConfigService.getActiveTermId()).thenReturn(TERM_ID);
+        when(scheduleWindowRepository.findByTermIdAndType(TERM_ID, WindowType.GROUP_CREATION))
+                .thenReturn(Optional.of(openWindow));
+
+        assertThatThrownBy(() -> groupService.createGroup(GROUP_NAME, STUDENT_ID))
+                .isInstanceOf(ScheduleWindowClosedException.class);
+
+        verify(projectGroupRepository, never()).save(any());
+    }
+
+    @Test
+    void createGroup_studentAlreadyInGroup_throwsAlreadyInGroupException() {
+        when(termConfigService.getActiveTermId()).thenReturn(TERM_ID);
+        when(scheduleWindowRepository.findByTermIdAndType(TERM_ID, WindowType.GROUP_CREATION))
+                .thenReturn(Optional.of(openWindow));
+        when(groupMembershipRepository.existsByStudentId(STUDENT_ID)).thenReturn(true);
+
+        assertThatThrownBy(() -> groupService.createGroup(GROUP_NAME, STUDENT_ID))
+                .isInstanceOf(AlreadyInGroupException.class)
+                .hasMessageContaining("already a member");
+
+        verify(projectGroupRepository, never()).save(any());
+    }
+
+    @Test
+    void createGroup_duplicateGroupName_throwsDuplicateGroupNameException() {
+        when(termConfigService.getActiveTermId()).thenReturn(TERM_ID);
+        when(scheduleWindowRepository.findByTermIdAndType(TERM_ID, WindowType.GROUP_CREATION))
+                .thenReturn(Optional.of(openWindow));
+        when(groupMembershipRepository.existsByStudentId(STUDENT_ID)).thenReturn(false);
+        when(projectGroupRepository.existsByGroupNameAndTermId(GROUP_NAME, TERM_ID)).thenReturn(true);
+
+        assertThatThrownBy(() -> groupService.createGroup(GROUP_NAME, STUDENT_ID))
+                .isInstanceOf(DuplicateGroupNameException.class)
+                .hasMessageContaining(GROUP_NAME);
+
+        verify(projectGroupRepository, never()).save(any());
+    }
+
+    // ── getMyGroup ─────────────────────────────────────────────────────────────
+
+    @Test
+    void getMyGroup_success_returnsGroupDetailResponse() {
+        GroupMembership membership = new GroupMembership();
+        membership.setStudent(student);
+        membership.setRole(MemberRole.TEAM_LEADER);
+        membership.setJoinedAt(LocalDateTime.now());
+        membership.setGroup(savedGroup);
+
+        when(groupMembershipRepository.findByStudentId(STUDENT_ID))
+                .thenReturn(Optional.of(membership));
+        when(projectGroupRepository.findById(savedGroup.getId()))
+                .thenReturn(Optional.of(savedGroup));
+        when(groupMembershipRepository.findByGroupId(savedGroup.getId()))
+                .thenReturn(List.of(membership));
+
+        GroupDetailResponse response = groupService.getMyGroup(STUDENT_ID);
+
+        assertThat(response.getId()).isEqualTo(savedGroup.getId());
+        assertThat(response.getGroupName()).isEqualTo(GROUP_NAME);
+        assertThat(response.getMembers()).hasSize(1);
+        assertThat(response.getMembers().get(0).getRole()).isEqualTo("TEAM_LEADER");
+    }
+
+    @Test
+    void getMyGroup_noMembership_throwsRuntimeException() {
+        when(groupMembershipRepository.findByStudentId(STUDENT_ID))
+                .thenReturn(Optional.empty());
+
+        // Currently throws RuntimeException — should be GroupNotFoundException (follow-up fix)
+        assertThatThrownBy(() -> groupService.getMyGroup(STUDENT_ID))
+                .isInstanceOf(RuntimeException.class)
+                .hasMessageContaining("not a member");
+    }
+}

--- a/backend/src/test/java/com/senior/spm/service/GroupServiceTest.java
+++ b/backend/src/test/java/com/senior/spm/service/GroupServiceTest.java
@@ -153,7 +153,7 @@ class GroupServiceTest {
 
     @Test
     void createGroup_windowExpired_throwsScheduleWindowClosedException() {
-        openWindow.setClosesAt(LocalDateTime.now().minusHours(1)); // already closed
+        openWindow.setClosesAt(LocalDateTime.now(java.time.ZoneOffset.UTC).minusHours(1)); // already closed in UTC
 
         when(termConfigService.getActiveTermId()).thenReturn(TERM_ID);
         when(scheduleWindowRepository.findByTermIdAndType(TERM_ID, WindowType.GROUP_CREATION))

--- a/backend/src/test/java/com/senior/spm/service/GroupServiceTest.java
+++ b/backend/src/test/java/com/senior/spm/service/GroupServiceTest.java
@@ -30,6 +30,7 @@ import com.senior.spm.entity.ScheduleWindow.WindowType;
 import com.senior.spm.entity.Student;
 import com.senior.spm.exception.AlreadyInGroupException;
 import com.senior.spm.exception.DuplicateGroupNameException;
+import com.senior.spm.exception.NotInGroupException;
 import com.senior.spm.exception.ScheduleWindowClosedException;
 import com.senior.spm.repository.GroupMembershipRepository;
 import com.senior.spm.repository.ProjectGroupRepository;
@@ -119,6 +120,56 @@ class GroupServiceTest {
     }
 
     @Test
+    void createGroup_termIdAlwaysFromTermConfigService_neverFromClient() {
+        // Architecture rule (CLAUDE.md): termId is NEVER from the request body.
+        // Verify TermConfigService is called and its value stamps the saved group.
+        when(termConfigService.getActiveTermId()).thenReturn(TERM_ID);
+        when(scheduleWindowRepository.findByTermIdAndType(TERM_ID, WindowType.GROUP_CREATION))
+                .thenReturn(Optional.of(openWindow));
+        when(groupMembershipRepository.existsByStudentId(STUDENT_ID)).thenReturn(false);
+        when(projectGroupRepository.existsByGroupNameAndTermId(GROUP_NAME, TERM_ID)).thenReturn(false);
+        when(projectGroupRepository.save(any())).thenReturn(savedGroup);
+        when(studentRepository.findById(STUDENT_ID)).thenReturn(Optional.of(student));
+        when(groupMembershipRepository.save(any())).thenReturn(new GroupMembership());
+        when(groupMembershipRepository.findByGroupId(any())).thenReturn(List.of());
+
+        groupService.createGroup(GROUP_NAME, STUDENT_ID);
+
+        verify(termConfigService).getActiveTermId();
+        ArgumentCaptor<ProjectGroup> captor = ArgumentCaptor.forClass(ProjectGroup.class);
+        verify(projectGroupRepository).save(captor.capture());
+        assertThat(captor.getValue().getTermId()).isEqualTo(TERM_ID);
+    }
+
+    @Test
+    void createGroup_responseIncludesTeamLeaderInMembers() {
+        // Sequence 2.1: response must include members:[{studentId, role:"TEAM_LEADER"}]
+        student.setStudentId("23070006036");
+
+        GroupMembership savedMembership = new GroupMembership();
+        savedMembership.setStudent(student);
+        savedMembership.setRole(MemberRole.TEAM_LEADER);
+        savedMembership.setJoinedAt(LocalDateTime.now());
+        savedMembership.setGroup(savedGroup);
+
+        when(termConfigService.getActiveTermId()).thenReturn(TERM_ID);
+        when(scheduleWindowRepository.findByTermIdAndType(TERM_ID, WindowType.GROUP_CREATION))
+                .thenReturn(Optional.of(openWindow));
+        when(groupMembershipRepository.existsByStudentId(STUDENT_ID)).thenReturn(false);
+        when(projectGroupRepository.existsByGroupNameAndTermId(GROUP_NAME, TERM_ID)).thenReturn(false);
+        when(projectGroupRepository.save(any())).thenReturn(savedGroup);
+        when(studentRepository.findById(STUDENT_ID)).thenReturn(Optional.of(student));
+        when(groupMembershipRepository.save(any())).thenReturn(savedMembership);
+        when(groupMembershipRepository.findByGroupId(savedGroup.getId())).thenReturn(List.of(savedMembership));
+
+        GroupDetailResponse response = groupService.createGroup(GROUP_NAME, STUDENT_ID);
+
+        assertThat(response.getMembers()).hasSize(1);
+        assertThat(response.getMembers().get(0).getRole()).isEqualTo("TEAM_LEADER");
+        assertThat(response.getMembers().get(0).getStudentId()).isEqualTo("23070006036");
+    }
+
+    @Test
     void createGroup_savesTeamLeaderMembership() {
         when(termConfigService.getActiveTermId()).thenReturn(TERM_ID);
         when(scheduleWindowRepository.findByTermIdAndType(TERM_ID, WindowType.GROUP_CREATION))
@@ -161,6 +212,23 @@ class GroupServiceTest {
 
         assertThatThrownBy(() -> groupService.createGroup(GROUP_NAME, STUDENT_ID))
                 .isInstanceOf(ScheduleWindowClosedException.class);
+
+        verify(projectGroupRepository, never()).save(any());
+    }
+
+    @Test
+    void createGroup_windowNotYetOpen_throwsScheduleWindowClosedException() {
+        // NFR-3: both bounds enforced — opensAt <= now <= closesAt.
+        // PR #83 added the opensAt check; this test covers that new branch.
+        openWindow.setOpensAt(LocalDateTime.now().plusHours(1)); // opens in the future
+
+        when(termConfigService.getActiveTermId()).thenReturn(TERM_ID);
+        when(scheduleWindowRepository.findByTermIdAndType(TERM_ID, WindowType.GROUP_CREATION))
+                .thenReturn(Optional.of(openWindow));
+
+        assertThatThrownBy(() -> groupService.createGroup(GROUP_NAME, STUDENT_ID))
+                .isInstanceOf(ScheduleWindowClosedException.class)
+                .hasMessageContaining("not currently active");
 
         verify(projectGroupRepository, never()).save(any());
     }
@@ -220,13 +288,132 @@ class GroupServiceTest {
     }
 
     @Test
-    void getMyGroup_noMembership_throwsRuntimeException() {
+    void getMyGroup_noMembership_throwsNotInGroupException() {
+        // PR #83 fixed: was RuntimeException, now NotInGroupException → GlobalExceptionHandler returns 404
         when(groupMembershipRepository.findByStudentId(STUDENT_ID))
                 .thenReturn(Optional.empty());
 
-        // Currently throws RuntimeException — should be GroupNotFoundException (follow-up fix)
+        assertThatThrownBy(() -> groupService.getMyGroup(STUDENT_ID))
+                .isInstanceOf(NotInGroupException.class)
+                .hasMessageContaining("not a member");
+    }
+
+    @Test
+    void getMyGroup_groupEntityMissing_throwsRuntimeException() {
+        // Data integrity edge case: membership row exists but ProjectGroup row is missing.
+        // Service throws raw RuntimeException("Group not found") — no typed exception.
+        GroupMembership membership = new GroupMembership();
+        membership.setStudent(student);
+        membership.setRole(MemberRole.TEAM_LEADER);
+        membership.setJoinedAt(LocalDateTime.now());
+        membership.setGroup(savedGroup);
+
+        when(groupMembershipRepository.findByStudentId(STUDENT_ID)).thenReturn(Optional.of(membership));
+        when(projectGroupRepository.findById(savedGroup.getId())).thenReturn(Optional.empty());
+
         assertThatThrownBy(() -> groupService.getMyGroup(STUDENT_ID))
                 .isInstanceOf(RuntimeException.class)
-                .hasMessageContaining("not a member");
+                .hasMessageContaining("Group not found");
+    }
+
+    @Test
+    void createGroup_studentNotFound_throwsRuntimeException() {
+        // Data integrity edge case: JWT UUID has no matching student row.
+        // Service throws raw RuntimeException("Student not found") — no typed exception.
+        when(termConfigService.getActiveTermId()).thenReturn(TERM_ID);
+        when(scheduleWindowRepository.findByTermIdAndType(TERM_ID, WindowType.GROUP_CREATION))
+                .thenReturn(Optional.of(openWindow));
+        when(groupMembershipRepository.existsByStudentId(STUDENT_ID)).thenReturn(false);
+        when(projectGroupRepository.existsByGroupNameAndTermId(GROUP_NAME, TERM_ID)).thenReturn(false);
+        when(projectGroupRepository.save(any())).thenReturn(savedGroup);
+        when(studentRepository.findById(STUDENT_ID)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> groupService.createGroup(GROUP_NAME, STUDENT_ID))
+                .isInstanceOf(RuntimeException.class)
+                .hasMessageContaining("Student not found");
+    }
+
+    // ── MemberResponse mapping ─────────────────────────────────────────────────
+
+    @Test
+    void getMyGroup_memberStudentIdIsEnrollmentString_notUUID() {
+        // PR #83 critical fix: MemberResponse.studentId must be the enrollment number
+        // (e.g. "23070006036"), NOT the internal UUID. Verifies m.getStudent().getStudentId().
+        student.setStudentId("23070006036");
+
+        GroupMembership membership = new GroupMembership();
+        membership.setStudent(student);
+        membership.setRole(MemberRole.TEAM_LEADER);
+        membership.setJoinedAt(LocalDateTime.now());
+        membership.setGroup(savedGroup);
+
+        when(groupMembershipRepository.findByStudentId(STUDENT_ID)).thenReturn(Optional.of(membership));
+        when(projectGroupRepository.findById(savedGroup.getId())).thenReturn(Optional.of(savedGroup));
+        when(groupMembershipRepository.findByGroupId(savedGroup.getId())).thenReturn(List.of(membership));
+
+        GroupDetailResponse response = groupService.getMyGroup(STUDENT_ID);
+
+        assertThat(response.getMembers().get(0).getStudentId()).isEqualTo("23070006036");
+        assertThat(response.getMembers().get(0).getStudentId()).isNotEqualTo(STUDENT_ID.toString());
+    }
+
+    // ── jiraBound / githubBound derivation ────────────────────────────────────
+
+    @Test
+    void getMyGroup_jiraBoundTrueWhenBothJiraFieldsSet() {
+        savedGroup.setJiraSpaceUrl("https://senior.atlassian.net");
+        savedGroup.setJiraProjectKey("SPM");
+
+        GroupMembership membership = new GroupMembership();
+        membership.setStudent(student);
+        membership.setRole(MemberRole.TEAM_LEADER);
+        membership.setJoinedAt(LocalDateTime.now());
+        membership.setGroup(savedGroup);
+
+        when(groupMembershipRepository.findByStudentId(STUDENT_ID)).thenReturn(Optional.of(membership));
+        when(projectGroupRepository.findById(savedGroup.getId())).thenReturn(Optional.of(savedGroup));
+        when(groupMembershipRepository.findByGroupId(savedGroup.getId())).thenReturn(List.of(membership));
+
+        GroupDetailResponse response = groupService.getMyGroup(STUDENT_ID);
+
+        assertThat(response.getJiraBound()).isTrue();
+        assertThat(response.getJiraSpaceUrl()).isEqualTo("https://senior.atlassian.net");
+    }
+
+    @Test
+    void getMyGroup_jiraBoundFalseWhenFieldsMissing() {
+        // Default: jiraSpaceUrl and jiraProjectKey are null → jiraBound = false
+        GroupMembership membership = new GroupMembership();
+        membership.setStudent(student);
+        membership.setRole(MemberRole.TEAM_LEADER);
+        membership.setJoinedAt(LocalDateTime.now());
+        membership.setGroup(savedGroup);
+
+        when(groupMembershipRepository.findByStudentId(STUDENT_ID)).thenReturn(Optional.of(membership));
+        when(projectGroupRepository.findById(savedGroup.getId())).thenReturn(Optional.of(savedGroup));
+        when(groupMembershipRepository.findByGroupId(savedGroup.getId())).thenReturn(List.of(membership));
+
+        GroupDetailResponse response = groupService.getMyGroup(STUDENT_ID);
+
+        assertThat(response.getJiraBound()).isFalse();
+    }
+
+    @Test
+    void getMyGroup_githubBoundTrueWhenOrgSet() {
+        savedGroup.setGithubOrgName("senior-team-6");
+
+        GroupMembership membership = new GroupMembership();
+        membership.setStudent(student);
+        membership.setRole(MemberRole.TEAM_LEADER);
+        membership.setJoinedAt(LocalDateTime.now());
+        membership.setGroup(savedGroup);
+
+        when(groupMembershipRepository.findByStudentId(STUDENT_ID)).thenReturn(Optional.of(membership));
+        when(projectGroupRepository.findById(savedGroup.getId())).thenReturn(Optional.of(savedGroup));
+        when(groupMembershipRepository.findByGroupId(savedGroup.getId())).thenReturn(List.of(membership));
+
+        GroupDetailResponse response = groupService.getMyGroup(STUDENT_ID);
+
+        assertThat(response.getGithubBound()).isTrue();
     }
 }

--- a/backend/src/test/java/com/senior/spm/service/JiraValidationServiceTest.java
+++ b/backend/src/test/java/com/senior/spm/service/JiraValidationServiceTest.java
@@ -1,0 +1,163 @@
+package com.senior.spm.service;
+
+import static org.assertj.core.api.Assertions.assertThatNoException;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.client.ResourceAccessException;
+import org.springframework.web.client.RestTemplate;
+
+import com.senior.spm.exception.ExternalToolValidationException;
+import com.senior.spm.exception.JiraValidationException;
+
+@ExtendWith(MockitoExtension.class)
+class JiraValidationServiceTest {
+
+    @Mock
+    private RestTemplate restTemplate;
+
+    @InjectMocks
+    private JiraValidationService service;
+
+    private static final String JIRA_URL = "https://myteam.atlassian.net";
+    private static final String PROJECT_KEY = "SPM";
+    private static final String API_TOKEN = "test-api-token";
+    private static final String EXPECTED_URL = JIRA_URL + "/rest/api/3/project/" + PROJECT_KEY;
+
+    // ── Happy path ───────────────────────────────────────────────────────────
+
+    @Test
+    void validate_success_whenJiraReturns200() {
+        when(restTemplate.exchange(eq(EXPECTED_URL), eq(HttpMethod.GET), any(HttpEntity.class), eq(Void.class)))
+                .thenReturn(new ResponseEntity<>(HttpStatus.OK));
+
+        assertThatNoException().isThrownBy(() -> service.validate(JIRA_URL, PROJECT_KEY, API_TOKEN));
+    }
+
+    // ── 401 / 403 — invalid token ─────────────────────────────────────────
+
+    @Test
+    void validate_throwsInvalidToken_whenJiraReturns401() {
+        when(restTemplate.exchange(eq(EXPECTED_URL), eq(HttpMethod.GET), any(HttpEntity.class), eq(Void.class)))
+                .thenThrow(new HttpClientErrorException(HttpStatus.UNAUTHORIZED));
+
+        assertThatThrownBy(() -> service.validate(JIRA_URL, PROJECT_KEY, API_TOKEN))
+                .isInstanceOf(JiraValidationException.class)
+                .hasMessage("JIRA validation failed: API token is invalid or expired");
+    }
+
+    @Test
+    void validate_throwsInvalidToken_whenJiraReturns403() {
+        when(restTemplate.exchange(eq(EXPECTED_URL), eq(HttpMethod.GET), any(HttpEntity.class), eq(Void.class)))
+                .thenThrow(new HttpClientErrorException(HttpStatus.FORBIDDEN));
+
+        assertThatThrownBy(() -> service.validate(JIRA_URL, PROJECT_KEY, API_TOKEN))
+                .isInstanceOf(JiraValidationException.class)
+                .hasMessage("JIRA validation failed: API token is invalid or expired");
+    }
+
+    // ── 404 — project key not found ──────────────────────────────────────
+
+    @Test
+    void validate_throwsProjectNotFound_whenJiraReturns404() {
+        when(restTemplate.exchange(eq(EXPECTED_URL), eq(HttpMethod.GET), any(HttpEntity.class), eq(Void.class)))
+                .thenThrow(new HttpClientErrorException(HttpStatus.NOT_FOUND));
+
+        assertThatThrownBy(() -> service.validate(JIRA_URL, PROJECT_KEY, API_TOKEN))
+                .isInstanceOf(JiraValidationException.class)
+                .hasMessage("JIRA validation failed: Project key 'SPM' not found");
+    }
+
+    // ── Other 4xx — unreachable / misconfigured URL ──────────────────────
+
+    @Test
+    void validate_throwsUnreachable_whenJiraReturnsOther4xx() {
+        when(restTemplate.exchange(eq(EXPECTED_URL), eq(HttpMethod.GET), any(HttpEntity.class), eq(Void.class)))
+                .thenThrow(new HttpClientErrorException(HttpStatus.BAD_REQUEST));
+
+        assertThatThrownBy(() -> service.validate(JIRA_URL, PROJECT_KEY, API_TOKEN))
+                .isInstanceOf(JiraValidationException.class)
+                .hasMessage("JIRA validation failed: JIRA space URL is unreachable");
+    }
+
+    // ── Timeout / network failure ─────────────────────────────────────────
+
+    @Test
+    void validate_throwsUnreachable_whenTimeout() {
+        when(restTemplate.exchange(eq(EXPECTED_URL), eq(HttpMethod.GET), any(HttpEntity.class), eq(Void.class)))
+                .thenThrow(new ResourceAccessException("Connection timed out"));
+
+        assertThatThrownBy(() -> service.validate(JIRA_URL, PROJECT_KEY, API_TOKEN))
+                .isInstanceOf(JiraValidationException.class)
+                .hasMessage("JIRA validation failed: JIRA space URL is unreachable");
+    }
+
+    // ── URL normalisation ─────────────────────────────────────────────────
+
+    @Test
+    void validate_handlesTrailingSlash_inJiraUrl() {
+        // Trailing slash in jiraSpaceUrl must be stripped before appending the path.
+        // "https://myteam.atlassian.net/" → exchange must be called with
+        // "https://myteam.atlassian.net/rest/api/3/project/SPM" (single slash, not double).
+        String urlWithSlash = JIRA_URL + "/";
+        when(restTemplate.exchange(eq(EXPECTED_URL), eq(HttpMethod.GET), any(HttpEntity.class), eq(Void.class)))
+                .thenReturn(new ResponseEntity<>(HttpStatus.OK));
+
+        assertThatNoException().isThrownBy(() -> service.validate(urlWithSlash, PROJECT_KEY, API_TOKEN));
+        verify(restTemplate).exchange(eq(EXPECTED_URL), eq(HttpMethod.GET), any(HttpEntity.class), eq(Void.class));
+    }
+
+    @Test
+    void validate_stripsTrailingWhitespace_fromJiraUrl() {
+        String urlWithSpaces = JIRA_URL + "   ";
+        when(restTemplate.exchange(eq(EXPECTED_URL), eq(HttpMethod.GET), any(HttpEntity.class), eq(Void.class)))
+                .thenReturn(new ResponseEntity<>(HttpStatus.OK));
+
+        assertThatNoException().isThrownBy(() -> service.validate(urlWithSpaces, PROJECT_KEY, API_TOKEN));
+        verify(restTemplate).exchange(eq(EXPECTED_URL), eq(HttpMethod.GET), any(HttpEntity.class), eq(Void.class));
+    }
+
+    // ── Exception hierarchy — GlobalExceptionHandler relies on this ───────
+
+    @Test
+    void validate_throwsExternalToolValidationException_onFailure() {
+        // JiraValidationException must extend ExternalToolValidationException so that
+        // GlobalExceptionHandler.handleExternalToolValidation() catches it and returns 422.
+        // If this hierarchy breaks, failures silently become 500s instead of 422s.
+        when(restTemplate.exchange(eq(EXPECTED_URL), eq(HttpMethod.GET), any(HttpEntity.class), eq(Void.class)))
+                .thenThrow(new HttpClientErrorException(HttpStatus.UNAUTHORIZED));
+
+        assertThatThrownBy(() -> service.validate(JIRA_URL, PROJECT_KEY, API_TOKEN))
+                .isInstanceOf(ExternalToolValidationException.class);
+    }
+
+    // ── Authorization header ──────────────────────────────────────────────
+
+    @SuppressWarnings("unchecked")
+    @Test
+    void validate_setsBearerHeader() {
+        when(restTemplate.exchange(eq(EXPECTED_URL), eq(HttpMethod.GET), any(HttpEntity.class), eq(Void.class)))
+                .thenReturn(new ResponseEntity<>(HttpStatus.OK));
+
+        service.validate(JIRA_URL, PROJECT_KEY, API_TOKEN);
+
+        ArgumentCaptor<HttpEntity<Void>> captor = ArgumentCaptor.forClass(HttpEntity.class);
+        verify(restTemplate).exchange(eq(EXPECTED_URL), eq(HttpMethod.GET), captor.capture(), eq(Void.class));
+        String authHeader = captor.getValue().getHeaders().getFirst("Authorization");
+        org.assertj.core.api.Assertions.assertThat(authHeader).isEqualTo("Bearer " + API_TOKEN);
+    }
+}

--- a/backend/src/test/java/com/senior/spm/service/TermConfigServiceTest.java
+++ b/backend/src/test/java/com/senior/spm/service/TermConfigServiceTest.java
@@ -1,0 +1,139 @@
+package com.senior.spm.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.when;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.senior.spm.entity.SystemConfig;
+import com.senior.spm.exception.TermConfigNotFoundException;
+import com.senior.spm.repository.SystemConfigRepository;
+
+@ExtendWith(MockitoExtension.class)
+class TermConfigServiceTest {
+
+    @Mock
+    private SystemConfigRepository systemConfigRepository;
+
+    @InjectMocks
+    private TermConfigService termConfigService;
+
+    // ── getActiveTermId ──────────────────────────────────────────────────────
+
+    @Test
+    void getActiveTermId_keyExists_returnsValue() {
+        SystemConfig config = configEntry("active_term_id", "2026-SPRING");
+        when(systemConfigRepository.findByConfigKey("active_term_id"))
+                .thenReturn(Optional.of(config));
+
+        assertThat(termConfigService.getActiveTermId()).isEqualTo("2026-SPRING");
+    }
+
+    @Test
+    void getActiveTermId_keyMissing_throwsTermConfigNotFoundException() {
+        // Requirement: both getActiveTermId() and getMaxTeamSize() throw
+        // TermConfigNotFoundException (HTTP 500) if the key is missing — CLAUDE.md
+        when(systemConfigRepository.findByConfigKey("active_term_id"))
+                .thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> termConfigService.getActiveTermId())
+                .isInstanceOf(TermConfigNotFoundException.class)
+                .hasMessageContaining("active_term_id");
+    }
+
+    // ── getMaxTeamSize ───────────────────────────────────────────────────────
+
+    @Test
+    void getMaxTeamSize_keyExists_returnsInteger() {
+        SystemConfig config = configEntry("max_team_size", "5");
+        when(systemConfigRepository.findByConfigKey("max_team_size"))
+                .thenReturn(Optional.of(config));
+
+        assertThat(termConfigService.getMaxTeamSize()).isEqualTo(5);
+    }
+
+    @Test
+    void getMaxTeamSize_keyMissing_throwsTermConfigNotFoundException() {
+        when(systemConfigRepository.findByConfigKey("max_team_size"))
+                .thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> termConfigService.getMaxTeamSize())
+                .isInstanceOf(TermConfigNotFoundException.class)
+                .hasMessageContaining("max_team_size");
+    }
+
+    @Test
+    void getMaxTeamSize_valueBoundary_one_returnsOne() {
+        // P2 rule: max_team_size enforced at 1 should allow no invitations
+        SystemConfig config = configEntry("max_team_size", "1");
+        when(systemConfigRepository.findByConfigKey("max_team_size"))
+                .thenReturn(Optional.of(config));
+
+        assertThat(termConfigService.getMaxTeamSize()).isEqualTo(1);
+    }
+
+    @Test
+    void getMaxTeamSize_valueBoundary_large_returnsValue() {
+        SystemConfig config = configEntry("max_team_size", "100");
+        when(systemConfigRepository.findByConfigKey("max_team_size"))
+                .thenReturn(Optional.of(config));
+
+        assertThat(termConfigService.getMaxTeamSize()).isEqualTo(100);
+    }
+
+    /**
+     * BUG: getMaxTeamSize() does not guard against non-numeric config_value.
+     * Integer.parseInt("abc") throws NumberFormatException — not TermConfigNotFoundException.
+     * The raw NumberFormatException bypasses @ResponseStatus and GlobalExceptionHandler,
+     * producing an unstructured 500 with a cryptic message.
+     *
+     * Suggested Fix: wrap parseInt in try-catch and re-throw as TermConfigNotFoundException.
+     *
+     *   try {
+     *       return Integer.parseInt(config.getConfigValue().trim());
+     *   } catch (NumberFormatException e) {
+     *       throw new TermConfigNotFoundException(
+     *           "max_team_size config value is not a valid integer: " + config.getConfigValue());
+     *   }
+     */
+    @Test
+    void getMaxTeamSize_valueNotNumeric_shouldThrowTermConfigNotFoundException() {
+        SystemConfig config = configEntry("max_team_size", "abc");
+        when(systemConfigRepository.findByConfigKey("max_team_size"))
+                .thenReturn(Optional.of(config));
+
+        // FAILS until the fix above is applied — NumberFormatException leaks instead.
+        assertThatThrownBy(() -> termConfigService.getMaxTeamSize())
+                .isInstanceOf(TermConfigNotFoundException.class)
+                .hasMessageContaining("not a valid integer");
+    }
+
+    @Test
+    void getMaxTeamSize_valueWithWhitespace_shouldThrowTermConfigNotFoundException() {
+        // " 4 " — Integer.parseInt does not trim, same root cause.
+        SystemConfig config = configEntry("max_team_size", " 4 ");
+        when(systemConfigRepository.findByConfigKey("max_team_size"))
+                .thenReturn(Optional.of(config));
+
+        // FAILS until the fix above is applied.
+        assertThatThrownBy(() -> termConfigService.getMaxTeamSize())
+                .isInstanceOf(TermConfigNotFoundException.class)
+                .hasMessageContaining("not a valid integer");
+    }
+
+    // ── helpers ──────────────────────────────────────────────────────────────
+
+    private static SystemConfig configEntry(String key, String value) {
+        SystemConfig c = new SystemConfig();
+        c.setConfigKey(key);
+        c.setConfigValue(value);
+        return c;
+    }
+}

--- a/backend/src/test/resources/test.properties
+++ b/backend/src/test/resources/test.properties
@@ -1,0 +1,9 @@
+# Test-only configuration using H2 in-memory database.
+# DO NOT add real credentials or sensitive information here — this file is committed to git.
+spring.datasource.url=jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1;MODE=MySQL
+spring.datasource.driver-class-name=org.h2.Driver
+spring.datasource.username=sa
+spring.datasource.password=
+spring.jpa.database-platform=org.hibernate.dialect.H2Dialect
+spring.jpa.hibernate.ddl-auto=create-drop
+spring.sql.init.mode=never

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -114,6 +114,432 @@ components:
         weight:
           type: number
 
+    # ── P2 — Red Team ─────────────────────────────────────────────────────────
+    GroupMember:
+      type: object
+      properties:
+        studentId:
+          type: string
+        role:
+          type: string
+          enum: [TEAM_LEADER, MEMBER]
+        joinedAt:
+          type: string
+          format: date-time
+
+    CreateGroupRequest:
+      type: object
+      required: [groupName]
+      properties:
+        groupName:
+          type: string
+
+    CreateGroupResponse:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        groupName:
+          type: string
+        termId:
+          type: string
+        status:
+          type: string
+        createdAt:
+          type: string
+          format: date-time
+        members:
+          type: array
+          items:
+            $ref: '#/components/schemas/GroupMember'
+
+    GroupDetailResponse:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        groupName:
+          type: string
+        termId:
+          type: string
+        status:
+          type: string
+        createdAt:
+          type: string
+          format: date-time
+        jiraSpaceUrl:
+          type: string
+          nullable: true
+        jiraProjectKey:
+          type: string
+          nullable: true
+        jiraBound:
+          type: boolean
+        githubOrgName:
+          type: string
+          nullable: true
+        githubBound:
+          type: boolean
+        advisorId:
+          type: string
+          format: uuid
+          nullable: true
+        members:
+          type: array
+          items:
+            $ref: '#/components/schemas/GroupMember'
+
+    StudentSearchResponse:
+      type: object
+      properties:
+        studentId:
+          type: string
+        githubUsername:
+          type: string
+          nullable: true
+        inGroup:
+          type: boolean
+
+    SendInvitationRequest:
+      type: object
+      required: [targetStudentId]
+      properties:
+        targetStudentId:
+          type: string
+
+    InvitationResponse:
+      type: object
+      properties:
+        invitationId:
+          type: string
+          format: uuid
+        groupId:
+          type: string
+          format: uuid
+        targetStudentId:
+          type: string
+        status:
+          type: string
+          enum: [PENDING, ACCEPTED, DECLINED, AUTO_DENIED, CANCELLED]
+        sentAt:
+          type: string
+          format: date-time
+
+    PendingInvitationResponse:
+      type: object
+      properties:
+        invitationId:
+          type: string
+          format: uuid
+        groupId:
+          type: string
+          format: uuid
+        groupName:
+          type: string
+        teamLeaderStudentId:
+          type: string
+        sentAt:
+          type: string
+          format: date-time
+
+    RespondInvitationRequest:
+      type: object
+      required: [accept]
+      properties:
+        accept:
+          type: boolean
+
+    DeclineInvitationResponse:
+      type: object
+      properties:
+        invitationId:
+          type: string
+          format: uuid
+        status:
+          type: string
+
+    BindJiraRequest:
+      type: object
+      required: [jiraSpaceUrl, jiraProjectKey, jiraApiToken]
+      properties:
+        jiraSpaceUrl:
+          type: string
+        jiraProjectKey:
+          type: string
+        jiraApiToken:
+          type: string
+
+    BindJiraResponse:
+      type: object
+      properties:
+        groupId:
+          type: string
+          format: uuid
+        status:
+          type: string
+        jiraSpaceUrl:
+          type: string
+        jiraProjectKey:
+          type: string
+        jiraBound:
+          type: boolean
+
+    BindGithubRequest:
+      type: object
+      required: [githubOrgName, githubPat]
+      properties:
+        githubOrgName:
+          type: string
+        githubPat:
+          type: string
+
+    BindGithubResponse:
+      type: object
+      properties:
+        groupId:
+          type: string
+          format: uuid
+        status:
+          type: string
+        githubOrgName:
+          type: string
+        githubBound:
+          type: boolean
+
+    CoordinatorGroupSummary:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        groupName:
+          type: string
+        termId:
+          type: string
+        status:
+          type: string
+        memberCount:
+          type: integer
+        jiraBound:
+          type: boolean
+        githubBound:
+          type: boolean
+
+    CoordinatorMemberActionRequest:
+      type: object
+      required: [studentId, action]
+      properties:
+        studentId:
+          type: string
+        action:
+          type: string
+          enum: [ADD, REMOVE]
+
+    CoordinatorDisbandResponse:
+      type: object
+      properties:
+        groupId:
+          type: string
+          format: uuid
+        status:
+          type: string
+
+    # ── P3 — Red Team ─────────────────────────────────────────────────────────
+    AdvisorSummary:
+      type: object
+      properties:
+        advisorId:
+          type: string
+          format: uuid
+        name:
+          type: string
+        mail:
+          type: string
+        currentGroupCount:
+          type: integer
+        capacity:
+          type: integer
+
+    CoordinatorAdvisorSummary:
+      type: object
+      properties:
+        advisorId:
+          type: string
+          format: uuid
+        name:
+          type: string
+        mail:
+          type: string
+        currentGroupCount:
+          type: integer
+        capacity:
+          type: integer
+        atCapacity:
+          type: boolean
+
+    AdvisorRequestPayload:
+      type: object
+      required: [advisorId]
+      properties:
+        advisorId:
+          type: string
+          format: uuid
+
+    AdvisorRequestCreatedResponse:
+      type: object
+      properties:
+        requestId:
+          type: string
+          format: uuid
+        groupId:
+          type: string
+          format: uuid
+        advisorId:
+          type: string
+          format: uuid
+        status:
+          type: string
+        sentAt:
+          type: string
+          format: date-time
+
+    AdvisorRequestDetailStudent:
+      type: object
+      properties:
+        requestId:
+          type: string
+          format: uuid
+        advisorId:
+          type: string
+          format: uuid
+        advisorName:
+          type: string
+        status:
+          type: string
+        sentAt:
+          type: string
+          format: date-time
+        respondedAt:
+          type: string
+          format: date-time
+          nullable: true
+
+    AdvisorRequestCancelResponse:
+      type: object
+      properties:
+        requestId:
+          type: string
+          format: uuid
+        status:
+          type: string
+
+    AdvisorRequestSummaryProfessor:
+      type: object
+      properties:
+        requestId:
+          type: string
+          format: uuid
+        groupId:
+          type: string
+          format: uuid
+        groupName:
+          type: string
+        termId:
+          type: string
+        memberCount:
+          type: integer
+        sentAt:
+          type: string
+          format: date-time
+
+    AdvisorRequestDetailProfessor:
+      type: object
+      properties:
+        requestId:
+          type: string
+          format: uuid
+        group:
+          $ref: '#/components/schemas/GroupDetailResponse'
+        sentAt:
+          type: string
+          format: date-time
+
+    RespondAdvisorRequestPayload:
+      type: object
+      required: [accept]
+      properties:
+        accept:
+          type: boolean
+
+    RespondAdvisorRequestAcceptResponse:
+      type: object
+      properties:
+        requestId:
+          type: string
+          format: uuid
+        status:
+          type: string
+        groupId:
+          type: string
+          format: uuid
+        groupStatus:
+          type: string
+
+    RespondAdvisorRequestRejectResponse:
+      type: object
+      properties:
+        requestId:
+          type: string
+          format: uuid
+        status:
+          type: string
+
+    SanitizeRequest:
+      type: object
+      properties:
+        force:
+          type: boolean
+
+    SanitizationReportResponse:
+      type: object
+      properties:
+        disbandedCount:
+          type: integer
+        autoRejectedRequestCount:
+          type: integer
+        triggeredAt:
+          type: string
+          format: date-time
+
+    CoordinatorAdvisorActionRequest:
+      type: object
+      required: [action]
+      description: For action=ASSIGN, advisorId is required. For action=REMOVE, advisorId is ignored.
+      properties:
+        action:
+          type: string
+          enum: [ASSIGN, REMOVE]
+        advisorId:
+          type: string
+          format: uuid
+          nullable: true
+          description: Required when action=ASSIGN. Ignored when action=REMOVE.
+
+    CoordinatorAdvisorActionResponse:
+      type: object
+      properties:
+        groupId:
+          type: string
+          format: uuid
+        status:
+          type: string
+        advisorId:
+          type: string
+          format: uuid
+          nullable: true
+
 security:
   - bearerAuth: []
 
@@ -639,6 +1065,739 @@ paths:
                 $ref: '#/components/schemas/ErrorMessage'
         '403':
           description: Caller is not a Coordinator
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorMessage'
+
+  # ── P2 — Red Team ────────────────────────────────────────────────────────────
+
+  /groups:
+    post:
+      tags: [Student]
+      summary: Validate Schedule & Create Group
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateGroupRequest'
+      responses:
+        '201':
+          description: Group created successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CreateGroupResponse'
+        '400':
+          description: Schedule window closed or student already in a group
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorMessage'
+        '409':
+          description: Group name already exists
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorMessage'
+
+  /groups/my:
+    get:
+      tags: [Student]
+      summary: Get student's current group
+      responses:
+        '200':
+          description: Returns the group details
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GroupDetailResponse'
+        '404':
+          description: Not a member of any group
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorMessage'
+
+  /students/search:
+    get:
+      tags: [Student]
+      summary: Search ungrouped students
+      parameters:
+        - name: q
+          in: query
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Returns list of available students
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/StudentSearchResponse'
+        '400':
+          description: Query parameter too short
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorMessage'
+
+  /groups/{groupId}/invitations:
+    post:
+      tags: [Student]
+      summary: Send Invitation
+      parameters:
+        - name: groupId
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SendInvitationRequest'
+      responses:
+        '201':
+          description: Invitation sent
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/InvitationResponse'
+        '400':
+          description: Target student already in a group; group is DISBANDED; or (members + pending invitations) >= max team size
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorMessage'
+        '403':
+          description: Caller is not the Team Leader
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorMessage'
+        '409':
+          description: Pending invitation already exists
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorMessage'
+    get:
+      tags: [Student]
+      summary: List group invitations
+      parameters:
+        - name: groupId
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        '200':
+          description: Returns list of invitations
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/InvitationResponse'
+        '403':
+          description: Caller is not the Team Leader
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorMessage'
+        '404':
+          description: Group not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorMessage'
+
+  /invitations/{invitationId}:
+    delete:
+      tags: [Student]
+      summary: Cancel a pending invitation
+      parameters:
+        - name: invitationId
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        '200':
+          description: Invitation cancelled
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DeclineInvitationResponse'
+        '400':
+          description: Invitation is no longer pending
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorMessage'
+        '403':
+          description: Caller is not the Team Leader
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorMessage'
+        '404':
+          description: Invitation not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorMessage'
+
+  /invitations/pending:
+    get:
+      tags: [Student]
+      summary: List pending invitations for the student
+      responses:
+        '200':
+          description: Returns list of pending invitations
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/PendingInvitationResponse'
+
+  /invitations/{invitationId}/respond:
+    patch:
+      tags: [Student]
+      summary: Respond to an invitation
+      parameters:
+        - name: invitationId
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RespondInvitationRequest'
+      responses:
+        '200':
+          description: Invitation processed successfully
+          content:
+            application/json:
+              schema:
+                oneOf:
+                  - $ref: '#/components/schemas/GroupDetailResponse'
+                  - $ref: '#/components/schemas/DeclineInvitationResponse'
+        '400':
+          description: Invitation is no longer pending; or group status is TOOLS_BOUND or higher (roster lock blocks student accept)
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorMessage'
+        '403':
+          description: Invitation does not belong to the user
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorMessage'
+        '404':
+          description: Invitation not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorMessage'
+
+  /groups/{groupId}/jira:
+    post:
+      tags: [Student]
+      summary: Validate and Bind JIRA
+      parameters:
+        - name: groupId
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/BindJiraRequest'
+      responses:
+        '200':
+          description: JIRA successfully bound
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BindJiraResponse'
+        '400':
+          description: Group is DISBANDED
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorMessage'
+        '403':
+          description: Caller is not the Team Leader
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorMessage'
+        '422':
+          description: JIRA Validation Failed
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorMessage'
+
+  /groups/{groupId}/github:
+    post:
+      tags: [Student]
+      summary: Validate and Bind GitHub
+      parameters:
+        - name: groupId
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/BindGithubRequest'
+      responses:
+        '200':
+          description: GitHub successfully bound
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BindGithubResponse'
+        '400':
+          description: Group is DISBANDED
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorMessage'
+        '403':
+          description: Caller is not the Team Leader
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorMessage'
+        '422':
+          description: GitHub Validation Failed
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorMessage'
+
+  /coordinator/groups:
+    get:
+      tags: [Coordinator]
+      summary: List all groups for the active term
+      responses:
+        '200':
+          description: Returns list of all groups
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/CoordinatorGroupSummary'
+
+  /coordinator/groups/{groupId}:
+    get:
+      tags: [Coordinator]
+      summary: Get details of a specific group
+      parameters:
+        - name: groupId
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        '200':
+          description: Returns group details
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GroupDetailResponse'
+        '404':
+          description: Group not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorMessage'
+
+  /coordinator/groups/{groupId}/members:
+    patch:
+      tags: [Coordinator]
+      summary: Add or remove a member manually
+      parameters:
+        - name: groupId
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CoordinatorMemberActionRequest'
+      responses:
+        '200':
+          description: Group member updated
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GroupDetailResponse'
+        '400':
+          description: Removing the Team Leader; or (members + pending invitations) >= max team size on ADD
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorMessage'
+        '404':
+          description: Group or Student not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorMessage'
+
+  /coordinator/groups/{groupId}/disband:
+    patch:
+      tags: [Coordinator]
+      summary: Disband a group manually
+      parameters:
+        - name: groupId
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        '200':
+          description: Group disbanded
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CoordinatorDisbandResponse'
+        '400':
+          description: Group already disbanded
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorMessage'
+        '404':
+          description: Group not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorMessage'
+
+  # ── P3 — Red Team ────────────────────────────────────────────────────────────
+
+  /advisors:
+    get:
+      tags: [Student]
+      summary: Browse available advisors
+      responses:
+        '200':
+          description: Returns list of available advisors below capacity
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/AdvisorSummary'
+
+  /groups/{groupId}/advisor-request:
+    post:
+      tags: [Student]
+      summary: Send an advisor request
+      parameters:
+        - name: groupId
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AdvisorRequestPayload'
+      responses:
+        '201':
+          description: Advisor request sent
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AdvisorRequestCreatedResponse'
+        '400':
+          description: Window inactive, status not TOOLS_BOUND, or advisor at capacity
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorMessage'
+        '403':
+          description: Caller is not the Team Leader
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorMessage'
+        '404':
+          description: Advisor not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorMessage'
+        '409':
+          description: Pending request already exists
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorMessage'
+    get:
+      tags: [Student]
+      summary: Get group's advisor request status
+      parameters:
+        - name: groupId
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        '200':
+          description: Returns the latest advisor request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AdvisorRequestDetailStudent'
+        '403':
+          description: Not a member of the group
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorMessage'
+        '404':
+          description: No request found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorMessage'
+    delete:
+      tags: [Student]
+      summary: Cancel an advisor request
+      parameters:
+        - name: groupId
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        '200':
+          description: Request cancelled
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AdvisorRequestCancelResponse'
+        '400':
+          description: No active pending request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorMessage'
+        '403':
+          description: Caller is not the Team Leader
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorMessage'
+        '404':
+          description: Group or request not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorMessage'
+
+  /advisor/requests:
+    get:
+      tags: [Professor]
+      summary: Get all pending advisor requests for the professor
+      responses:
+        '200':
+          description: Returns list of pending requests
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/AdvisorRequestSummaryProfessor'
+
+  /advisor/requests/{requestId}:
+    get:
+      tags: [Professor]
+      summary: Get details of a specific advisor request
+      parameters:
+        - name: requestId
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        '200':
+          description: Returns request details
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AdvisorRequestDetailProfessor'
+        '403':
+          description: Request not addressed to this professor
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorMessage'
+        '404':
+          description: Request not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorMessage'
+
+  /advisor/requests/{requestId}/respond:
+    patch:
+      tags: [Professor]
+      summary: Respond to an advisor request
+      parameters:
+        - name: requestId
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RespondAdvisorRequestPayload'
+      responses:
+        '200':
+          description: Request processed successfully
+          content:
+            application/json:
+              schema:
+                oneOf:
+                  - $ref: '#/components/schemas/RespondAdvisorRequestAcceptResponse'
+                  - $ref: '#/components/schemas/RespondAdvisorRequestRejectResponse'
+        '400':
+          description: Request is no longer pending; or advisor has reached maximum capacity (AdvisorAtCapacityException — request stays PENDING, group can retry)
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorMessage'
+        '403':
+          description: Request not addressed to this professor
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorMessage'
+        '404':
+          description: Request not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorMessage'
+
+  /coordinator/sanitize:
+    post:
+      tags: [Coordinator]
+      summary: Trigger auto-sanitization manually
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SanitizeRequest'
+      responses:
+        '200':
+          description: Sanitization run complete
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SanitizationReportResponse'
+        '400':
+          description: Window is active and force flag not set
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorMessage'
+
+  /coordinator/advisors:
+    get:
+      tags: [Coordinator]
+      summary: List all professors with capacity status
+      responses:
+        '200':
+          description: Returns list of all advisors
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/CoordinatorAdvisorSummary'
+
+  /coordinator/groups/{groupId}/advisor:
+    patch:
+      tags: [Coordinator]
+      summary: Override group advisor assignment
+      parameters:
+        - name: groupId
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CoordinatorAdvisorActionRequest'
+      responses:
+        '200':
+          description: Advisor overridden successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CoordinatorAdvisorActionResponse'
+        '400':
+          description: ASSIGN — group is DISBANDED (no DISBANDED→ADVISOR_ASSIGNED transition); or group status is not TOOLS_BOUND or ADVISOR_ASSIGNED. REMOVE — group has no assigned advisor.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorMessage'
+        '404':
+          description: Group or advisor not found
           content:
             application/json:
               schema:

--- a/docs/process2/endpoints_p2.md
+++ b/docs/process2/endpoints_p2.md
@@ -1,0 +1,659 @@
+# Process 2 — API Endpoints
+## Group Creation & Tool Integration (Sub-Processes 2.1–2.6)
+
+> Sources: `process2_dfd_lvl1.drawio`, `dfd_level1_process2.md`
+> All endpoints are under base path `/api/`. Auth via `Authorization: Bearer <JWT>`.
+> SP scale: Fibonacci (1, 2, 3, 5, 8). Difficulty: Easy / Medium / Hard.
+
+---
+
+## Conventions
+
+| Item | Rule |
+|------|------|
+| Primary keys | UUID |
+| Timestamps | ISO-8601 (`LocalDateTime`) |
+| Student JWT | `sub="Student"`, claim `studentId` |
+| Staff JWT | `sub="StaffUser"`, claim `role` |
+| Error body | `{ "error": "Human-readable message" }` |
+
+### HTTP Status Codes
+
+| Code | Meaning |
+|------|---------|
+| 200 | OK |
+| 201 | Resource created |
+| 400 | Business rule violation |
+| 403 | Role / ownership mismatch |
+| 404 | Resource not found |
+| 409 | Conflict (duplicate) |
+| 422 | External service validation failure |
+
+---
+
+## 2.1 — Validate Schedule & Create Group
+
+### `POST /api/groups` — SP: 3 | Difficulty: Medium
+**Auth:** Student JWT | **Issue:** API-01
+
+Checks `D1: Term Config` for an active `GROUP_CREATION` schedule window before creating the group. `termId` is resolved server-side via `TermConfigService.getActiveTermId()` — never passed by the client. The requesting student is automatically added as `TEAM_LEADER`.
+
+**Request:**
+```json
+{
+  "groupName": "string"
+}
+```
+
+**Response 201:**
+```json
+{
+  "id": "uuid",
+  "groupName": "string",
+  "termId": "string",
+  "status": "FORMING",
+  "createdAt": "ISO-8601",
+  "members": [
+    { "studentId": "string", "role": "TEAM_LEADER", "joinedAt": "ISO-8601" }
+  ]
+}
+```
+
+**Errors:**
+```
+400  { "error": "Group creation window is not currently active" }
+400  { "error": "You are already a member of a group" }
+409  { "error": "A group named '{name}' already exists for this term" }
+```
+
+---
+
+### `GET /api/groups/my` — SP: 1 | Difficulty: Easy
+**Auth:** Student JWT | **Issue:** API-01
+
+Returns the full `GroupDetailResponse` for the student's current group.
+
+**Response 200:**
+```json
+{
+  "id": "uuid",
+  "groupName": "string",
+  "termId": "string",
+  "status": "FORMING | TOOLS_PENDING | TOOLS_BOUND | ADVISOR_ASSIGNED | DISBANDED",
+  "createdAt": "ISO-8601",
+  "jiraSpaceUrl": "string | null",
+  "jiraProjectKey": "string | null",
+  "jiraBound": false,
+  "githubOrgName": "string | null",
+  "githubBound": false,
+  "members": [
+    { "studentId": "string", "role": "TEAM_LEADER | MEMBER", "joinedAt": "ISO-8601" }
+  ]
+}
+```
+
+**Errors:**
+```
+404  { "error": "You are not a member of any group" }
+```
+
+---
+
+## 2.2 — Search Student & Send Invitation
+
+### `GET /api/students/search?q={query}` — SP: 2 | Difficulty: Easy
+**Auth:** Student JWT | **Issue:** API-02
+
+Searches `D2: Users` for students who are **not** currently in any group. Minimum 3 characters required.
+
+**Query params:**
+- `q` — partial match on `studentId` (required, min 3 chars)
+
+**Response 200:**
+```json
+[
+  {
+    "studentId": "string",
+    "githubUsername": "string | null",
+    "inGroup": false
+  }
+]
+```
+
+**Errors:**
+```
+400  { "error": "Query must be at least 3 characters" }
+```
+
+---
+
+### `POST /api/groups/{groupId}/invitations` — SP: 3 | Difficulty: Medium
+**Auth:** Student JWT (must be `TEAM_LEADER` of `groupId`) | **Issue:** API-02
+
+Looks up target student in `D2: Users`, checks they are not already in a group, then creates a `PENDING` invitation record.
+
+**Request:**
+```json
+{
+  "targetStudentId": "string"
+}
+```
+
+**Response 201:**
+```json
+{
+  "invitationId": "uuid",
+  "groupId": "uuid",
+  "targetStudentId": "string",
+  "status": "PENDING",
+  "sentAt": "ISO-8601"
+}
+```
+
+**Errors:**
+```
+403  { "error": "Only the Team Leader can send invitations" }
+400  { "error": "Cannot send invitation from a disbanded group" }
+400  { "error": "Student '{id}' is not registered in the system" }
+400  { "error": "Student '{id}' is already a member of a group" }
+400  { "error": "Group has reached maximum team size" }
+409  { "error": "A pending invitation already exists for this student" }
+```
+
+---
+
+### `GET /api/groups/{groupId}/invitations` — SP: 1 | Difficulty: Easy
+**Auth:** Student JWT (must be `TEAM_LEADER` of `groupId`) | **Issue:** API-02
+
+Returns all invitations sent by this group (all statuses).
+
+**Response 200:**
+```json
+[
+  {
+    "invitationId": "uuid",
+    "targetStudentId": "string",
+    "status": "PENDING | ACCEPTED | DECLINED | AUTO_DENIED",
+    "sentAt": "ISO-8601"
+  }
+]
+```
+
+**Errors:**
+```
+403  { "error": "Only the Team Leader can view group invitations" }
+404  { "error": "Group not found" }
+```
+
+---
+
+### `DELETE /api/invitations/{invitationId}` — SP: 2 | Difficulty: Easy
+**Auth:** Student JWT (must be `TEAM_LEADER` of the inviting group) | **Issue:** API-02
+
+Cancels a `PENDING` invitation before the invitee responds.
+
+**Response 200:**
+```json
+{ "invitationId": "uuid", "status": "CANCELLED" }
+```
+
+**Errors:**
+```
+403  { "error": "Only the Team Leader can cancel invitations" }
+400  { "error": "Invitation is no longer pending" }
+404  { "error": "Invitation not found" }
+```
+
+---
+
+## 2.3 — Process Invitation Response
+
+### `GET /api/invitations/pending` — SP: 1 | Difficulty: Easy
+**Auth:** Student JWT | **Issue:** API-03
+
+Returns all `PENDING` invitations addressed to the authenticated student.
+
+**Response 200:**
+```json
+[
+  {
+    "invitationId": "uuid",
+    "groupId": "uuid",
+    "groupName": "string",
+    "teamLeaderStudentId": "string",
+    "sentAt": "ISO-8601"
+  }
+]
+```
+
+---
+
+### `PATCH /api/invitations/{invitationId}/respond` — SP: 5 | Difficulty: Hard
+**Auth:** Student JWT (must be the invitee) | **Issue:** API-03
+
+On `ACCEPTED`: creates a `GroupMembership` record with `role=MEMBER`, auto-denies all other `PENDING` invitations for the same student in the same transaction.
+On `DECLINED`: updates only this invitation's status.
+
+**Request:**
+```json
+{
+  "accept": true
+}
+```
+
+**Response 200 (accepted):** Full `GroupDetailResponse` (same shape as `GET /api/groups/my`)
+
+**Response 200 (declined):**
+```json
+{
+  "invitationId": "uuid",
+  "status": "DECLINED"
+}
+```
+
+**Errors:**
+```
+403  { "error": "This invitation does not belong to you" }
+400  { "error": "Invitation is no longer pending" }
+404  { "error": "Invitation not found" }
+```
+
+---
+
+## 2.4 — Validate & Bind JIRA
+
+### `POST /api/groups/{groupId}/jira` — SP: 5 | Difficulty: Hard
+**Auth:** Student JWT (must be `TEAM_LEADER` of `groupId`) | **Issue:** API-04
+
+Performs a live test call to JIRA API before storing anything. Stores `jiraSpaceUrl` and `jiraProjectKey` in plaintext; `jiraApiToken` is encrypted (AES-256-GCM) before persisting. Status transitions to `TOOLS_BOUND` if GitHub is already bound.
+
+**Request:**
+```json
+{
+  "jiraSpaceUrl": "string",
+  "jiraProjectKey": "string",
+  "jiraApiToken": "string"
+}
+```
+
+**Response 200:**
+```json
+{
+  "groupId": "uuid",
+  "status": "FORMING | TOOLS_PENDING | TOOLS_BOUND",
+  "jiraSpaceUrl": "string",
+  "jiraProjectKey": "string",
+  "jiraBound": true
+}
+```
+
+**Errors:**
+```
+403  { "error": "Only the Team Leader can bind tool integrations" }
+422  { "error": "JIRA validation failed: JIRA space URL is unreachable" }
+422  { "error": "JIRA validation failed: Project key '{key}' not found" }
+422  { "error": "JIRA validation failed: API token is invalid or expired" }
+```
+
+---
+
+## 2.5 — Validate & Bind GitHub
+
+### `POST /api/groups/{groupId}/github` — SP: 5 | Difficulty: Hard
+**Auth:** Student JWT (must be `TEAM_LEADER` of `groupId`) | **Issue:** API-05
+
+Performs two test calls: `GET /orgs/{org}` (org existence + PAT validity) and `GET /orgs/{org}/repos` (confirms `repo` scope). Stores `githubOrgName` in plaintext; PAT is AES-256-GCM encrypted. Status transitions to `TOOLS_BOUND` if JIRA is already bound.
+
+**Request:**
+```json
+{
+  "githubOrgName": "string",
+  "githubPat": "string"
+}
+```
+
+**Response 200:**
+```json
+{
+  "groupId": "uuid",
+  "status": "FORMING | TOOLS_PENDING | TOOLS_BOUND",
+  "githubOrgName": "string",
+  "githubBound": true
+}
+```
+
+**Errors:**
+```
+403  { "error": "Only the Team Leader can bind tool integrations" }
+422  { "error": "GitHub validation failed: PAT is invalid or expired" }
+422  { "error": "GitHub validation failed: PAT lacks required 'repo' scope" }
+422  { "error": "GitHub validation failed: Organization '{name}' not found" }
+```
+
+---
+
+## 2.6 — Coordinator Group Override
+
+### `GET /api/coordinator/groups` — SP: 2 | Difficulty: Easy
+**Auth:** Staff JWT (Role = `Coordinator`) | **Issue:** API-06
+
+> `termId` is resolved server-side via `TermConfigService.getActiveTermId()` — no query param required.
+
+**Query params:** _(none)_
+
+**Response 200:**
+```json
+[
+  {
+    "id": "uuid",
+    "groupName": "string",
+    "termId": "string",
+    "status": "FORMING | TOOLS_PENDING | TOOLS_BOUND | ADVISOR_ASSIGNED | DISBANDED",
+    "memberCount": 4,
+    "jiraBound": true,
+    "githubBound": false
+  }
+]
+```
+
+---
+
+### `GET /api/coordinator/groups/{groupId}` — SP: 1 | Difficulty: Easy
+**Auth:** Staff JWT (Role = `Coordinator`) | **Issue:** API-06
+
+Returns full group detail including members. Encrypted tokens are **never** returned.
+
+**Response 200:**
+```json
+{
+  "id": "uuid",
+  "groupName": "string",
+  "termId": "string",
+  "status": "string",
+  "createdAt": "ISO-8601",
+  "jiraSpaceUrl": "string | null",
+  "jiraProjectKey": "string | null",
+  "jiraBound": true,
+  "githubOrgName": "string | null",
+  "githubBound": true,
+  "members": [
+    { "studentId": "string", "role": "TEAM_LEADER | MEMBER", "joinedAt": "ISO-8601" }
+  ]
+}
+```
+
+**Errors:**
+```
+404  { "error": "Group not found" }
+```
+
+---
+
+### `PATCH /api/coordinator/groups/{groupId}/members` — SP: 3 | Difficulty: Medium
+**Auth:** Staff JWT (Role = `Coordinator`) | **Issue:** API-06
+
+Overrides the normal invitation flow. Removing the `TEAM_LEADER` is blocked.
+
+**Request:**
+```json
+{
+  "studentId": "string",
+  "action": "ADD | REMOVE"
+}
+```
+
+**Response 200:** Full `GroupDetailResponse` (same shape as `GET /api/coordinator/groups/{groupId}`)
+
+**Errors:**
+```
+400  { "error": "Cannot remove Team Leader; transfer leadership first" }
+400  { "error": "Student '{id}' is already a member of a group" }
+404  { "error": "Group not found" }
+404  { "error": "Student '{id}' not found" }
+```
+
+---
+
+### `PATCH /api/coordinator/groups/{groupId}/disband` — SP: 3 | Difficulty: Medium
+**Auth:** Staff JWT (Role = `Coordinator`) | **Issue:** API-06
+
+Sets group `status` to `DISBANDED`. All `GroupMembership` rows for the group are hard-deleted (freeing members to join new groups). All `PENDING` invitations for members are set to `AUTO_DENIED`. Group record itself is retained.
+
+**Request:** _(no body)_
+
+**Response 200:**
+```json
+{
+  "groupId": "uuid",
+  "status": "DISBANDED"
+}
+```
+
+**Errors:**
+```
+400  { "error": "Group is already disbanded" }
+404  { "error": "Group not found" }
+```
+
+---
+
+## Endpoint Summary Table
+
+| # | Method | Path | Auth | Sub-process | Issue | SP | Difficulty |
+|---|--------|------|------|-------------|-------|----|------------|
+| 1 | POST | `/api/groups` | Student | 2.1 | API-01 | 3 | Medium |
+| 2 | GET | `/api/groups/my` | Student | 2.1 | API-01 | 1 | Easy |
+| 3 | GET | `/api/students/search?q=` | Student | 2.2 | API-02 | 2 | Easy |
+| 4 | POST | `/api/groups/{groupId}/invitations` | Student (TEAM_LEADER) | 2.2 | API-02 | 3 | Medium |
+| 5 | GET | `/api/groups/{groupId}/invitations` | Student (TEAM_LEADER) | 2.2 | API-02 | 1 | Easy |
+| 6 | DELETE | `/api/invitations/{invitationId}` | Student (TEAM_LEADER) | 2.2 | API-02 | 2 | Easy |
+| 7 | GET | `/api/invitations/pending` | Student | 2.3 | API-03 | 1 | Easy |
+| 8 | PATCH | `/api/invitations/{invitationId}/respond` | Student (invitee) | 2.3 | API-03 | 5 | Hard |
+| 9 | POST | `/api/groups/{groupId}/jira` | Student (TEAM_LEADER) | 2.4 | API-04 | 5 | Hard |
+| 10 | POST | `/api/groups/{groupId}/github` | Student (TEAM_LEADER) | 2.5 | API-05 | 5 | Hard |
+| 11 | GET | `/api/coordinator/groups` | Staff (Coordinator) | 2.6 | API-06 | 2 | Easy |
+| 12 | GET | `/api/coordinator/groups/{groupId}` | Staff (Coordinator) | 2.6 | API-06 | 1 | Easy |
+| 13 | PATCH | `/api/coordinator/groups/{groupId}/members` | Staff (Coordinator) | 2.6 | API-06 | 3 | Medium |
+| 14 | PATCH | `/api/coordinator/groups/{groupId}/disband` | Staff (Coordinator) | 2.6 | API-06 | 3 | Medium |
+
+**Total SP: 37**
+
+---
+
+## Issue Breakdown
+
+> Issues group endpoints that share a service layer and can be developed, reviewed, and merged together. Each issue assumes the infrastructure issues from `estimated_issues_process2.md` (B-01 through B-07, B-17, B-18) are completed first.
+
+---
+
+### API-01 — Group Setup Endpoints
+**Story Points: 4** | **Sub-process: 2.1** | **Depends on: B-01, B-02, B-03, B-05, B-07, B-08, B-17, B-18**
+
+Implements the group creation controller and service method. The `POST` endpoint is the most business-logic-heavy of this issue — it must atomically create the `ProjectGroup` and the `TEAM_LEADER` membership row after checking the schedule window and duplicate name constraints.
+
+**Endpoints:**
+
+| Method | Path | SP | Difficulty |
+|--------|------|----|------------|
+| POST | `/api/groups` | 3 | Medium |
+| GET | `/api/groups/my` | 1 | Easy |
+
+**What makes it Medium:**
+- Must query `D1: ScheduleWindow` to verify an active `GROUP_CREATION` window exists for the given `termId`
+- Three pre-condition checks before any write (window active, student not already in group, name unique per term)
+- Group + membership created atomically in a single `@Transactional` method
+
+**Acceptance criteria:**
+- [ ] `POST /api/groups` returns 400 if the schedule window is closed for the given `termId`
+- [ ] `POST /api/groups` returns 400 if the authenticated student is already in any group
+- [ ] `POST /api/groups` returns 409 if `groupName` already exists in the same `termId`
+- [ ] `POST /api/groups` creates both a `ProjectGroup` row (status=`FORMING`) and a `GroupMembership` row (role=`TEAM_LEADER`) atomically
+- [ ] `GET /api/groups/my` returns 404 when the student has no membership
+- [ ] `GET /api/groups/my` reflects updated `status` and tool-binding fields after subsequent bind operations
+
+---
+
+### API-02 — Invitation Dispatch Endpoints
+**Story Points: 8** | **Sub-process: 2.2** | **Depends on: B-03, B-04, B-05, B-09, B-17, B-18**
+
+Implements all invitation-sending operations from the TEAM_LEADER perspective. The `POST` endpoint has the most logic (4 pre-condition checks); search and list are straightforward queries.
+
+**Endpoints:**
+
+| Method | Path | SP | Difficulty |
+|--------|------|----|------------|
+| GET | `/api/students/search?q=` | 2 | Easy |
+| POST | `/api/groups/{groupId}/invitations` | 3 | Medium |
+| GET | `/api/groups/{groupId}/invitations` | 1 | Easy |
+| DELETE | `/api/invitations/{invitationId}` | 2 | Easy |
+
+**What makes POST Medium:**
+- TEAM_LEADER authorization check against `GroupMembership`
+- Target student must exist in `D2: Users` and must not already belong to any group
+- Duplicate-invitation guard: a second `PENDING` invite to the same student → 409 (not a DB unique constraint — service-layer check)
+
+**Acceptance criteria:**
+- [ ] `GET /api/students/search` only returns students where `existsByStudentId(id)` is `false`
+- [ ] `POST` returns 403 when caller is not TEAM_LEADER of `groupId`
+- [ ] `POST` returns 400 when target student is already in any group
+- [ ] `POST` returns 409 when a `PENDING` invitation to the same student already exists from this group
+- [ ] `GET invitations` (list) returns all statuses, not just `PENDING`
+- [ ] `DELETE` returns 400 if the invitation is not in `PENDING` status
+
+---
+
+### API-03 — Invitation Response Endpoints
+**Story Points: 6** | **Sub-process: 2.3** | **Depends on: B-03, B-04, B-09, B-17, B-18**
+
+The `PATCH /respond` endpoint is the most complex single endpoint in this process. The auto-denial side-effect (bulk-updating all other `PENDING` invitations for the accepting student) must execute atomically — no partial state allowed.
+
+**Endpoints:**
+
+| Method | Path | SP | Difficulty |
+|--------|------|----|------------|
+| GET | `/api/invitations/pending` | 1 | Easy |
+| PATCH | `/api/invitations/{invitationId}/respond` | 5 | Hard |
+
+**What makes PATCH Hard:**
+- Dual response shape depending on `accept` value (two different DTO types from one method)
+- On accept: creates `GroupMembership` + bulk-updates competing invitations to `AUTO_DENIED` in the same transaction
+- Must verify the invitee's JWT identity against the invitation's `inviteeId` — 403 if they don't match
+- Race condition risk: two concurrent accepts of different invitations by the same student must not result in two memberships (handled by the transactional bulk-deny)
+
+**Acceptance criteria:**
+- [ ] `GET /api/invitations/pending` returns empty list (not 404) when no pending invitations exist
+- [ ] `PATCH` with `accept: true` creates a `GroupMembership` row with `role=MEMBER`
+- [ ] `PATCH` with `accept: true` sets all other `PENDING` invitations for the same student to `AUTO_DENIED` in the same transaction
+- [ ] `PATCH` with `accept: false` does not affect other invitations
+- [ ] `PATCH` returns 403 when the authenticated student is not the invitation's invitee
+- [ ] `PATCH` returns 400 when the invitation status is not `PENDING`
+
+---
+
+### API-04 — JIRA Binding Endpoint
+**Story Points: 5** | **Sub-process: 2.4** | **Depends on: B-02, B-06, B-10, B-12, B-17, B-18**
+
+Single endpoint, but the most infrastructure-heavy of the non-GitHub issues. Requires `EncryptionService` (AES-256-GCM) and `JiraValidationService` (live HTTP) to both be complete before this can be fully tested end-to-end.
+
+**Endpoints:**
+
+| Method | Path | SP | Difficulty |
+|--------|------|----|------------|
+| POST | `/api/groups/{groupId}/jira` | 5 | Hard |
+
+**What makes it Hard:**
+- Live outbound HTTP call to JIRA REST API (5-second timeout, multiple failure modes each mapping to a specific 422 message)
+- `jiraApiToken` must be encrypted before persistence; plaintext must never reach the DB
+- `TOOLS_BOUND` status transition logic: only fires if `encryptedGithubPat` is already set
+- Validation failure must not persist any data (validate before encrypt before save — order matters)
+
+**Acceptance criteria:**
+- [ ] A non-TEAM_LEADER requester gets 403 before any external HTTP call is made
+- [ ] An invalid JIRA token returns 422 with the `"API token is invalid or expired"` message
+- [ ] A bad project key returns 422 with the `"Project key '{key}' not found"` message
+- [ ] An unreachable URL returns 422 with the `"JIRA space URL is unreachable"` message
+- [ ] On success, `encryptedJiraToken` in DB is not the plaintext token (verified by direct DB query)
+- [ ] `jiraSpaceUrl` and `jiraProjectKey` are stored as plaintext
+- [ ] If GitHub was already bound, response contains `status: "TOOLS_BOUND"`
+- [ ] If GitHub was not bound, response contains `status: "TOOLS_PENDING"`
+- [ ] Calling the endpoint a second time overwrites the previous credentials
+
+---
+
+### API-05 — GitHub Binding Endpoint
+**Story Points: 5** | **Sub-process: 2.5** | **Depends on: B-02, B-06, B-11, B-12, B-17, B-18**
+
+Similar structure to API-04 but with two sequential outbound calls to GitHub. The second call (`/repos`) is specifically for scope verification — GitHub returns 403 (not 401) for scope failures.
+
+**Endpoints:**
+
+| Method | Path | SP | Difficulty |
+|--------|------|----|------------|
+| POST | `/api/groups/{groupId}/github` | 5 | Hard |
+
+**What makes it Hard:**
+- Two sequential GitHub API calls with distinct failure modes each mapped to a different 422 message
+- Scope check (`repo` scope) is separate from authentication check — 403 from GitHub must map to a specific user-facing message, not a generic "forbidden"
+- `githubPat` must be AES-256-GCM encrypted before persistence
+- `TOOLS_BOUND` transition only if `encryptedJiraToken` is already set
+
+**Acceptance criteria:**
+- [ ] A non-TEAM_LEADER requester gets 403 before any external HTTP call
+- [ ] An invalid PAT returns 422 `"PAT is invalid or expired"` (GitHub returns 401)
+- [ ] A PAT without `repo` scope returns 422 `"PAT lacks required 'repo' scope"` (GitHub returns 403 on second call)
+- [ ] A non-existent org name returns 422 `"Organization '{name}' not found"` (GitHub returns 404)
+- [ ] On success, `encryptedGithubPat` in DB is not the plaintext PAT
+- [ ] `githubOrgName` is stored as plaintext
+- [ ] If JIRA was already bound, response contains `status: "TOOLS_BOUND"`
+- [ ] If JIRA was not bound, response contains `status: "TOOLS_PENDING"`
+
+---
+
+### API-06 — Coordinator Override Endpoints
+**Story Points: 9** | **Sub-process: 2.6** | **Depends on: B-02, B-03, B-04, B-05, B-13, B-17, B-18**
+
+All coordinator endpoints share the same role guard (Staff JWT with role=`Coordinator`). The disband endpoint has a cascade side effect (auto-deny all pending invitations) similar to API-03's accept flow.
+
+**Endpoints:**
+
+| Method | Path | SP | Difficulty |
+|--------|------|----|------------|
+| GET | `/api/coordinator/groups` | 2 | Easy |
+| GET | `/api/coordinator/groups/{groupId}` | 1 | Easy |
+| PATCH | `/api/coordinator/groups/{groupId}/members` | 3 | Medium |
+| PATCH | `/api/coordinator/groups/{groupId}/disband` | 3 | Medium |
+
+**What makes PATCH endpoints Medium:**
+- `members`: must handle both `ADD` and `REMOVE` from a single `action` field; TEAM_LEADER removal is explicitly blocked
+- `disband`: cascade auto-deny of all `PENDING` invitations for members must be atomic with the status update
+
+**Acceptance criteria:**
+- [ ] All four endpoints return 403 for a Staff JWT with role `Professor` or `Admin`
+- [ ] `GET /coordinator/groups` resolves termId server-side via `TermConfigService.getActiveTermId()` — no query param accepted (ADR 2026-04-02)
+- [ ] `PATCH /members` with `action: "REMOVE"` on a TEAM_LEADER returns 400 with the exact message `"Cannot remove Team Leader; transfer leadership first"`
+- [ ] `PATCH /members` with `action: "ADD"` for a student already in any group returns 400
+- [ ] `PATCH /disband` sets group status to `DISBANDED` and all `PENDING` invitations for group members to `AUTO_DENIED`
+- [ ] `PATCH /disband` on an already-disbanded group returns 400
+- [ ] Encrypted token fields (`encryptedJiraToken`, `encryptedGithubPat`) are never present in any coordinator response body
+
+---
+
+## GroupStatus State Machine
+
+```
+FORMING ──(first tool bound)──► TOOLS_PENDING
+FORMING ──(both tools bound simultaneously)──► TOOLS_BOUND
+TOOLS_PENDING ──(second tool bound)──► TOOLS_BOUND
+Any state ──(coordinator disbands)──► DISBANDED
+```
+
+## Security Notes
+
+| Credential | Storage |
+|------------|---------|
+| `jiraApiToken` | AES-256-GCM → `encryptedJiraToken` column (length 1024) |
+| `githubPat` | AES-256-GCM → `encryptedGithubPat` column (length 1024) |
+| `jiraSpaceUrl` | Plaintext (required for P5 sprint queries) |
+| `jiraProjectKey` | Plaintext (required for P5 sprint queries) |
+| `githubOrgName` | Plaintext (required for P5 sprint queries) |
+| Any token | **Never returned** in any API response |

--- a/docs/process2/p2_issues.md
+++ b/docs/process2/p2_issues.md
@@ -1,0 +1,376 @@
+# P2 Issues — Sprint 2
+
+---
+
+## #39 — [Backend] P2 Core Domain Entities & Repositories
+**Estimate:** 2 Points
+
+**Problem Summary:** Implement the complete JPA Data Layer in a single pass to ensure all foreign keys, unique constraints, and bidirectional relationships are mapped correctly.
+**Scope:** Backend API and Database (Data Layer).
+
+**Deliverables:**
+1. Implement `ScheduleWindow`, `ProjectGroup`, `GroupMembership`, and `GroupInvitation` JPA entities with exact constraints (e.g., `uq_gm_student`), `@Version Long version` field on `ProjectGroup` for optimistic locking.
+2. Create corresponding Spring Data JPA repositories.
+
+**References:** Process 2 (DFD 2.1 - 2.6); Data Models.
+**Acceptance Criteria:**
+- [ ] Tables are auto-created by Hibernate on startup with all specified columns and constraints.
+- [ ] Database-level unique constraints successfully prevent duplicate memberships, even under race conditions.
+- [ ] Repositories return correct `Optional` or aggregate counts based on provided query methods.
+- [ ] `project_group` table has a `version` column (BIGINT); concurrent updates on the same group throw `OptimisticLockException`.
+
+**Related Issues:** Foundational task. Consolidates the creation of all database tables, fields, and queries into a single setup effort. Required by all backend services.
+
+---
+
+## #40 — [Backend] Base API Layer & Exception Handling
+**Estimate:** 1 Point
+
+**Problem Summary:** Establish the foundation for REST controllers, request/response validation, and a standardized global exception handler for the process-2.
+**Scope:** Backend API (Controller Layer).
+
+**Deliverables:**
+1. Create all Request DTOs with Bean Validation and Response DTOs using Lombok `@Data`.
+2. Implement the base `GroupController` for student endpoints.
+3. Extend existing `GlobalExceptionHandler` mapping domain exceptions to standard HTTP statuses within a `{ "error": "message" }` JSON envelope.
+
+**References:** Process 2 API Definitions; HTTP Status Code Conventions.
+**Acceptance Criteria:**
+- [ ] No endpoint returns a raw Java stack trace; all errors match the standard envelope.
+- [ ] Invalid DTO payloads immediately return 400 with a readable validation error.
+- [ ] Encrypted fields never appear in Response DTOs.
+
+**Related Issues:** Consolidates the setup of student controllers, data transfer objects, and error handling. Depends on **[Backend] Core Domain Entities & Repositories**.
+
+---
+
+## #41 — [Frontend] Shared UI Components
+
+**Estimate:** 1 Point
+
+**Problem Summary:** Create the reusable Vue components required across multiple group and coordinator views.
+**Scope:** Frontend (Shared Components). **Framework:** Vue.
+
+**Deliverables:**
+1. Implement `GroupStatusBadge.vue` mapping status strings to Tailwind color pills.
+2. Implement `MemberList.vue` displaying members, distinguishing the `TEAM_LEADER`, and conditionally rendering an `onRemove` action button.
+
+**References:** Process 2 GroupStatus state machine; GroupDetailResponse schema.
+**Acceptance Criteria:**
+- [ ] Status badges render correct colors in both light and dark modes.
+- [ ] Empty member arrays render a graceful placeholder.
+- [ ] TEAM_LEADER rows feature a distinct icon.
+
+**Related Issues:** Foundational frontend task. Consolidates the creation of reusable badges and list items. Used by all Student and Coordinator frontend views.
+
+---
+
+## #42 — [Backend] Validate Schedule & Create Group Service
+**Estimate:** 1 Point
+
+**Problem Summary:** Implement the business logic for creating a group, checking schedule windows and uniqueness constraints.
+**Scope:** Backend API (Service Layer).
+
+**Deliverables:**
+1. Implement `@Transactional` `GroupService.createGroup()` method.
+2. Validate active schedule window, check that the user isn't grouped, and ensure group name uniqueness.
+3. Save the new `ProjectGroup` and `GroupMembership`.
+
+**References:** Process 2 (DFD 2.1).
+**Acceptance Criteria:**
+- [ ] Method rolls back entirely if any condition fails (no partial database state).
+- [ ] Correctly throws specific domain exceptions mapping to 400 or 409 errors.
+
+**Related Issues:** Depends on **[Backend] Core Domain Entities & Repositories**.
+
+---
+
+## #43 — [Frontend] Student Group Hub & Creation Flow
+
+**Estimate:** 2 Points
+
+**Problem Summary:** Implement the main student landing page, conditional states, and creation form.
+**Scope:** Frontend (Pages). **Framework:** Vue.
+
+**Deliverables:**
+1. Implement `/student/group/create` page with Zod client-side validation.
+2. Implement `/student/group` hub page functioning as a router for "No Group", "Leader", and "Member" views.
+
+**References:** Process 2 (DFD 2.1).
+**Acceptance Criteria:**
+- [ ] Group creation form handles 409 conflicts with inline errors.
+- [ ] Hub page conditionally renders the correct interface based on API response.
+
+**Related Issues:** Consolidates the dedicated group creation form page with the main student routing hub page. Depends on **[Frontend] Shared UI Components**.
+
+---
+
+## #44 — [QA] Schedule & Creation Integration
+**Estimate:** 1 Point
+
+**Problem Summary:** Verify group creation end-to-end, testing boundaries and database integrity.
+**Scope:** QA Integration Tests.
+
+**Deliverables:**
+1. Write tests for creating a group in an active window.
+2. Write tests attempting creation outside the window, with duplicate names, or as a grouped student.
+
+**References:** Process 2 (DFD 2.1).
+**Acceptance Criteria:**
+- [ ] Closed-window scenarios produce the correct 400 error.
+- [ ] Direct DB queries verify the presence of Group and Membership records on success.
+
+**Related Issues:** Consolidates end-to-end tests for both the group creation happy path and the schedule window enforcement logic. Depends on **[Backend] Validate Schedule & Create Group Service**.
+
+---
+
+## #45 — [Backend] Invitation Lifecycle Services & Controller
+**Estimate:** 2 Points
+
+**Problem Summary:** Implement logic for sending, canceling, accepting, and declining invitations, including bulk auto-denial.
+**Scope:** Backend API (Service & Controller Layers).
+
+**Deliverables:**
+1. Implement `GroupService` methods for the invite lifecycle.
+2. Build the `@Transactional` response logic: On accept, create the `GroupMembership` row and bulk update competing `PENDING` invites to `AUTO_DENIED`.
+3. Implement `InvitationController`.
+4. Enforce DISBANDED freeze: throw 400 if `group.status == DISBANDED` before sending an invitation.
+5. Enforce max team size on send and accept: count = current members + pending outbound invitations; read limit via `TermConfigService.getMaxTeamSize()`.
+6. Enforce roster lock on accept: throw 400 if `group.status` is `TOOLS_BOUND` or higher when student calls `PATCH /invitations/{id}/respond`.
+
+**References:** Process 2 (DFD 2.2, 2.3).
+**Acceptance Criteria:**
+- [ ] Only the `TEAM_LEADER` can send/cancel invitations.
+- [ ] Accepting an invitation atomically updates all competing invites.
+- [ ] Sending an invitation to/from a DISBANDED group returns 400.
+- [ ] Invitation rejected when (members + pending invitations) >= max team size.
+- [ ] Student accept blocked with 400 when group status is `TOOLS_BOUND` or higher.
+
+**Related Issues:** Consolidates the business service layer logic for invitations with the REST controller endpoints. Depends on **[Backend] Core Domain Entities & Repositories**.
+
+---
+
+## #46 — [Frontend] Invitation Interface & Navigation Badge
+
+**Estimate:** 1 Point
+
+**Problem Summary:** Build the UI for managing pending invitations and a persistent notification badge.
+**Scope:** Frontend (Pages & Layout). **Framework:** Vue.
+
+**Deliverables:**
+1. Implement `InvitationCard.vue`.
+2. Implement `/student/group/invitations` inbox page.
+3. Implement a layout-level composable to fetch/display the pending invitation count.
+
+**References:** Process 2 (DFD 2.2, 2.3).
+**Acceptance Criteria:**
+- [ ] Buttons disable during API calls.
+- [ ] Navigation badge updates when an invitation is accepted/declined without a page reload.
+
+**Related Issues:** Consolidates the invitation card component, the inbox list page, and the persistent navigation layout badge. Depends on **[Backend] Invitation Lifecycle Services & Controller**.
+
+---
+
+## #47 — [QA] Invitation Lifecycle E2E
+**Estimate:** 1 Point
+
+**Problem Summary:** Verify the complete invitation lifecycle and high-risk auto-denial side-effects.
+**Scope:** QA Integration Tests.
+
+**Deliverables:**
+1. Test successful dispatch and TEAM_LEADER authorization.
+2. Test the accept flow and auto-denial updates in the database.
+3. Execute a concurrency test on simultaneous accept requests.
+4. Test DISBANDED freeze: verify sending an invitation on a DISBANDED group returns 400.
+5. Test roster lock: verify student accept is blocked with 400 when group is `TOOLS_BOUND`.
+6. Test max team size: verify invitation is rejected when (members + pending) >= limit.
+
+**References:** Process 2 (DFD 2.2, 2.3).
+**Acceptance Criteria:**
+- [ ] Auto-denial verified via direct database queries.
+- [ ] Concurrency test proves only one membership row is generated.
+- [ ] DISBANDED group invitation attempt returns 400.
+- [ ] Accept on TOOLS_BOUND group returns 400.
+- [ ] Over-capacity invitation attempt returns 400.
+
+**Related Issues:** Depends on **[Backend] Invitation Lifecycle Services & Controller**.
+
+---
+
+## #48 — [Backend] External Tool Validation Services
+**Estimate:** 2 Points
+
+**Problem Summary:** Build REST clients to ping the JIRA and GitHub APIs.
+**Scope:** Backend API (External Integrations).
+
+**Deliverables:**
+1. Implement `JiraValidationService` and `GitHubValidationService`.
+2. Map external HTTP failures to specific 422 domain exceptions.
+
+**References:** Process 2 (DFD 2.4, 2.5).
+**Acceptance Criteria:**
+- [ ] Services strictly enforce a 5-second timeout.
+- [ ] GitHub service halts if the first call fails, skipping the second.
+
+**Related Issues:** Consolidates the external API REST clients for both JIRA and GitHub into a single implementation effort.
+
+---
+
+## #49 — [Backend] Tool Binding & Encryption Orchestration
+**Estimate:** 3 Points
+
+**Problem Summary:** Implement AES encryption at rest and orchestration logic.
+**Scope:** Backend API (Security & Service Layer).
+
+**Deliverables:**
+1. Implement `EncryptionService` using AES-256-GCM.
+2. Implement `GroupService.bindJira()` and `bindGitHub()`.
+3. Enforce DISBANDED freeze in both `bindJira()` and `bindGitHub()`: throw 400 if `group.status == DISBANDED`.
+
+**References:** Process 2 (DFD 2.4, 2.5).
+**Acceptance Criteria:**
+- [ ] Encryption requires a 32-byte key and throws unchecked exceptions on tampering.
+- [ ] No DB changes occur if external validation fails.
+- [ ] Tokens are never saved as plaintext.
+- [ ] Binding attempt on a DISBANDED group returns 400 without touching the DB.
+
+**Related Issues:** Consolidates the creation of the AES encryption service, configuration setup, and the tool-binding service logic. Depends on **[Backend] External Tool Validation Services**.
+
+---
+
+## #50 — [Frontend] Tool Binding UI
+
+**Estimate:** 1 Point
+
+**Problem Summary:** Create the interface for the Team Leader to input external credentials.
+**Scope:** Frontend (Components & Pages). **Framework:** Vue.
+
+**Deliverables:**
+1. Implement `ToolBindingForm.vue` with locked/success states.
+2. Implement `/student/group/tools` page for JIRA and GitHub forms.
+
+**References:** Process 2 (DFD 2.4, 2.5).
+**Acceptance Criteria:**
+- [ ] Redirects non-Team Leaders.
+- [ ] Forms lock into a read-only state displaying a success icon when bound.
+
+**Related Issues:** Consolidates the dual-purpose form component with the overarching binding page. Depends on **[Backend] Tool Binding & Encryption Orchestration**.
+
+---
+
+## #51 — [QA] Tool Integration & Security E2E
+**Estimate:** 2 Points
+
+**Problem Summary:** Verify external tool binding logic via WireMock and assert at-rest encryption.
+**Scope:** QA Integration Tests.
+
+**Deliverables:**
+1. Test JIRA and GitHub binding using WireMock.
+2. Write JDBC-level tests to assert stored ciphertext does not match plaintext.
+3. Test DISBANDED freeze: verify JIRA and GitHub binding on a DISBANDED group returns 400.
+
+**References:** Process 2 (DFD 2.4, 2.5).
+**Acceptance Criteria:**
+- [ ] WireMock verifies API call behaviors and specific 422 error strings.
+- [ ] Direct DB queries confirm random IVs per encryption.
+- [ ] DISBANDED group tool binding attempt returns 400.
+
+**Related Issues:** Consolidates the WireMock tests for both external tools alongside the database-level AES encryption checks. Depends on **[Backend] Tool Binding & Encryption Orchestration**.
+
+---
+
+## #52 — [Backend] Coordinator Override Services & Controller
+**Estimate:** 2 Points
+
+**Problem Summary:** Provide endpoints for staff to manually add/remove students and disband groups.
+**Scope:** Backend API (Service & Controller Layers).
+
+**Deliverables:**
+1. Implement `GroupService` bypass methods and `CoordinatorGroupController`.
+2. Ensure disbanding cascades correctly.
+3. On coordinator force-add: bulk `AUTO_DENY` all other `PENDING` invitations for that student in the same `@Transactional` block.
+4. Enforce max team size on coordinator force-add: count = current members + pending outbound invitations; read limit via `TermConfigService.getMaxTeamSize()`.
+
+**References:** Process 2 (DFD 2.6).
+**Acceptance Criteria:**
+- [ ] Blocks the removal of a `TEAM_LEADER`.
+- [ ] Disbanding nullifies group associations cleanly.
+- [ ] Force-add atomically sets all competing PENDING invitations for that student to AUTO_DENIED.
+- [ ] Force-add rejected with 400 when (members + pending) >= max team size.
+
+**Related Issues:** Consolidates the coordinator-specific bypass logic with its corresponding secure controller endpoints. Depends on **[Backend] Core Domain Entities & Repositories**.
+
+---
+
+## #53 — [QA] Coordinator Role & Overrides E2E
+**Estimate:** 2 Points
+
+**Problem Summary:** Verify manual staff overrides and strict RBAC enforcement.
+**Scope:** QA Integration Tests.
+
+**Deliverables:**
+1. Test manual additions, removals, disband operations, and the `TEAM_LEADER` removal blocker.
+2. Verify RBAC with `Professor` and `Admin` tokens.
+3. Test auto-deny on force-add: verify all PENDING invitations for the added student are set to AUTO_DENIED in the DB.
+4. Test max team size on force-add: verify 400 is returned when group is at capacity.
+
+**References:** Process 2 (DFD 2.6).
+**Acceptance Criteria:**
+- [ ] Disband test confirms DB cascading.
+- [ ] Non-Coordinator roles receive a strict 403 Forbidden.
+- [ ] Direct DB query confirms AUTO_DENIED status on competing invitations after force-add.
+- [ ] Force-add at capacity returns 400.
+
+**Related Issues:** Depends on **[Backend] Coordinator Override Services & Controller**.
+
+---
+
+## #54 — [Frontend] Coordinator Dashboard & Management
+
+**Estimate:** 1 Point
+
+**Problem Summary:** Build staff-facing table views and detail pages.
+**Scope:** Frontend (Pages). **Framework:** Vue.
+
+**Deliverables:**
+1. Implement `/coordinator/groups` term-filtered table page.
+2. Implement `/coordinator/groups/:groupId` detail page with inline member controls and a disband button.
+
+**References:** Process 2 (DFD 2.6).
+**Acceptance Criteria:**
+- [ ] Disband requires confirmation dialog.
+- [ ] Member list updates immediately upon adding/removing without hard refreshes.
+
+**Related Issues:** Consolidates the list-view table page with the detailed individual group management view. Depends on **[Frontend] Shared UI Components**.
+
+---
+
+## #55 — [Backend] TermConfigService — Active Term & Max Team Size Resolution
+**Estimate:** 1 Point
+
+**Problem Summary:** All P2 services require a reliable way to read `active_term_id` and `max_team_size` from the `system_config` table without accepting these values from the frontend. Red Team owns this table — Blue Team adds their own config keys to it later.
+**Scope:** Backend — Data Layer + Service Layer.
+
+**Deliverables:**
+1. Create `SystemConfig` JPA entity mapping to `system_config` table: `config_key (VARCHAR PK)`, `config_value (VARCHAR)`.
+2. Create `SystemConfigRepository` with `findByConfigKey(String key)`.
+3. Seed `data.sql` with Red Team's required rows:
+   ```sql
+   INSERT IGNORE INTO system_config (config_key, config_value) VALUES ('active_term_id', '2024-FALL');
+   INSERT IGNORE INTO system_config (config_key, config_value) VALUES ('max_team_size', '5');
+   ```
+4. Implement `TermConfigService` with `getActiveTermId()` and `getMaxTeamSize()` reading from `system_config` by `config_key`.
+5. Throw `TermConfigNotFoundException` (500) if the key is missing.
+6. Integrate into `GroupService` and `InvitationService` so `termId` is never sourced from request bodies or query params.
+
+**References:** Process 2 — foundational dependency for all P2 services.
+**Acceptance Criteria:**
+- [ ] `system_config` table auto-created by Hibernate on startup.
+- [ ] `getActiveTermId()` returns the value where `config_key = 'active_term_id'`.
+- [ ] `getMaxTeamSize()` returns the integer value where `config_key = 'max_team_size'`.
+- [ ] Missing key throws `TermConfigNotFoundException` with HTTP 500.
+- [ ] No P2 endpoint accepts `termId` as a request parameter.
+
+**Note for Blue Team:** `system_config` is a shared key-value config table owned by Red Team. Add your own config keys (e.g. `system_state`) as rows — do not create a separate table.
+
+**Related Issues:** No Blue Team dependency — Red Team creates the table. Depended on by **[Backend] Validate Schedule & Create Group Service** and **[Backend] Invitation Lifecycle Services & Controller**.

--- a/docs/process2/sequences/2.1_create_group_p2.md
+++ b/docs/process2/sequences/2.1_create_group_p2.md
@@ -1,0 +1,97 @@
+# Sequence Diagram — P2 Sub-Process 2.1
+## Validate Schedule & Create Group
+
+> Endpoints: `POST /api/groups`, `GET /api/groups/my`
+> Issues: B-01, B-02, B-03, B-05, B-08, B-14
+> JWT principal = internal student UUID (not studentId string) — use `studentRepository.findById(UUID)`
+
+---
+
+### POST /api/groups
+
+```mermaid
+sequenceDiagram
+    actor Student
+    participant GroupController
+    participant GroupService
+    participant ScheduleWindowRepository
+    participant GroupMembershipRepository
+    participant ProjectGroupRepository
+
+    Student->>GroupController: POST /api/groups<br/>{groupName}<br/>Authorization: Bearer <student_jwt>
+
+    GroupController->>GroupController: extract studentUUID from SecurityContext
+
+    Note over GroupService: termId resolved server-side — never from client
+    GroupController->>GroupService: createGroup(groupName, studentUUID)
+
+    GroupService->>TermConfigService: getActiveTermId()
+    TermConfigService-->>GroupService: termId
+
+    GroupService->>ScheduleWindowRepository: findByTermIdAndType(termId, GROUP_CREATION)
+    ScheduleWindowRepository-->>GroupService: Optional<ScheduleWindow>
+
+    alt no active window (empty or closesAt < now)
+        GroupService-->>GroupController: throw ScheduleWindowClosedException
+        GroupController-->>Student: 400 {"error": "Group creation window is not currently active"}
+    end
+
+    GroupService->>GroupMembershipRepository: existsByStudentId(studentUUID)
+    GroupMembershipRepository-->>GroupService: boolean
+
+    alt student already in a group
+        GroupService-->>GroupController: throw AlreadyInGroupException
+        GroupController-->>Student: 400 {"error": "You are already a member of a group"}
+    end
+
+    GroupService->>ProjectGroupRepository: existsByGroupNameAndTermId(groupName, termId)
+    ProjectGroupRepository-->>GroupService: boolean
+
+    alt duplicate name in term
+        GroupService-->>GroupController: throw DuplicateGroupNameException
+        GroupController-->>Student: 409 {"error": "A group named '{name}' already exists for this term"}
+    end
+
+    Note over GroupService: @Transactional — both saves atomic
+    GroupService->>ProjectGroupRepository: save(ProjectGroup{status=FORMING})
+    ProjectGroupRepository-->>GroupService: savedGroup
+
+    GroupService->>GroupMembershipRepository: save(GroupMembership{role=TEAM_LEADER})
+    GroupMembershipRepository-->>GroupService: savedMembership
+
+    GroupService-->>GroupController: GroupDetailResponse
+    GroupController-->>Student: 201 {id, groupName, termId, status:"FORMING", members:[{studentId, role:"TEAM_LEADER"}]}
+```
+
+---
+
+### GET /api/groups/my
+
+```mermaid
+sequenceDiagram
+    actor Student
+    participant GroupController
+    participant GroupService
+    participant GroupMembershipRepository
+    participant ProjectGroupRepository
+
+    Student->>GroupController: GET /api/groups/my<br/>Authorization: Bearer <student_jwt>
+
+    GroupController->>GroupController: extract studentUUID from SecurityContext
+
+    GroupController->>GroupService: getMyGroup(studentUUID)
+
+    GroupService->>GroupMembershipRepository: findByStudentId(studentUUID)
+    GroupMembershipRepository-->>GroupService: Optional<GroupMembership>
+
+    alt no membership found
+        GroupService-->>GroupController: throw GroupNotFoundException
+        GroupController-->>Student: 404 {"error": "You are not a member of any group"}
+    end
+
+    GroupService->>ProjectGroupRepository: findById(membership.groupId)
+    ProjectGroupRepository-->>GroupService: ProjectGroup + members
+
+    GroupService-->>GroupController: GroupDetailResponse
+    GroupController-->>Student: 200 {id, groupName, termId, status, jiraBound, githubBound, members:[...]}
+```

--- a/docs/process2/sequences/2.2_invitation_send_p2.md
+++ b/docs/process2/sequences/2.2_invitation_send_p2.md
@@ -1,0 +1,191 @@
+# Sequence Diagram — P2 Sub-Process 2.2
+## Search Student & Send / Cancel Invitation
+
+> Endpoints: `GET /api/students/search`, `POST /api/groups/{groupId}/invitations`, `GET /api/groups/{groupId}/invitations`, `DELETE /api/invitations/{invitationId}`
+> Issues: B-04, B-05, B-09, B-15, B-17
+> JWT principal = internal student UUID
+
+---
+
+### GET /api/students/search?q={query}
+
+```mermaid
+sequenceDiagram
+    actor Student
+    participant StudentSearchController
+    participant StudentRepository
+
+    Student->>StudentSearchController: GET /api/students/search?q=230<br/>Authorization: Bearer <student_jwt>
+
+    alt q.length < 3
+        StudentSearchController-->>Student: 400 {"error": "Query must be at least 3 characters"}
+    end
+
+    Note over StudentSearchController: Query students not in any group.<br/>Join student LEFT JOIN group_membership WHERE membership IS NULL<br/>+ studentId LIKE '%q%'
+    StudentSearchController->>StudentRepository: findUngroupedByStudentIdContaining(q)
+    StudentRepository-->>StudentSearchController: List<Student>
+
+    StudentSearchController-->>Student: 200 [{studentId, githubUsername}]
+```
+
+---
+
+### POST /api/groups/{groupId}/invitations
+
+```mermaid
+sequenceDiagram
+    actor Student as Student (Team Leader)
+    participant GroupController
+    participant GroupService
+    participant GroupMembershipRepository
+    participant StudentRepository
+    participant GroupInvitationRepository
+
+    Student->>GroupController: POST /api/groups/{groupId}/invitations<br/>{targetStudentId: "23070006036"}<br/>Authorization: Bearer <student_jwt>
+
+    GroupController->>GroupController: extract requesterUUID from SecurityContext
+
+    GroupController->>GroupService: sendInvitation(groupId, targetStudentId, requesterUUID)
+
+    GroupService->>GroupMembershipRepository: findByGroupIdAndStudentId(groupId, requesterUUID)
+    GroupMembershipRepository-->>GroupService: Optional<GroupMembership>
+
+    alt requester is not TEAM_LEADER of this group
+        GroupService-->>GroupController: throw ForbiddenException
+        GroupController-->>Student: 403 {"error": "Only the Team Leader can send invitations"}
+    end
+
+    Note over GroupService: DISBANDED freeze — fetch group and check status first
+    GroupService->>ProjectGroupRepository: findById(groupId)
+    ProjectGroupRepository-->>GroupService: ProjectGroup
+
+    alt group.status == DISBANDED
+        GroupService-->>GroupController: throw BusinessRuleException
+        GroupController-->>Student: 400 {"error": "This group has been disbanded"}
+    end
+
+    alt group.status == TOOLS_BOUND or ADVISOR_ASSIGNED
+        GroupService-->>GroupController: throw BusinessRuleException
+        GroupController-->>Student: 400 {"error": "Group roster is locked after tool binding"}
+    end
+
+    Note over GroupService: Max team size check — members + pending outbound invitations
+    GroupService->>TermConfigService: getMaxTeamSize()
+    TermConfigService-->>GroupService: maxTeamSize
+    GroupService->>GroupMembershipRepository: countByGroupId(groupId)
+    GroupService->>GroupInvitationRepository: countByGroupIdAndStatus(groupId, PENDING)
+    GroupMembershipRepository-->>GroupService: memberCount
+    GroupInvitationRepository-->>GroupService: pendingCount
+
+    alt memberCount + pendingCount >= maxTeamSize
+        GroupService-->>GroupController: throw BusinessRuleException
+        GroupController-->>Student: 400 {"error": "Group has reached maximum team size"}
+    end
+
+    GroupService->>StudentRepository: findByStudentId(targetStudentId)
+    StudentRepository-->>GroupService: Optional<Student>
+
+    alt student not found
+        GroupService-->>GroupController: throw StudentNotFoundException
+        GroupController-->>Student: 400 {"error": "Student '{id}' is not registered in the system"}
+    end
+
+    GroupService->>GroupMembershipRepository: existsByStudentId(targetStudent.id)
+    GroupMembershipRepository-->>GroupService: boolean
+
+    alt target already in a group
+        GroupService-->>GroupController: throw AlreadyInGroupException
+        GroupController-->>Student: 400 {"error": "Student '{id}' is already a member of a group"}
+    end
+
+    GroupService->>GroupInvitationRepository: findByGroupIdAndInviteeIdAndStatus(groupId, targetId, PENDING)
+    GroupInvitationRepository-->>GroupService: Optional<GroupInvitation>
+
+    alt pending invitation already exists
+        GroupService-->>GroupController: throw DuplicateInvitationException
+        GroupController-->>Student: 409 {"error": "A pending invitation already exists for this student"}
+    end
+
+    GroupService->>GroupInvitationRepository: save(GroupInvitation{status=PENDING})
+    GroupInvitationRepository-->>GroupService: savedInvitation
+
+    GroupService-->>GroupController: InvitationResponse
+    GroupController-->>Student: 201 {invitationId, groupId, targetStudentId, status:"PENDING", sentAt}
+```
+
+---
+
+### GET /api/groups/{groupId}/invitations
+
+```mermaid
+sequenceDiagram
+    actor Student as Student (Team Leader)
+    participant GroupController
+    participant GroupService
+    participant GroupMembershipRepository
+    participant GroupInvitationRepository
+
+    Student->>GroupController: GET /api/groups/{groupId}/invitations<br/>Authorization: Bearer <student_jwt>
+
+    GroupController->>GroupController: extract requesterUUID from SecurityContext
+    GroupController->>GroupService: getGroupInvitations(groupId, requesterUUID)
+
+    GroupService->>GroupMembershipRepository: findByGroupIdAndStudentId(groupId, requesterUUID)
+    GroupMembershipRepository-->>GroupService: Optional<GroupMembership>
+
+    alt not TEAM_LEADER
+        GroupService-->>GroupController: throw ForbiddenException
+        GroupController-->>Student: 403 {"error": "Only the Team Leader can view group invitations"}
+    end
+
+    GroupService->>GroupInvitationRepository: findByGroupId(groupId)
+    GroupInvitationRepository-->>GroupService: List<GroupInvitation> (all statuses)
+
+    GroupService-->>GroupController: List<InvitationResponse>
+    GroupController-->>Student: 200 [{invitationId, targetStudentId, status, sentAt}, ...]
+```
+
+---
+
+### DELETE /api/invitations/{invitationId}
+
+```mermaid
+sequenceDiagram
+    actor Student as Student (Team Leader)
+    participant InvitationController
+    participant GroupService
+    participant GroupInvitationRepository
+    participant GroupMembershipRepository
+
+    Student->>InvitationController: DELETE /api/invitations/{invitationId}<br/>Authorization: Bearer <student_jwt>
+
+    InvitationController->>InvitationController: extract requesterUUID from SecurityContext
+    InvitationController->>GroupService: cancelInvitation(invitationId, requesterUUID)
+
+    GroupService->>GroupInvitationRepository: findById(invitationId)
+    GroupInvitationRepository-->>GroupService: Optional<GroupInvitation>
+
+    alt not found
+        GroupService-->>InvitationController: throw InvitationNotFoundException
+        InvitationController-->>Student: 404 {"error": "Invitation not found"}
+    end
+
+    GroupService->>GroupMembershipRepository: findByGroupIdAndStudentId(invitation.groupId, requesterUUID)
+    GroupMembershipRepository-->>GroupService: Optional<GroupMembership>
+
+    alt requester is not TEAM_LEADER of the inviting group
+        GroupService-->>InvitationController: throw ForbiddenException
+        InvitationController-->>Student: 403 {"error": "Only the Team Leader can cancel invitations"}
+    end
+
+    alt invitation.status != PENDING
+        GroupService-->>InvitationController: throw InvitationNotPendingException
+        InvitationController-->>Student: 400 {"error": "Invitation is no longer pending"}
+    end
+
+    GroupService->>GroupInvitationRepository: save(invitation{status=CANCELLED})
+    GroupInvitationRepository-->>GroupService: ok
+
+    GroupService-->>InvitationController: {invitationId, status:"CANCELLED"}
+    InvitationController-->>Student: 200 {invitationId, status:"CANCELLED"}
+```

--- a/docs/process2/sequences/2.3_invitation_respond_p2.md
+++ b/docs/process2/sequences/2.3_invitation_respond_p2.md
@@ -1,0 +1,149 @@
+# Sequence Diagram — P2 Sub-Process 2.3
+## Process Invitation Response
+
+> Endpoints: `GET /api/invitations/pending`, `PATCH /api/invitations/{invitationId}/respond`
+> Issues: B-09, B-15
+> JWT principal = internal student UUID
+> ⚠️ The ACCEPT path is the most complex transaction in P2 — auto-deny must happen in the same @Transactional call.
+
+---
+
+### GET /api/invitations/pending
+
+```mermaid
+sequenceDiagram
+    actor Student
+    participant InvitationController
+    participant GroupService
+    participant GroupInvitationRepository
+
+    Student->>InvitationController: GET /api/invitations/pending<br/>Authorization: Bearer <student_jwt>
+
+    InvitationController->>InvitationController: extract studentUUID from SecurityContext
+
+    InvitationController->>GroupService: getPendingInvitationsForStudent(studentUUID)
+
+    GroupService->>GroupInvitationRepository: findByInviteeIdAndStatus(studentUUID, PENDING)
+    GroupInvitationRepository-->>GroupService: List<GroupInvitation>
+
+    Note over GroupService: Empty list is valid — never 404
+    GroupService-->>InvitationController: List<InvitationResponse>
+    InvitationController-->>Student: 200 [{invitationId, groupId, groupName, teamLeaderStudentId, sentAt}, ...]
+```
+
+---
+
+### PATCH /api/invitations/{invitationId}/respond — DECLINED path
+
+```mermaid
+sequenceDiagram
+    actor Student
+    participant InvitationController
+    participant GroupService
+    participant GroupInvitationRepository
+
+    Student->>InvitationController: PATCH /api/invitations/{invitationId}/respond<br/>{accept: false}<br/>Authorization: Bearer <student_jwt>
+
+    InvitationController->>InvitationController: extract studentUUID from SecurityContext
+    InvitationController->>GroupService: respondToInvitation(invitationId, studentUUID, accept=false)
+
+    GroupService->>GroupInvitationRepository: findById(invitationId)
+    GroupInvitationRepository-->>GroupService: Optional<GroupInvitation>
+
+    alt not found
+        GroupService-->>InvitationController: throw InvitationNotFoundException
+        InvitationController-->>Student: 404 {"error": "Invitation not found"}
+    end
+
+    alt invitation.inviteeId != studentUUID
+        GroupService-->>InvitationController: throw ForbiddenException
+        InvitationController-->>Student: 403 {"error": "This invitation does not belong to you"}
+    end
+
+    alt invitation.status != PENDING
+        GroupService-->>InvitationController: throw InvitationNotPendingException
+        InvitationController-->>Student: 400 {"error": "Invitation is no longer pending"}
+    end
+
+    GroupService->>GroupInvitationRepository: save(invitation{status=DECLINED, respondedAt=now})
+    GroupInvitationRepository-->>GroupService: ok
+
+    GroupService-->>InvitationController: {invitationId, status:"DECLINED"}
+    InvitationController-->>Student: 200 {invitationId, status:"DECLINED"}
+```
+
+---
+
+### PATCH /api/invitations/{invitationId}/respond — ACCEPTED path
+
+```mermaid
+sequenceDiagram
+    actor Student
+    participant InvitationController
+    participant GroupService
+    participant GroupInvitationRepository
+    participant GroupMembershipRepository
+
+    Student->>InvitationController: PATCH /api/invitations/{invitationId}/respond<br/>{accept: true}<br/>Authorization: Bearer <student_jwt>
+
+    InvitationController->>InvitationController: extract studentUUID from SecurityContext
+    InvitationController->>GroupService: respondToInvitation(invitationId, studentUUID, accept=true)
+
+    GroupService->>GroupInvitationRepository: findById(invitationId)
+    GroupInvitationRepository-->>GroupService: Optional<GroupInvitation>
+
+    alt not found
+        GroupService-->>InvitationController: throw InvitationNotFoundException
+        InvitationController-->>Student: 404 {"error": "Invitation not found"}
+    end
+
+    alt invitation.inviteeId != studentUUID
+        GroupService-->>InvitationController: throw ForbiddenException
+        InvitationController-->>Student: 403 {"error": "This invitation does not belong to you"}
+    end
+
+    alt invitation.status != PENDING
+        GroupService-->>InvitationController: throw InvitationNotPendingException
+        InvitationController-->>Student: 400 {"error": "Invitation is no longer pending"}
+    end
+
+    Note over GroupService: Roster lock — fetch group and check status
+    GroupService->>ProjectGroupRepository: findById(invitation.groupId)
+    ProjectGroupRepository-->>GroupService: ProjectGroup
+
+    alt group.status == DISBANDED
+        GroupService-->>InvitationController: throw BusinessRuleException
+        InvitationController-->>Student: 400 {"error": "This group has been disbanded"}
+    end
+
+    alt group.status == TOOLS_BOUND or ADVISOR_ASSIGNED
+        GroupService-->>InvitationController: throw BusinessRuleException
+        InvitationController-->>Student: 400 {"error": "Group roster is locked after tool binding"}
+    end
+
+    Note over GroupService: Max team size check
+    GroupService->>TermConfigService: getMaxTeamSize()
+    TermConfigService-->>GroupService: maxTeamSize
+    GroupService->>GroupMembershipRepository: countByGroupId(invitation.groupId)
+    GroupMembershipRepository-->>GroupService: memberCount
+
+    alt memberCount >= maxTeamSize
+        GroupService-->>InvitationController: throw BusinessRuleException
+        InvitationController-->>Student: 400 {"error": "Group has reached maximum team size"}
+    end
+
+    Note over GroupService: @Transactional — all three writes are atomic.<br/>If any step fails, nothing is persisted.
+
+    GroupService->>GroupInvitationRepository: save(invitation{status=ACCEPTED, respondedAt=now})
+    GroupInvitationRepository-->>GroupService: ok
+
+    GroupService->>GroupMembershipRepository: save(GroupMembership{studentId, groupId, role=MEMBER, joinedAt=now})
+    GroupMembershipRepository-->>GroupService: ok
+
+    Note over GroupService: Bulk-update ALL other PENDING invitations<br/>for this student across ALL groups → AUTO_DENIED
+    GroupService->>GroupInvitationRepository: bulkUpdateStatus(inviteeId=studentUUID, oldStatus=PENDING, newStatus=AUTO_DENIED, excludeId=invitationId)
+    GroupInvitationRepository-->>GroupService: updatedCount
+
+    GroupService-->>InvitationController: GroupDetailResponse (full group detail)
+    InvitationController-->>Student: 200 {id, groupName, termId, status, members:[...]}
+```

--- a/docs/process2/sequences/2.4_2.5_bind_tools_p2.md
+++ b/docs/process2/sequences/2.4_2.5_bind_tools_p2.md
@@ -1,0 +1,157 @@
+# Sequence Diagram — P2 Sub-Processes 2.4 & 2.5
+## Validate & Bind JIRA / GitHub
+
+> Endpoints: `POST /api/groups/{groupId}/jira`, `POST /api/groups/{groupId}/github`
+> Issues: B-06, B-10, B-11, B-12, B-14
+> JWT principal = internal student UUID
+> Both flows are structurally identical — JIRA shown in full, GitHub shown with diffs only.
+
+---
+
+### POST /api/groups/{groupId}/jira (Bind JIRA)
+
+```mermaid
+sequenceDiagram
+    actor Student as Student (Team Leader)
+    participant GroupController
+    participant GroupService
+    participant GroupMembershipRepository
+    participant JiraValidationService
+    participant JiraAPI as JIRA REST API
+    participant EncryptionService
+    participant ProjectGroupRepository
+
+    Student->>GroupController: POST /api/groups/{groupId}/jira<br/>{jiraSpaceUrl, jiraProjectKey, jiraApiToken}<br/>Authorization: Bearer <student_jwt>
+
+    GroupController->>GroupController: extract requesterUUID from SecurityContext
+    GroupController->>GroupService: bindJira(groupId, jiraSpaceUrl, jiraProjectKey, jiraApiToken, requesterUUID)
+
+    GroupService->>GroupMembershipRepository: findByGroupIdAndStudentId(groupId, requesterUUID)
+    GroupMembershipRepository-->>GroupService: Optional<GroupMembership>
+
+    alt not TEAM_LEADER
+        GroupService-->>GroupController: throw ForbiddenException
+        GroupController-->>Student: 403 {"error": "Only the Team Leader can bind tool integrations"}
+    end
+
+    Note over GroupService: DISBANDED freeze — fetch group before any external call
+    GroupService->>ProjectGroupRepository: findById(groupId)
+    ProjectGroupRepository-->>GroupService: ProjectGroup
+
+    alt group.status == DISBANDED
+        GroupService-->>GroupController: throw BusinessRuleException
+        GroupController-->>Student: 400 {"error": "This group has been disbanded"}
+    end
+
+    Note over GroupService,JiraAPI: Live validation — nothing is stored until this passes
+    GroupService->>JiraValidationService: validate(jiraSpaceUrl, jiraProjectKey, jiraApiToken)
+    JiraValidationService->>JiraAPI: GET {jiraSpaceUrl}/rest/api/3/project/{jiraProjectKey}<br/>Authorization: Bearer {token}<br/>timeout: 5s
+
+    alt 401 / 403
+        JiraAPI-->>JiraValidationService: 401/403
+        JiraValidationService-->>GroupService: throw JiraValidationException
+        GroupService-->>GroupController: propagate
+        GroupController-->>Student: 422 {"error": "JIRA validation failed: API token is invalid or expired"}
+    else 404
+        JiraAPI-->>JiraValidationService: 404
+        JiraValidationService-->>GroupService: throw JiraValidationException
+        GroupController-->>Student: 422 {"error": "JIRA validation failed: Project key '{key}' not found"}
+    else timeout / network error
+        JiraAPI-->>JiraValidationService: timeout
+        JiraValidationService-->>GroupService: throw JiraValidationException
+        GroupController-->>Student: 422 {"error": "JIRA validation failed: JIRA space URL is unreachable"}
+    else 200 OK
+        JiraAPI-->>JiraValidationService: 200
+        JiraValidationService-->>GroupService: return (no exception)
+    end
+
+    GroupService->>EncryptionService: encrypt(jiraApiToken)
+    EncryptionService-->>GroupService: encryptedToken (Base64Url[IV || ciphertext || authTag])
+
+    Note over GroupService: Update group fields (already fetched above).<br/>Determine new status:<br/>- GitHub already bound → TOOLS_BOUND<br/>- GitHub not bound → TOOLS_PENDING (or stays FORMING if first tool)
+    GroupService->>GroupService: newStatus = githubAlreadyBound ? TOOLS_BOUND : (status == FORMING ? TOOLS_PENDING : status)
+
+    GroupService->>ProjectGroupRepository: save(group{jiraSpaceUrl, jiraProjectKey, encryptedJiraToken, status=newStatus})
+    ProjectGroupRepository-->>GroupService: savedGroup
+
+    GroupService-->>GroupController: BindToolResponse
+    GroupController-->>Student: 200 {groupId, status, jiraSpaceUrl, jiraProjectKey, jiraBound:true}
+```
+
+---
+
+### POST /api/groups/{groupId}/github (Bind GitHub)
+
+```mermaid
+sequenceDiagram
+    actor Student as Student (Team Leader)
+    participant GroupController
+    participant GroupService
+    participant GroupMembershipRepository
+    participant GitHubValidationService
+    participant GitHubAPI as GitHub REST API
+    participant EncryptionService
+    participant ProjectGroupRepository
+
+    Student->>GroupController: POST /api/groups/{groupId}/github<br/>{githubOrgName, githubPat}<br/>Authorization: Bearer <student_jwt>
+
+    GroupController->>GroupController: extract requesterUUID from SecurityContext
+    GroupController->>GroupService: bindGitHub(groupId, githubOrgName, githubPat, requesterUUID)
+
+    GroupService->>GroupMembershipRepository: findByGroupIdAndStudentId(groupId, requesterUUID)
+    GroupMembershipRepository-->>GroupService: Optional<GroupMembership>
+
+    alt not TEAM_LEADER
+        GroupService-->>GroupController: throw ForbiddenException
+        GroupController-->>Student: 403 {"error": "Only the Team Leader can bind tool integrations"}
+    end
+
+    Note over GroupService: DISBANDED freeze — fetch group before any external call
+    GroupService->>ProjectGroupRepository: findById(groupId)
+    ProjectGroupRepository-->>GroupService: ProjectGroup
+
+    alt group.status == DISBANDED
+        GroupService-->>GroupController: throw BusinessRuleException
+        GroupController-->>Student: 400 {"error": "This group has been disbanded"}
+    end
+
+    Note over GroupService,GitHubAPI: Two sequential calls — second is skipped if first fails
+    GroupService->>GitHubValidationService: validate(githubOrgName, githubPat)
+
+    GitHubValidationService->>GitHubAPI: GET /orgs/{githubOrgName}<br/>Authorization: Bearer {githubPat}<br/>timeout: 5s
+
+    alt 401
+        GitHubAPI-->>GitHubValidationService: 401
+        GitHubValidationService-->>GroupService: throw GitHubValidationException
+        GroupController-->>Student: 422 {"error": "GitHub validation failed: PAT is invalid or expired"}
+    else 404
+        GitHubAPI-->>GitHubValidationService: 404
+        GitHubValidationService-->>GroupService: throw GitHubValidationException
+        GroupController-->>Student: 422 {"error": "GitHub validation failed: Organization '{name}' not found"}
+    else 200 OK — org found, PAT valid
+        GitHubAPI-->>GitHubValidationService: 200
+
+        GitHubValidationService->>GitHubAPI: GET /orgs/{githubOrgName}/repos?per_page=1<br/>Authorization: Bearer {githubPat}
+
+        alt 403 — missing repo scope
+            GitHubAPI-->>GitHubValidationService: 403
+            GitHubValidationService-->>GroupService: throw GitHubValidationException
+            GroupController-->>Student: 422 {"error": "GitHub validation failed: PAT lacks required 'repo' scope"}
+        else 200 OK
+            GitHubAPI-->>GitHubValidationService: 200
+            GitHubValidationService-->>GroupService: return (no exception)
+        end
+    end
+
+    GroupService->>EncryptionService: encrypt(githubPat)
+    EncryptionService-->>GroupService: encryptedPat
+
+    Note over GroupService: Determine new status (already fetched above):<br/>- JIRA already bound → TOOLS_BOUND<br/>- JIRA not bound → TOOLS_PENDING
+    GroupService->>GroupService: newStatus = jiraAlreadyBound ? TOOLS_BOUND : TOOLS_PENDING
+
+    GroupService->>ProjectGroupRepository: save(group{githubOrgName, encryptedGithubPat, status=newStatus})
+    ProjectGroupRepository-->>GroupService: savedGroup
+
+    GroupService-->>GroupController: BindToolResponse
+    GroupController-->>Student: 200 {groupId, status, githubOrgName, githubBound:true}
+```

--- a/docs/process2/sequences/2.6_coordinator_override_p2.md
+++ b/docs/process2/sequences/2.6_coordinator_override_p2.md
@@ -1,0 +1,206 @@
+# Sequence Diagram — P2 Sub-Process 2.6
+## Coordinator Group Override
+
+> Endpoints: `GET /api/coordinator/groups`, `GET /api/coordinator/groups/{groupId}`, `PATCH /api/coordinator/groups/{groupId}/members`, `PATCH /api/coordinator/groups/{groupId}/disband`
+> Issues: B-13, B-16
+> Auth: Staff JWT with role=Coordinator — enforced by SecurityConfig (`hasRole("COORDINATOR")`), no manual check needed in controller.
+
+---
+
+### GET /api/coordinator/groups
+
+> ⚠️ ADR update: `termId` was removed as a query param. Resolved server-side via `TermConfigService.getActiveTermId()`.
+
+```mermaid
+sequenceDiagram
+    actor Coordinator
+    participant CoordinatorGroupController
+    participant GroupService
+    participant TermConfigService
+    participant ProjectGroupRepository
+
+    Coordinator->>CoordinatorGroupController: GET /api/coordinator/groups<br/>Authorization: Bearer <staff_jwt>
+
+    Note over CoordinatorGroupController: Role=COORDINATOR enforced by SecurityConfig — no manual check
+    Note over CoordinatorGroupController: termId resolved server-side — never from client
+
+    CoordinatorGroupController->>GroupService: getGroupsForActiveTerm()
+
+    GroupService->>TermConfigService: getActiveTermId()
+    TermConfigService-->>GroupService: termId
+
+    GroupService->>ProjectGroupRepository: findByTermId(termId)
+    ProjectGroupRepository-->>GroupService: List<ProjectGroup>
+
+    GroupService-->>CoordinatorGroupController: List<GroupSummaryResponse>
+    CoordinatorGroupController-->>Coordinator: 200 [{id, groupName, termId, status, memberCount, jiraBound, githubBound}, ...]
+```
+
+---
+
+### GET /api/coordinator/groups/{groupId}
+
+```mermaid
+sequenceDiagram
+    actor Coordinator
+    participant CoordinatorGroupController
+    participant GroupService
+    participant ProjectGroupRepository
+
+    Coordinator->>CoordinatorGroupController: GET /api/coordinator/groups/{groupId}<br/>Authorization: Bearer <staff_jwt>
+
+    CoordinatorGroupController->>GroupService: getGroupDetail(groupId)
+    GroupService->>ProjectGroupRepository: findById(groupId) with members
+    ProjectGroupRepository-->>GroupService: Optional<ProjectGroup>
+
+    alt not found
+        GroupService-->>CoordinatorGroupController: throw GroupNotFoundException
+        CoordinatorGroupController-->>Coordinator: 404 {"error": "Group not found"}
+    end
+
+    Note over GroupService: Never include encryptedJiraToken or encryptedGithubPat in response
+    GroupService-->>CoordinatorGroupController: GroupDetailResponse
+    CoordinatorGroupController-->>Coordinator: 200 {id, groupName, termId, status, jiraSpaceUrl, jiraProjectKey, jiraBound, githubOrgName, githubBound, members:[...]}
+```
+
+---
+
+### PATCH /api/coordinator/groups/{groupId}/members
+
+```mermaid
+sequenceDiagram
+    actor Coordinator
+    participant CoordinatorGroupController
+    participant GroupService
+    participant ProjectGroupRepository
+    participant StudentRepository
+    participant GroupMembershipRepository
+
+    Coordinator->>CoordinatorGroupController: PATCH /api/coordinator/groups/{groupId}/members<br/>{studentId, action:"ADD"|"REMOVE"}<br/>Authorization: Bearer <staff_jwt>
+
+    alt action is not ADD or REMOVE
+        CoordinatorGroupController-->>Coordinator: 400 {"error": "action must be ADD or REMOVE"}
+    end
+
+    alt action == ADD
+        CoordinatorGroupController->>GroupService: coordinatorAddStudent(groupId, studentId)
+
+        GroupService->>ProjectGroupRepository: findById(groupId)
+        ProjectGroupRepository-->>GroupService: Optional<ProjectGroup>
+
+        alt group not found
+            GroupService-->>CoordinatorGroupController: throw GroupNotFoundException
+            CoordinatorGroupController-->>Coordinator: 404 {"error": "Group not found"}
+        end
+
+        GroupService->>StudentRepository: findByStudentId(studentId)
+        StudentRepository-->>GroupService: Optional<Student>
+
+        alt student not found
+            GroupService-->>CoordinatorGroupController: throw StudentNotFoundException
+            CoordinatorGroupController-->>Coordinator: 404 {"error": "Student '{id}' not found"}
+        end
+
+        GroupService->>GroupMembershipRepository: existsByStudentId(student.id)
+        GroupMembershipRepository-->>GroupService: boolean
+
+        alt already in a group
+            GroupService-->>CoordinatorGroupController: throw AlreadyInGroupException
+            CoordinatorGroupController-->>Coordinator: 400 {"error": "Student '{id}' is already a member of a group"}
+        end
+
+        Note over GroupService: Max team size check (coordinator force-add also enforces cap)
+        GroupService->>TermConfigService: getMaxTeamSize()
+        TermConfigService-->>GroupService: maxTeamSize
+        GroupService->>GroupMembershipRepository: countByGroupId(groupId)
+        GroupMembershipRepository-->>GroupService: memberCount
+
+        alt memberCount >= maxTeamSize
+            GroupService-->>CoordinatorGroupController: throw BusinessRuleException
+            CoordinatorGroupController-->>Coordinator: 400 {"error": "Group has reached maximum team size"}
+        end
+
+        Note over GroupService: @Transactional — membership save + auto-deny atomic
+        GroupService->>GroupMembershipRepository: save(GroupMembership{role=MEMBER})
+        GroupMembershipRepository-->>GroupService: ok
+
+        Note over GroupService: Auto-deny all PENDING invitations for this student (same as acceptance path)
+        GroupService->>GroupInvitationRepository: bulkUpdateStatus(inviteeId=student.id, PENDING → AUTO_DENIED)
+        GroupInvitationRepository-->>GroupService: updatedCount
+
+    else action == REMOVE
+        CoordinatorGroupController->>GroupService: coordinatorRemoveStudent(groupId, studentId)
+
+        GroupService->>StudentRepository: findByStudentId(studentId)
+        StudentRepository-->>GroupService: Optional<Student>
+
+        alt student not found
+            GroupService-->>CoordinatorGroupController: throw StudentNotFoundException
+            CoordinatorGroupController-->>Coordinator: 404 {"error": "Student '{id}' not found"}
+        end
+
+        GroupService->>GroupMembershipRepository: findByGroupIdAndStudentId(groupId, student.id)
+        GroupMembershipRepository-->>GroupService: Optional<GroupMembership>
+
+        alt membership not found
+            GroupService-->>CoordinatorGroupController: throw GroupNotFoundException
+            CoordinatorGroupController-->>Coordinator: 404 {"error": "Group not found"}
+        end
+
+        alt membership.role == TEAM_LEADER
+            GroupService-->>CoordinatorGroupController: throw ForbiddenException
+            CoordinatorGroupController-->>Coordinator: 400 {"error": "Cannot remove Team Leader; transfer leadership first"}
+        end
+
+        GroupService->>GroupMembershipRepository: delete(membership)
+        GroupMembershipRepository-->>GroupService: ok
+    end
+
+    GroupService-->>CoordinatorGroupController: GroupDetailResponse (refreshed)
+    CoordinatorGroupController-->>Coordinator: 200 {full group detail with updated members}
+```
+
+---
+
+### PATCH /api/coordinator/groups/{groupId}/disband
+
+```mermaid
+sequenceDiagram
+    actor Coordinator
+    participant CoordinatorGroupController
+    participant GroupService
+    participant ProjectGroupRepository
+    participant GroupInvitationRepository
+
+    Coordinator->>CoordinatorGroupController: PATCH /api/coordinator/groups/{groupId}/disband<br/>Authorization: Bearer <staff_jwt>
+
+    CoordinatorGroupController->>GroupService: disbandGroup(groupId)
+
+    GroupService->>ProjectGroupRepository: findById(groupId)
+    ProjectGroupRepository-->>GroupService: Optional<ProjectGroup>
+
+    alt not found
+        GroupService-->>CoordinatorGroupController: throw GroupNotFoundException
+        CoordinatorGroupController-->>Coordinator: 404 {"error": "Group not found"}
+    end
+
+    alt group.status == DISBANDED
+        GroupService-->>CoordinatorGroupController: throw BusinessRuleException
+        CoordinatorGroupController-->>Coordinator: 400 {"error": "Group is already disbanded"}
+    end
+
+    Note over GroupService: @Transactional — all three operations atomic
+    GroupService->>ProjectGroupRepository: save(group{status=DISBANDED})
+    ProjectGroupRepository-->>GroupService: ok
+
+    Note over GroupService: Hard-delete all membership rows — frees students to join new groups.<br/>Required by uq_gm_student unique constraint on studentId.
+    GroupService->>GroupMembershipRepository: deleteAllByGroupId(groupId)
+    GroupMembershipRepository-->>GroupService: ok
+
+    Note over GroupService: Auto-deny all PENDING outbound invitations from this group
+    GroupService->>GroupInvitationRepository: bulkUpdateStatusByGroupId(groupId, PENDING → AUTO_DENIED)
+    GroupInvitationRepository-->>GroupService: updatedCount
+
+    GroupService-->>CoordinatorGroupController: {groupId, status:"DISBANDED"}
+    CoordinatorGroupController-->>Coordinator: 200 {groupId, status:"DISBANDED"}
+```

--- a/docs/process2/state_machines_p2.md
+++ b/docs/process2/state_machines_p2.md
@@ -1,0 +1,61 @@
+# P2 State Machine Diagrams
+
+---
+
+## Group Status (P2 + P3 — full lifecycle)
+
+```mermaid
+stateDiagram-v2
+    [*] --> FORMING : Student creates group (2.1)
+
+    FORMING --> TOOLS_PENDING : First tool bound (2.4 or 2.5)
+    FORMING --> TOOLS_BOUND : Both tools bound at once (2.4 + 2.5)
+    TOOLS_PENDING --> TOOLS_BOUND : Second tool bound (2.4 or 2.5)
+
+    FORMING --> DISBANDED : Coordinator disbands (2.6)
+    TOOLS_PENDING --> DISBANDED : Coordinator disbands (2.6)
+    FORMING --> DISBANDED : Sanitization — no advisor at window close (3.4)
+    TOOLS_PENDING --> DISBANDED : Sanitization — no advisor at window close (3.4)
+    TOOLS_BOUND --> DISBANDED : Coordinator disbands (2.6) or sanitization — no advisor at window close (3.4)
+    ADVISOR_ASSIGNED --> DISBANDED : Coordinator disbands (2.6)
+
+    TOOLS_BOUND --> ADVISOR_ASSIGNED : Advisor accepts (3.3) or Coordinator assigns (3.5)
+    ADVISOR_ASSIGNED --> TOOLS_BOUND : Coordinator removes advisor (3.5)
+```
+
+---
+
+## Invitation Status
+
+```mermaid
+stateDiagram-v2
+    [*] --> PENDING : Team Leader sends invitation (2.2)
+
+    PENDING --> ACCEPTED : Invitee accepts (2.3)
+    PENDING --> DECLINED : Invitee declines (2.3)
+    PENDING --> CANCELLED : Team Leader cancels (2.2)
+    PENDING --> AUTO_DENIED : Invitee accepted another invite (2.3) or group disbanded (2.6)
+
+    ACCEPTED --> [*]
+    DECLINED --> [*]
+    CANCELLED --> [*]
+    AUTO_DENIED --> [*]
+```
+
+---
+
+## Combined View — What triggers each Group transition
+
+| From | To | Trigger | Sub-process |
+|---|---|---|---|
+| *(new)* | `FORMING` | Student creates group | 2.1 |
+| `FORMING` | `TOOLS_PENDING` | First tool (JIRA or GitHub) bound | 2.4 / 2.5 |
+| `FORMING` | `TOOLS_BOUND` | Both tools bound at same time | 2.4 / 2.5 |
+| `TOOLS_PENDING` | `TOOLS_BOUND` | Second tool bound | 2.4 / 2.5 |
+| `TOOLS_BOUND` | `ADVISOR_ASSIGNED` | Advisor accepts request | 3.3 |
+| `TOOLS_BOUND` | `ADVISOR_ASSIGNED` | Coordinator force-assigns advisor | 3.5 |
+| `ADVISOR_ASSIGNED` | `TOOLS_BOUND` | Coordinator removes advisor | 3.5 |
+| `FORMING` | `DISBANDED` | Sanitization — no advisor at window close | 3.4 |
+| `TOOLS_PENDING` | `DISBANDED` | Sanitization — no advisor at window close | 3.4 |
+| `TOOLS_BOUND` | `DISBANDED` | Sanitization — no advisor at window close | 3.4 |
+| any | `DISBANDED` | Coordinator force-disbands | 2.6 |

--- a/docs/process3/endpoints_p3.md
+++ b/docs/process3/endpoints_p3.md
@@ -1,0 +1,510 @@
+# Process 3 — API Endpoints
+## Advisor Association & Sanitization (Sub-Processes 3.1–3.5)
+
+> Sources: `dfd_level1_process3.md`, `process3_dfd_lvl1.drawio`
+> All endpoints are under base path `/api/`. Auth via `Authorization: Bearer <JWT>`.
+> SP scale: Fibonacci (1, 2, 3, 5, 8). Difficulty: Easy / Medium / Hard.
+> Builds directly on P2 output — `ProjectGroup`, `GroupMembership`, `ScheduleWindow` entities must exist.
+
+---
+
+## Conventions
+
+| Item | Rule |
+|------|------|
+| Primary keys | UUID |
+| Timestamps | ISO-8601 (`LocalDateTime`) |
+| Student JWT | `sub="Student"`, claim `studentId` |
+| Staff JWT | `sub="StaffUser"`, claim `role` |
+| Error body | `{ "error": "Human-readable message" }` |
+
+### HTTP Status Codes
+
+| Code | Meaning |
+|------|---------|
+| 200 | OK |
+| 201 | Resource created |
+| 400 | Business rule violation |
+| 403 | Role / ownership mismatch |
+| 404 | Resource not found |
+| 409 | Conflict (duplicate / already active request) |
+
+---
+
+## 3.1 — Browse Advisors & Send Request
+
+### `GET /api/advisors` — SP: 2 | Difficulty: Easy
+**Auth:** Student JWT | **Issue:** P3-API-01
+
+Returns all `Professor` staff users who are **below capacity** for the active term.
+`termId` is resolved server-side via `TermConfigService.getActiveTermId()` — never passed by the client.
+Capacity is stored on `StaffUser.advisorCapacity` (default 5).
+
+**Query params:** _(none)_
+
+**Response 200:**
+```json
+[
+  {
+    "advisorId": "uuid",
+    "name": "string",
+    "mail": "string",
+    "currentGroupCount": 2,
+    "capacity": 5
+  }
+]
+```
+
+---
+
+### `POST /api/groups/{groupId}/advisor-request` — SP: 5 | Difficulty: Hard
+**Auth:** Student JWT (must be `TEAM_LEADER` of `groupId`) | **Issue:** P3-API-01
+
+Checks schedule window → group status → existing PENDING request → advisor capacity → creates `AdvisorRequest`.
+
+**Request:**
+```json
+{
+  "advisorId": "uuid"
+}
+```
+
+**Response 201:**
+```json
+{
+  "requestId": "uuid",
+  "groupId": "uuid",
+  "advisorId": "uuid",
+  "status": "PENDING",
+  "sentAt": "ISO-8601"
+}
+```
+
+**Errors:**
+```
+403  { "error": "Only the Team Leader can send advisor requests" }
+400  { "error": "Advisor association window is not currently active" }
+400  { "error": "Group must be in TOOLS_BOUND status to request an advisor" }
+409  { "error": "Group already has an active pending advisor request" }
+400  { "error": "Advisor has reached maximum group capacity for this term" }
+404  { "error": "Advisor not found" }
+```
+
+---
+
+### `GET /api/groups/{groupId}/advisor-request` — SP: 1 | Difficulty: Easy
+**Auth:** Student JWT (must be member of `groupId`) | **Issue:** P3-API-01
+
+Returns the most recent `AdvisorRequest` for the group (any status).
+
+**Response 200:**
+```json
+{
+  "requestId": "uuid",
+  "advisorId": "uuid",
+  "advisorName": "string",
+  "status": "PENDING | ACCEPTED | REJECTED | AUTO_REJECTED | CANCELLED",
+  "sentAt": "ISO-8601",
+  "respondedAt": "ISO-8601 | null"
+}
+```
+
+**Errors:**
+```
+404  { "error": "No advisor request found for this group" }
+403  { "error": "You are not a member of this group" }
+```
+
+---
+
+### `DELETE /api/groups/{groupId}/advisor-request` — SP: 2 | Difficulty: Easy
+**Auth:** Student JWT (must be `TEAM_LEADER` of `groupId`) | **Issue:** P3-API-01
+
+Cancels the active `PENDING` advisor request. Sets status to `CANCELLED`.
+
+**Response 200:**
+```json
+{
+  "requestId": "uuid",
+  "status": "CANCELLED"
+}
+```
+
+**Errors:**
+```
+403  { "error": "Only the Team Leader can cancel advisor requests" }
+400  { "error": "No active pending request to cancel" }
+404  { "error": "Group not found" }
+404  { "error": "No advisor request found for this group" }
+```
+
+---
+
+## 3.2 — Advisor Reviews Pending Requests
+
+### `GET /api/advisor/requests` — SP: 2 | Difficulty: Easy
+**Auth:** Staff JWT (Role = `Professor`) | **Issue:** P3-API-02
+
+Returns all `PENDING` advisor requests addressed to the authenticated professor.
+
+**Response 200:**
+```json
+[
+  {
+    "requestId": "uuid",
+    "groupId": "uuid",
+    "groupName": "string",
+    "termId": "string",
+    "memberCount": 4,
+    "sentAt": "ISO-8601"
+  }
+]
+```
+
+---
+
+### `GET /api/advisor/requests/{requestId}` — SP: 2 | Difficulty: Easy
+**Auth:** Staff JWT (Role = `Professor`, must be the target advisor) | **Issue:** P3-API-02
+
+Returns full request detail including group members and group's Proposal submission summary (read-only context for the advisor to decide).
+
+**Response 200:**
+```json
+{
+  "requestId": "uuid",
+  "group": {
+    "id": "uuid",
+    "groupName": "string",
+    "termId": "string",
+    "status": "TOOLS_BOUND",
+    "members": [
+      { "studentId": "string", "role": "TEAM_LEADER | MEMBER", "joinedAt": "ISO-8601" }
+    ]
+  },
+  "sentAt": "ISO-8601"
+}
+```
+
+**Errors:**
+```
+403  { "error": "This request is not addressed to you" }
+404  { "error": "Request not found" }
+```
+
+---
+
+## 3.3 — Process Association Response
+
+### `PATCH /api/advisor/requests/{requestId}/respond` — SP: 5 | Difficulty: Hard
+**Auth:** Staff JWT (Role = `Professor`, must be the target advisor) | **Issue:** P3-API-03
+
+On `ACCEPTED`:
+- Sets `group.advisorId`
+- Sets `group.status` → `ADVISOR_ASSIGNED`
+- All other `PENDING` requests for the same group → `AUTO_REJECTED`
+- All atomic in one transaction
+
+On `REJECTED`:
+- Only this request's status → `REJECTED`
+- Group status remains `TOOLS_BOUND`
+- Group can send a new request
+
+**Request:**
+```json
+{
+  "accept": true
+}
+```
+
+**Response 200 (accepted):**
+```json
+{
+  "requestId": "uuid",
+  "status": "ACCEPTED",
+  "groupId": "uuid",
+  "groupStatus": "ADVISOR_ASSIGNED"
+}
+```
+
+**Response 200 (rejected):**
+```json
+{
+  "requestId": "uuid",
+  "status": "REJECTED"
+}
+```
+
+**Errors:**
+```
+403  { "error": "This request is not addressed to you" }
+400  { "error": "Request is no longer pending" }
+404  { "error": "Request not found" }
+```
+
+---
+
+## 3.4 — Auto-Sanitization
+
+### `POST /api/coordinator/sanitize` — SP: 3 | Difficulty: Medium
+**Auth:** Staff JWT (Role = `Coordinator`) | **Issue:** P3-API-04
+
+Manually triggers the sanitization job. Normally runs automatically when the `ADVISOR_ASSOCIATION` window `closesAt` passes.
+
+Disbands all groups **without** an assigned advisor (status `FORMING`, `TOOLS_PENDING`, `TOOLS_BOUND`).
+Hard-deletes all `GroupMembership` rows for each disbanded group (freeing students to rejoin next term).
+All `PENDING` advisor requests for disbanded groups → `AUTO_REJECTED`.
+
+**Request (optional body):**
+```json
+{ "force": true }
+```
+Omit body or send `{}` for normal trigger (window must be closed). Include `{ "force": true }` to trigger early while window is still active.
+
+**Response 200:**
+```json
+{
+  "disbandedCount": 3,
+  "autoRejectedRequestCount": 5,
+  "triggeredAt": "ISO-8601"
+}
+```
+
+**Errors:**
+```
+400  { "error": "Advisor association window is still active — cannot sanitize early without confirmation" }
+```
+
+---
+
+## 3.5 — Coordinator Advisor Override
+
+### `GET /api/coordinator/advisors` — SP: 1 | Difficulty: Easy
+**Auth:** Staff JWT (Role = `Coordinator`) | **Issue:** P3-API-05
+
+Lists all professors with their current group assignment count and capacity for the active term. Includes advisors at capacity (unlike the student-facing endpoint).
+`termId` resolved server-side via `TermConfigService.getActiveTermId()`.
+
+**Query params:** _(none)_
+
+**Response 200:**
+```json
+[
+  {
+    "advisorId": "uuid",
+    "name": "string",
+    "mail": "string",
+    "currentGroupCount": 5,
+    "capacity": 5,
+    "atCapacity": true
+  }
+]
+```
+
+---
+
+### `PATCH /api/coordinator/groups/{groupId}/advisor` — SP: 3 | Difficulty: Medium
+**Auth:** Staff JWT (Role = `Coordinator`) | **Issue:** P3-API-05
+
+Bypasses the request flow and window check entirely.
+
+- `ASSIGN`: sets `group.advisorId`, status → `ADVISOR_ASSIGNED`. Capacity constraint **not** enforced. Auto-rejects any `PENDING` advisor requests for the group.
+- `REMOVE`: clears `group.advisorId`, status → `TOOLS_BOUND`.
+
+**Request:**
+```json
+{
+  "action": "ASSIGN | REMOVE",
+  "advisorId": "uuid | null"
+}
+```
+
+> `advisorId` is **required** when `action = "ASSIGN"` (return 400 if absent), **optional/nullable** when `action = "REMOVE"`. DTO field should be `@Nullable` — do not use `@NotNull`.
+
+**Response 200:**
+```json
+{
+  "groupId": "uuid",
+  "status": "ADVISOR_ASSIGNED | TOOLS_BOUND",
+  "advisorId": "uuid | null"
+}
+```
+
+**Errors:**
+```
+400  { "error": "advisorId is required for ASSIGN action" }
+400  { "error": "Group already has this advisor assigned" }
+400  { "error": "Group has no advisor to remove" }
+404  { "error": "Group not found" }
+404  { "error": "Advisor not found" }
+```
+
+---
+
+## Endpoint Summary Table
+
+| # | Method | Path | Auth | Sub-process | Issue | SP | Difficulty |
+|---|--------|------|------|-------------|-------|----|------------|
+| 1 | GET | `/api/advisors` | Student | 3.1 | P3-API-01 | 2 | Easy |
+| 2 | POST | `/api/groups/{groupId}/advisor-request` | Student (TEAM_LEADER) | 3.1 | P3-API-01 | 5 | Hard |
+| 3 | GET | `/api/groups/{groupId}/advisor-request` | Student (member) | 3.1 | P3-API-01 | 1 | Easy |
+| 4 | DELETE | `/api/groups/{groupId}/advisor-request` | Student (TEAM_LEADER) | 3.1 | P3-API-01 | 2 | Easy |
+| 5 | GET | `/api/advisor/requests` | Staff (Professor) | 3.2 | P3-API-02 | 2 | Easy |
+| 6 | GET | `/api/advisor/requests/{requestId}` | Staff (Professor) | 3.2 | P3-API-02 | 2 | Easy |
+| 7 | PATCH | `/api/advisor/requests/{requestId}/respond` | Staff (Professor) | 3.3 | P3-API-03 | 5 | Hard |
+| 8 | POST | `/api/coordinator/sanitize` | Staff (Coordinator) | 3.4 | P3-API-04 | 3 | Medium |
+| 9 | GET | `/api/coordinator/advisors` | Staff (Coordinator) | 3.5 | P3-API-05 | 1 | Easy |
+| 10 | PATCH | `/api/coordinator/groups/{groupId}/advisor` | Staff (Coordinator) | 3.5 | P3-API-05 | 3 | Medium |
+
+**Total SP: 26**
+
+---
+
+## Issue Breakdown
+
+### P3-API-01 — Advisor Browse & Request (DFD 3.1)
+**SP: 10** | Depends on: P2 INFRA-01 (entities), P2 API-01 (ProjectGroup exists), B-07 (Student JWT)
+
+Endpoints 1–4. The `POST` is the hardest — five precondition checks before any write.
+
+**Acceptance criteria:**
+- [ ] `GET /api/advisors` only returns advisors where `currentGroupCount < capacity`
+- [ ] `POST` returns 400 if `ADVISOR_ASSOCIATION` window is not active for the group's `termId`
+- [ ] `POST` returns 400 if group status is not `TOOLS_BOUND`
+- [ ] `POST` returns 409 if group already has a `PENDING` request (regardless of target advisor)
+- [ ] `POST` returns 400 if target advisor is at capacity
+- [ ] `DELETE` returns 400 if no `PENDING` request exists
+
+---
+
+### P3-API-02 — Advisor Request Review (DFD 3.2)
+**SP: 4** | Depends on: P3-API-01
+
+Endpoints 5–6. Pure reads. Detail endpoint includes group member list.
+
+**Acceptance criteria:**
+- [ ] `GET /api/advisor/requests` returns empty list (not 404) when no pending requests exist
+- [ ] `GET /api/advisor/requests/{id}` returns 403 if the authenticated professor is not the target advisor
+- [ ] Neither endpoint modifies any state
+
+---
+
+### P3-API-03 — Advisor Association Response (DFD 3.3)
+**SP: 5** | Depends on: P3-API-02
+
+Endpoint 7. Hardest endpoint in P3.
+
+**Acceptance criteria:**
+- [ ] On `accept: true` — `group.advisorId` is set and `group.status` = `ADVISOR_ASSIGNED` in DB
+- [ ] On `accept: true` — all other `PENDING` requests for the same group are `AUTO_REJECTED` in the same transaction
+- [ ] On `accept: false` — only the target request is updated; group status unchanged; no other requests affected
+- [ ] Returns 400 if request is not `PENDING`
+- [ ] Returns 403 if authenticated professor is not the target advisor
+
+---
+
+### P3-API-04 — Auto-Sanitization (DFD 3.4)
+**SP: 3** | Depends on: P3-API-01, `@Scheduled` job setup
+
+Endpoint 8 + scheduled job.
+
+**Acceptance criteria:**
+- [ ] Scheduled job fires automatically when `ADVISOR_ASSOCIATION` window `closesAt` passes
+- [ ] Manual trigger via `POST /api/coordinator/sanitize` produces identical result
+- [ ] Only groups without `advisorId` are disbanded — `ADVISOR_ASSIGNED` groups are untouched
+- [ ] All `PENDING` advisor requests for disbanded groups are `AUTO_REJECTED` atomically
+- [ ] `SanitizationReport` response includes correct counts
+- [ ] `force: true` body allows early trigger while window is still active
+
+---
+
+### P3-API-05 — Coordinator Advisor Override (DFD 3.5)
+**SP: 4** | Depends on: P3-API-01
+
+Endpoints 9–10.
+
+**Acceptance criteria:**
+- [ ] `ASSIGN` works even if advisor is at capacity (capacity not enforced for coordinator)
+- [ ] `ASSIGN` works even if `ADVISOR_ASSOCIATION` window is closed (window not checked for coordinator)
+- [ ] `ASSIGN` auto-rejects any `PENDING` advisor requests for the group
+- [ ] `REMOVE` sets `group.status` back to `TOOLS_BOUND` and clears `group.advisorId`
+- [ ] Both actions return 403 for Staff JWT with role `Professor` or `Admin`
+
+---
+
+## New Entities Required
+
+### `AdvisorRequest`
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `id` | UUID PK | |
+| `group` | `@ManyToOne ProjectGroup` | FK, NOT NULL |
+| `advisor` | `@ManyToOne StaffUser` | FK, NOT NULL |
+| `status` | `AdvisorRequestStatus` enum | default `PENDING` |
+| `sentAt` | LocalDateTime | NOT NULL |
+| `respondedAt` | LocalDateTime | NULLABLE |
+
+One active `PENDING` request per group enforced at service layer (409), not DB constraint.
+
+### `AdvisorRequestRepository` (required methods)
+
+| Method | Used by |
+|--------|---------|
+| `findByGroupIdAndStatus(UUID groupId, AdvisorRequestStatus status)` | 3.1 (duplicate check, cancel) |
+| `findByAdvisorIdAndStatus(UUID advisorId, AdvisorRequestStatus status)` | 3.2 (list pending for professor) |
+| `findById(UUID id)` | 3.3, 3.2 detail |
+| `findTopByGroupIdOrderBySentAtDesc(UUID groupId)` | 3.1 GET request status |
+| `@Modifying @Query bulkUpdateStatus(UUID groupId, AdvisorRequestStatus oldStatus, AdvisorRequestStatus newStatus, UUID excludeId)` | 3.3 ACCEPT (auto-reject other requests for same group) |
+| `@Modifying @Query bulkUpdateStatusByGroupId(UUID groupId, AdvisorRequestStatus oldStatus, AdvisorRequestStatus newStatus)` | 3.4 sanitization, 3.5 ASSIGN |
+
+### `ProjectGroup` additions (P3 extends P2 entity)
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `advisorId` | UUID (FK to `StaffUser`) | NULLABLE — set on `ADVISOR_ASSIGNED` |
+
+### `StaffUser` additions
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `advisorCapacity` | int | Default 5 — max groups per term for Professor role |
+
+---
+
+## GroupStatus State Machine (full — P2 + P3)
+
+```
+FORMING ──(first tool bound)──────────────► TOOLS_PENDING
+FORMING ──(both tools bound simultaneously)► TOOLS_BOUND
+TOOLS_PENDING ──(second tool bound)────────► TOOLS_BOUND
+TOOLS_BOUND ──(advisor accepts)────────────► ADVISOR_ASSIGNED
+FORMING       ──(sanitization: window closes)► DISBANDED
+TOOLS_PENDING ──(sanitization: window closes)► DISBANDED
+TOOLS_BOUND   ──(sanitization: window closes)► DISBANDED
+ADVISOR_ASSIGNED ──(coordinator removes)───► TOOLS_BOUND
+Any state ──(coordinator disbands)─────────► DISBANDED
+```
+
+---
+
+## AdvisorRequestStatus Enum
+
+```
+PENDING       — sent by TEAM_LEADER, awaiting advisor response
+ACCEPTED      — advisor accepted; group.advisorId is now set
+REJECTED      — advisor declined; group may send a new request
+AUTO_REJECTED — rejected when group's other request was accepted, or group was disbanded
+CANCELLED     — TEAM_LEADER withdrew the request before advisor responded
+```
+
+---
+
+## Security Notes
+
+| Rule | Detail |
+|------|--------|
+| Student endpoints | Require `sub="Student"` JWT |
+| Professor endpoints (`/api/advisor/**`) | Require `role=PROFESSOR` Staff JWT — `SecurityConfig` must add `hasRole("PROFESSOR")` for `/api/advisor/**` (Blue Team action item from sequence 3.2 note) |
+| Coordinator endpoints (`/api/coordinator/**`) | Require `role=COORDINATOR` Staff JWT — already enforced by `SecurityConfig` |
+| Admin role | `ADMIN` role never has `COORDINATOR` or `PROFESSOR` — it is blocked from all P2/P3 endpoints automatically by `SecurityConfig`. No extra manual check needed. |
+| `advisorId` in responses | Always returned as UUID — no sensitive data exposed |

--- a/docs/process3/p3_issues.md
+++ b/docs/process3/p3_issues.md
@@ -1,0 +1,258 @@
+# P3 Issues — Sprint 2
+
+
+---
+
+## [Backend] P3 Entities & Repository Additions
+**Estimate:** 1 Point
+
+**Problem Summary:** Extend the data model to support Process 3. Adds `AdvisorRequest` entity and small additions to existing `ProjectGroup` and `StaffUser` entities.
+**Scope:** Backend — Data Layer.
+
+**Deliverables:**
+1. Create `AdvisorRequest` JPA entity: `id` (UUID), `group` (`@ManyToOne ProjectGroup`), `advisor` (`@ManyToOne StaffUser`), `status` (Enum: `PENDING`, `ACCEPTED`, `REJECTED`, `AUTO_REJECTED`, `CANCELLED`), `sentAt`, `respondedAt` (nullable).
+2. Add `AdvisorRequestRepository` with required query methods including `@Modifying bulkUpdateStatus` for cascade rejections.
+3. Update `ProjectGroup` entity: add nullable `advisorId` (FK to `StaffUser`).
+4. Update `StaffUser` entity: add `advisorCapacity` integer column (default 5).
+
+**References:** `endpoints_p3.md`, `er_p2_p3.md`.
+**Acceptance Criteria:**
+- [ ] `advisorId` on `ProjectGroup` is nullable and persists correctly.
+- [ ] `bulkUpdateStatus` properly updates request statuses in bulk (excluding a target ID if specified).
+- [ ] Schema changes auto-generate via Hibernate on startup.
+
+**Related Issues:** Required by all other Backend P3 issues: **[Backend] AdvisorService — Browse & Request Flow**, **[Backend] AdvisorService — Review & Respond Flow**, **[Backend] SanitizationService — Auto-Disband Scheduler**, **[Backend] P3 Controllers, DTOs & Coordinator Override**. Note: `@Version Long version` on `ProjectGroup` is already covered by **[Backend] P2 Core Domain Entities & Repositories**.
+
+---
+
+## [Backend] AdvisorService — Browse & Request Flow
+**Estimate:** 2 Points
+
+**Problem Summary:** Implement the service methods enabling a Team Leader to browse available advisors and manage their single active advisor request.
+**Scope:** Backend — Service Layer.
+
+**Deliverables:**
+1. `getAvailableAdvisors()`: Fetch active term via `TermConfigService.getActiveTermId()`, query all Professors, calculate current active groups per professor, return only those below `advisorCapacity`.
+2. `sendAdvisorRequest()`: Check active `ADVISOR_ASSOCIATION` window, enforce `TOOLS_BOUND` status, verify no existing `PENDING` request, check advisor capacity, save request.
+3. `getAdvisorRequest()` & `cancelAdvisorRequest()`: Fetch or cancel the active pending request for the caller's group.
+
+**References:** Process 3 (DFD 3.1), `3.1_advisor_request_p3.md`, `endpoints_p3.md` (P3-API-01).
+**Acceptance Criteria:**
+- [ ] `termId` resolved server-side via `TermConfigService` — never from client.
+- [ ] `sendAdvisorRequest` returns 400 if group is not `TOOLS_BOUND`.
+- [ ] `sendAdvisorRequest` returns 409 if another `PENDING` request already exists for the group.
+- [ ] `getAvailableAdvisors` filters out advisors where `currentGroupCount >= advisorCapacity`.
+
+**Related Issues:** Depends on **[Backend] P3 Entities & Repository Additions**.
+
+---
+
+## [Backend] AdvisorService — Review & Respond Flow
+**Estimate:** 2 Points
+
+**Problem Summary:** Implement the logic allowing a Professor to view their pending requests and accept or decline them. Accepting requires a transactional capacity guard to prevent race conditions.
+**Scope:** Backend — Service Layer.
+
+**Deliverables:**
+1. `getPendingRequestsForAdvisor(professorId)` & `getRequestDetail(requestId, professorId)`: Return read-only request data.
+2. `respondToRequest(requestId, professorId, accept)`: Process the advisor's decision.
+3. **Capacity Guard:** Inside the `@Transactional` block on `ACCEPT`, re-run `ProjectGroupRepository.countByAdvisorIdAndTermIdAndStatusNot(advisorId, termId, GroupStatus.DISBANDED)`. If at capacity, throw `AdvisorAtCapacityException` (400) and roll back. **Do NOT auto-reject the request** — it stays `PENDING` so the group can retry later.
+4. **Cascade Rejections:** On `ACCEPT`, assign `advisorId` to group, update group status to `ADVISOR_ASSIGNED`, bulk update all other `PENDING` requests for this group to `AUTO_REJECTED`.
+
+**References:** Process 3 (DFD 3.2, 3.3), `3.2_3.3_advisor_respond_p3.md`, `endpoints_p3.md` (P3-API-02, P3-API-03).
+**Acceptance Criteria:**
+- [ ] `respondToRequest(accept=true)` changes group status to `ADVISOR_ASSIGNED` and links the advisor.
+- [ ] Capacity Guard throws `AdvisorAtCapacityException` (400) and rolls back if advisor exceeds capacity inside the transaction.
+- [ ] Cascade rejection sets all competing `PENDING` requests for the same group to `AUTO_REJECTED` atomically.
+
+**Related Issues:** Depends on **[Backend] P3 Entities & Repository Additions**, **[Backend] AdvisorService — Browse & Request Flow**.
+
+---
+
+## [Backend] SanitizationService — Auto-Disband Scheduler
+**Estimate:** 2 Points
+
+**Problem Summary:** Implement the scheduled job and manual trigger to disband unadvised groups once the association window closes, utilizing optimistic locking to prevent race conditions.
+**Scope:** Backend — Service Layer & Scheduler.
+
+**Deliverables:**
+1. Create `SanitizationService` with `@Scheduled` method checking for newly closed `ADVISOR_ASSOCIATION` windows.
+2. `runSanitization(termId, force)`: Query all groups without an `advisorId` (status `FORMING`, `TOOLS_PENDING`, `TOOLS_BOUND`) and mark them `DISBANDED`.
+3. Hard-delete associated `GroupMembership` rows.
+4. Atomically bulk update all their `PENDING` advisor requests to `AUTO_REJECTED`.
+5. Handle `OptimisticLockException` gracefully in the disband loop — skip group if concurrently modified by an advisor accept, continue loop.
+
+**References:** Process 3 (DFD 3.4), `3.4_sanitization_p3.md`, `endpoints_p3.md` (P3-API-04).
+**Acceptance Criteria:**
+- [ ] Groups lacking an `advisorId` transition to `DISBANDED` upon window close.
+- [ ] `OptimisticLockException` triggered by `@Version` correctly skips the group — does not halt the entire job.
+- [ ] Manual trigger `POST /api/coordinator/sanitize` requires `force: true` if the schedule window is still open.
+
+**Related Issues:** Depends on **[Backend] P3 Entities & Repository Additions**.
+
+---
+
+## [Backend] P3 Controllers, DTOs & Coordinator Override
+**Estimate:** 2 Points
+
+**Problem Summary:** Map all Process 3 REST endpoints, create Request/Response DTOs, wire to services, and implement the Coordinator advisor override service methods.
+**Scope:** Backend — Controller & Service Layer.
+
+**Deliverables:**
+1. Create `AdvisorController` for Student (`/api/advisors`, `/api/groups/{id}/advisor-request`) and Professor (`/api/advisor/requests/**`) endpoints.
+2. Update `CoordinatorGroupController` with `/api/coordinator/advisors` and `/api/coordinator/groups/{groupId}/advisor`.
+3. Add `SanitizationController` for `POST /api/coordinator/sanitize`.
+4. Create DTOs: `AdvisorRequestResponse`, `AdvisorCapacityResponse`, `SanitizationReport`.
+5. Ensure Professor endpoints use `@PreAuthorize("hasRole('PROFESSOR')")`.
+6. Implement coordinator override methods:
+   - `getAllAdvisorsWithCapacity()`: bypasses capacity filter, includes `atCapacity` flag.
+   - `assignAdvisor(groupId, advisorId)`: Two guards before write — (a) throw 400 if `group.status == DISBANDED`; (b) throw 400 if `group.status` is not `TOOLS_BOUND` and not `ADVISOR_ASSIGNED`. On success, set `group.advisorId`, set `group.status = ADVISOR_ASSIGNED`, bulk `AUTO_REJECTED` all `PENDING` advisor requests for the group. No capacity check. No window check.
+   - `removeAdvisor(groupId)`: Clears `group.advisorId`, sets `group.status = TOOLS_BOUND`. Throw 400 if group has no advisor.
+7. Amend `GroupService.disbandGroup()` (implemented in **[Backend] Coordinator Override Services & Controller**) to also call `AdvisorRequestRepository.bulkUpdateStatusByGroupId(groupId, PENDING → AUTO_REJECTED)` in the same `@Transactional` block. This is a P3 cleanup step that must be added to the existing P2 disband path once `AdvisorRequestRepository` exists.
+
+**References:** `endpoints_p3.md`, Process 3 (DFD 3.5), `3.5_coordinator_advisor_p3.md`.
+**Acceptance Criteria:**
+- [ ] All request payload validations return 400 correctly.
+- [ ] Role-based access control restricts Student, Professor, and Coordinator endpoints.
+- [ ] Force assignment returns 400 if group is `DISBANDED`.
+- [ ] Force assignment returns 400 if group status is not `TOOLS_BOUND` or `ADVISOR_ASSIGNED`.
+- [ ] Force assignment does not fail if advisor is at or above capacity.
+- [ ] Force assignment atomically triggers cascade `AUTO_REJECTED` for all `PENDING` requests of the group.
+- [ ] Removing an advisor reverts group status to `TOOLS_BOUND`.
+- [ ] Coordinator disband endpoint now also auto-rejects all `PENDING` `AdvisorRequest` rows for the group.
+- [ ] Controllers never accept `termId` as input.
+
+**Related Issues:** Depends on **[Backend] AdvisorService — Browse & Request Flow**, **[Backend] AdvisorService — Review & Respond Flow**, **[Backend] SanitizationService — Auto-Disband Scheduler**.
+
+---
+
+## [Frontend] Student Advisor Discovery & Request UI
+
+**Estimate:** 1 Point
+
+**Problem Summary:** Provide a UI for the Team Leader to browse available advisors, send a request, view the pending request, and cancel it.
+**Scope:** Frontend — Page / Components. **Framework:** Vue.
+
+**Deliverables:**
+1. Advisor Discovery view: fetch `GET /api/advisors`, display cards/list.
+2. Request CTA: POST to `/api/groups/{groupId}/advisor-request`. Handle 400/409 errors gracefully.
+3. Active Request component: show current `PENDING` request on the Group Hub with a "Cancel Request" button.
+
+**References:** `endpoints_p3.md` (P3-API-01), Process 3 (DFD 3.1).
+**Acceptance Criteria:**
+- [ ] Discovery view handles empty state if no advisors have capacity.
+- [ ] Team Leader sees action buttons; normal Members see read-only request status.
+- [ ] Canceling an active request optimistically updates the UI to allow sending a new request.
+
+**Related Issues:** Depends on **[Backend] P3 Controllers, DTOs & Coordinator Override**.
+
+---
+
+## [Frontend] Professor Requests Inbox & Detail View
+
+**Estimate:** 2 Points
+
+**Problem Summary:** Create the dashboard where Professors review incoming advisee requests and accept or decline them.
+**Scope:** Frontend — Page / Components. **Framework:** Vue.
+
+**Deliverables:**
+1. Professor Inbox page (`/advisor/requests`): fetch `GET /api/advisor/requests`.
+2. Request Detail Modal/Page: show group members and details via `GET /api/advisor/requests/{requestId}`.
+3. Accept / Decline action buttons. Must handle 400 capacity guard errors with a clear user-facing message.
+
+**References:** `endpoints_p3.md` (P3-API-02, P3-API-03), Process 3 (DFD 3.2, 3.3).
+**Acceptance Criteria:**
+- [ ] Inbox handles empty state (`[]` response) gracefully.
+- [ ] Accepting a request visually removes it from the pending list and shows success.
+- [ ] A 400 from the Capacity Guard shows a readable error: "You have reached maximum capacity".
+
+**Related Issues:** Depends on **[Backend] P3 Controllers, DTOs & Coordinator Override**.
+
+---
+
+## [Frontend] Coordinator Advisor Override & Sanitization Trigger
+
+**Estimate:** 1 Point
+
+**Problem Summary:** Extend the existing Coordinator Group Detail page with advisor management, and add a manual sanitization trigger to the Coordinator dashboard.
+**Scope:** Frontend — Components. **Framework:** Vue.
+
+**Deliverables:**
+1. Update `/coordinator/groups/:groupId` to include an "Advisor Management" panel with a dropdown fetching `GET /api/coordinator/advisors`. Highlight advisors `atCapacity` but keep them selectable.
+2. Submit assignment (`PATCH .../advisor {action: "ASSIGN"}`). Add "Remove Advisor" button (`PATCH .../advisor {action: "REMOVE"}`), requires confirmation click.
+3. Add "Run Sanitization" button in Coordinator dashboard. Send `POST /api/coordinator/sanitize` (with `{ force: true }` if window is active). Display returned `SanitizationReport` in a modal.
+
+**References:** `endpoints_p3.md` (P3-API-04, P3-API-05), Process 3 (DFD 3.5).
+**Acceptance Criteria:**
+- [ ] Advisors at capacity are marked but not disabled (Coordinator override is absolute).
+- [ ] UI reflects `ADVISOR_ASSIGNED` or `TOOLS_BOUND` status update without full page reload.
+- [ ] Sanitization button while window is active prompts a severe warning before sending.
+- [ ] Results (disbanded count, rejected request count) are displayed clearly.
+
+**Related Issues:** Depends on **[Backend] P3 Controllers, DTOs & Coordinator Override**.
+
+---
+
+## [QA] Advisor Lifecycle, Override & Security E2E
+**Estimate:** 1 Point
+
+**Problem Summary:** Verify the advisor request lifecycle (send, cancel, reject), coordinator override flow, and strict RBAC enforcement across all P3 endpoints.
+**Scope:** QA — Integration Tests.
+
+**Deliverables:**
+1. Test happy path: send request → 201 Created, cancel → 200.
+2. Test business rule violations: group not `TOOLS_BOUND` → 400, double request → 409, advisor at capacity → 400.
+3. Test coordinator force-assign at max capacity → 200 OK, cascade `AUTO_REJECTED` on pending requests verified in DB.
+4. Test remove advisor → 200, group status reverts to `TOOLS_BOUND`.
+5. Security: Student JWT on Professor endpoints → 403. Professor JWT on Coordinator endpoints → 403.
+
+**References:** `endpoints_p3.md` (P3-API-01, P3-API-05).
+**Acceptance Criteria:**
+- [ ] DB state correctly reflects `PENDING` or `CANCELLED` statuses after lifecycle tests.
+- [ ] Non-Team Leader token on send request rejected with 403.
+- [ ] Coordinator overrides bypass all capacity and window validations.
+- [ ] All P3 endpoints enforce correct role mapping.
+
+**Related Issues:** Depends on **[Backend] AdvisorService — Browse & Request Flow**, **[Backend] P3 Controllers, DTOs & Coordinator Override**.
+
+---
+
+## [QA] Capacity Guard, Sanitization & Race Conditions E2E
+**Estimate:** 1 Point
+
+**Problem Summary:** Verify the transactional capacity guard, auto-sanitization scheduler, and optimistic locking behavior under concurrent load.
+**Scope:** QA — Integration Tests / Concurrency.
+
+**Deliverables:**
+1. Capacity guard: force advisor capacity max-out during accept → verify `AdvisorAtCapacityException` rollback.
+2. Cascade rejection: accept a request → other `PENDING` requests for the same group become `AUTO_REJECTED`.
+3. Sanitization: trigger job → verify all unadvised groups (`FORMING`, `TOOLS_PENDING`, `TOOLS_BOUND`) are `DISBANDED`, `GroupMembership` rows hard-deleted.
+4. Race condition: simulate Professor "Accept" simultaneously with Sanitization job → `@Version` throws `OptimisticLockException`, group is preserved, job skips it.
+5. State machine: `TOOLS_BOUND` → `ADVISOR_ASSIGNED` → `TOOLS_BOUND` (remove) → `DISBANDED` (sanitize).
+
+**References:** `endpoints_p3.md` (P3-API-03, P3-API-04), `3.2_3.3_advisor_respond_p3.md`, `3.4_sanitization_p3.md`.
+**Acceptance Criteria:**
+- [ ] Capacity constraints cannot be bypassed by concurrent Professor accepts.
+- [ ] `SanitizationReport` returns accurate disbanded and rejected counts.
+- [ ] Race condition simulation safely protects newly-advised groups from being disbanded.
+- [ ] State transitions match the P3 state machine exactly.
+
+**Related Issues:** Depends on **[Backend] AdvisorService — Review & Respond Flow**, **[Backend] SanitizationService — Auto-Disband Scheduler**, **[Backend] P3 Controllers, DTOs & Coordinator Override**.
+
+---
+
+## Summary Table
+
+| Description | SP |
+|---|:---:|
+| [Backend] P3 Entities & Repository Additions | 1 |
+| [Backend] AdvisorService — Browse & Request Flow | 2 |
+| [Backend] AdvisorService — Review & Respond (Capacity Guard) | 2 |
+| [Backend] SanitizationService — Auto-Disband Scheduler | 2 |
+| [Backend] P3 Controllers, DTOs & Coordinator Override | 2 |
+| [Frontend] Student Advisor Discovery & Request UI | 1 |
+| [Frontend] Professor Requests Inbox & Detail View | 2 |
+| [Frontend] Coordinator Override UI & Sanitization Trigger | 1 |
+| [QA] Advisor Lifecycle, Override & Security E2E | 1 |
+| [QA] Capacity Guard, Sanitization & Race Conditions E2E | 1 |
+| **Total** | **15** |

--- a/docs/process3/sequences/3.1_advisor_request_p3.md
+++ b/docs/process3/sequences/3.1_advisor_request_p3.md
@@ -1,0 +1,205 @@
+# Sequence Diagram — P3 Sub-Process 3.1
+## Browse Advisors & Send / Cancel Advisor Request
+
+> Endpoints: `GET /api/advisors`, `POST /api/groups/{groupId}/advisor-request`, `GET /api/groups/{groupId}/advisor-request`, `DELETE /api/groups/{groupId}/advisor-request`
+> Issues: P3-API-01
+> JWT principal = internal student UUID
+> Prerequisite: group must be in TOOLS_BOUND status (output of P2)
+
+---
+
+### GET /api/advisors
+
+```mermaid
+sequenceDiagram
+    actor Student
+    participant AdvisorController
+    participant AdvisorService
+    participant TermConfigService
+    participant StaffUserRepository
+    participant AdvisorRequestRepository
+
+    Student->>AdvisorController: GET /api/advisors<br/>Authorization: Bearer <student_jwt>
+
+    AdvisorController->>AdvisorService: getAvailableAdvisors()
+
+    Note over AdvisorService: termId resolved server-side — never from client
+    AdvisorService->>TermConfigService: getActiveTermId()
+    TermConfigService-->>AdvisorService: termId
+
+    AdvisorService->>StaffUserRepository: findByRole(PROFESSOR)
+    StaffUserRepository-->>AdvisorService: List<StaffUser>
+
+    Note over AdvisorService: For each professor, count groups where<br/>advisor_id = professor.id AND term_id = termId AND status != DISBANDED.<br/>Only include professors where count < advisorCapacity.
+    AdvisorService->>ProjectGroupRepository: countByAdvisorIdAndTermId(advisorId, termId)
+    ProjectGroupRepository-->>AdvisorService: currentGroupCount per professor
+
+    AdvisorService-->>AdvisorController: List of professors where currentGroupCount < capacity
+    AdvisorController-->>Student: 200 [{advisorId, name, mail, currentGroupCount, capacity}, ...]
+```
+
+---
+
+### POST /api/groups/{groupId}/advisor-request
+
+```mermaid
+sequenceDiagram
+    actor Student as Student (Team Leader)
+    participant AdvisorController
+    participant AdvisorService
+    participant GroupMembershipRepository
+    participant ProjectGroupRepository
+    participant ScheduleWindowRepository
+    participant AdvisorRequestRepository
+    participant StaffUserRepository
+
+    Student->>AdvisorController: POST /api/groups/{groupId}/advisor-request<br/>{advisorId: "uuid"}<br/>Authorization: Bearer <student_jwt>
+
+    AdvisorController->>AdvisorController: extract requesterUUID from SecurityContext
+    AdvisorController->>AdvisorService: sendAdvisorRequest(groupId, advisorId, requesterUUID)
+
+    AdvisorService->>GroupMembershipRepository: findByGroupIdAndStudentId(groupId, requesterUUID)
+    GroupMembershipRepository-->>AdvisorService: Optional<GroupMembership>
+
+    alt not TEAM_LEADER
+        AdvisorService-->>AdvisorController: throw ForbiddenException
+        AdvisorController-->>Student: 403 {"error": "Only the Team Leader can send advisor requests"}
+    end
+
+    AdvisorService->>ProjectGroupRepository: findById(groupId)
+    ProjectGroupRepository-->>AdvisorService: ProjectGroup
+
+    alt group.status != TOOLS_BOUND
+        AdvisorService-->>AdvisorController: throw BusinessRuleException
+        AdvisorController-->>Student: 400 {"error": "Group must be in TOOLS_BOUND status to request an advisor"}
+    end
+
+    AdvisorService->>ScheduleWindowRepository: findByTermIdAndType(group.termId, ADVISOR_ASSOCIATION)
+    ScheduleWindowRepository-->>AdvisorService: Optional<ScheduleWindow>
+
+    alt no active window
+        AdvisorService-->>AdvisorController: throw ScheduleWindowClosedException
+        AdvisorController-->>Student: 400 {"error": "Advisor association window is not currently active"}
+    end
+
+    AdvisorService->>AdvisorRequestRepository: findByGroupIdAndStatus(groupId, PENDING)
+    AdvisorRequestRepository-->>AdvisorService: Optional<AdvisorRequest>
+
+    alt pending request already exists
+        AdvisorService-->>AdvisorController: throw DuplicateRequestException
+        AdvisorController-->>Student: 409 {"error": "Group already has an active pending advisor request"}
+    end
+
+    AdvisorService->>StaffUserRepository: findById(advisorId)
+    StaffUserRepository-->>AdvisorService: Optional<StaffUser>
+
+    alt advisor not found or not a Professor
+        AdvisorService-->>AdvisorController: throw AdvisorNotFoundException
+        AdvisorController-->>Student: 404 {"error": "Advisor not found"}
+    end
+
+    AdvisorService->>ProjectGroupRepository: countByAdvisorIdAndTermId(advisorId, termId)
+    ProjectGroupRepository-->>AdvisorService: currentGroupCount
+
+    alt currentGroupCount >= advisor.advisorCapacity
+        AdvisorService-->>AdvisorController: throw AdvisorAtCapacityException
+        AdvisorController-->>Student: 400 {"error": "Advisor has reached maximum group capacity for this term"}
+    end
+
+    AdvisorService->>AdvisorRequestRepository: save(AdvisorRequest{status=PENDING, sentAt=now})
+    AdvisorRequestRepository-->>AdvisorService: savedRequest
+
+    AdvisorService-->>AdvisorController: AdvisorRequestResponse
+    AdvisorController-->>Student: 201 {requestId, groupId, advisorId, status:"PENDING", sentAt}
+```
+
+---
+
+### GET /api/groups/{groupId}/advisor-request
+
+```mermaid
+sequenceDiagram
+    actor Student
+    participant AdvisorController
+    participant AdvisorService
+    participant GroupMembershipRepository
+    participant AdvisorRequestRepository
+
+    Student->>AdvisorController: GET /api/groups/{groupId}/advisor-request<br/>Authorization: Bearer <student_jwt>
+
+    AdvisorController->>AdvisorController: extract studentUUID from SecurityContext
+    AdvisorController->>AdvisorService: getAdvisorRequest(groupId, studentUUID)
+
+    AdvisorService->>GroupMembershipRepository: existsByGroupIdAndStudentId(groupId, studentUUID)
+    GroupMembershipRepository-->>AdvisorService: boolean
+
+    alt student is not a member of this group
+        AdvisorService-->>AdvisorController: throw ForbiddenException
+        AdvisorController-->>Student: 403 {"error": "You are not a member of this group"}
+    end
+
+    AdvisorService->>AdvisorRequestRepository: findTopByGroupIdOrderBySentAtDesc(groupId)
+    AdvisorRequestRepository-->>AdvisorService: Optional<AdvisorRequest>
+
+    alt no request exists
+        AdvisorService-->>AdvisorController: throw RequestNotFoundException
+        AdvisorController-->>Student: 404 {"error": "No advisor request found for this group"}
+    end
+
+    AdvisorService-->>AdvisorController: AdvisorRequestResponse
+    AdvisorController-->>Student: 200 {requestId, advisorId, advisorName, status, sentAt, respondedAt}
+```
+
+---
+
+### DELETE /api/groups/{groupId}/advisor-request
+
+```mermaid
+sequenceDiagram
+    actor Student as Student (Team Leader)
+    participant AdvisorController
+    participant AdvisorService
+    participant GroupMembershipRepository
+    participant ProjectGroupRepository
+    participant AdvisorRequestRepository
+
+    Student->>AdvisorController: DELETE /api/groups/{groupId}/advisor-request<br/>Authorization: Bearer <student_jwt>
+
+    AdvisorController->>AdvisorController: extract requesterUUID from SecurityContext
+    AdvisorController->>AdvisorService: cancelAdvisorRequest(groupId, requesterUUID)
+
+    AdvisorService->>GroupMembershipRepository: findByGroupIdAndStudentId(groupId, requesterUUID)
+    GroupMembershipRepository-->>AdvisorService: Optional<GroupMembership>
+
+    alt not TEAM_LEADER
+        AdvisorService-->>AdvisorController: throw ForbiddenException
+        AdvisorController-->>Student: 403 {"error": "Only the Team Leader can cancel advisor requests"}
+    end
+
+    AdvisorService->>ProjectGroupRepository: findById(groupId)
+    ProjectGroupRepository-->>AdvisorService: Optional<ProjectGroup>
+
+    alt group not found
+        AdvisorService-->>AdvisorController: throw GroupNotFoundException
+        AdvisorController-->>Student: 404 {"error": "Group not found"}
+    end
+
+    AdvisorService->>AdvisorRequestRepository: findByGroupIdAndStatus(groupId, PENDING)
+    AdvisorRequestRepository-->>AdvisorService: Optional<AdvisorRequest>
+
+    alt no pending request
+        AdvisorService-->>AdvisorController: throw BusinessRuleException
+        AdvisorController-->>Student: 400 {"error": "No active pending request to cancel"}
+    end
+
+    alt no advisor request found at all
+        AdvisorService-->>AdvisorController: throw RequestNotFoundException
+        AdvisorController-->>Student: 404 {"error": "No advisor request found for this group"}
+    end
+
+    AdvisorService->>AdvisorRequestRepository: save(request{status=CANCELLED})
+    AdvisorRequestRepository-->>AdvisorService: ok
+
+    AdvisorService-->>AdvisorController: {requestId, status:"CANCELLED"}
+    AdvisorController-->>Student: 200 {requestId, status:"CANCELLED"}
+```

--- a/docs/process3/sequences/3.2_3.3_advisor_respond_p3.md
+++ b/docs/process3/sequences/3.2_3.3_advisor_respond_p3.md
@@ -1,0 +1,168 @@
+# Sequence Diagram — P3 Sub-Processes 3.2 & 3.3
+## Advisor Reviews Requests & Processes Response
+
+> Endpoints: `GET /api/advisor/requests`, `GET /api/advisor/requests/{requestId}`, `PATCH /api/advisor/requests/{requestId}/respond`
+> Issues: P3-API-02, P3-API-03
+> Auth: Staff JWT with role=Professor
+> ⚠️ `/api/advisor/**` must be protected with `hasRole("PROFESSOR")` in SecurityConfig (blue team action item)
+> JWT principal = internal StaffUser UUID (same pattern as student: claims.get("id"))
+
+---
+
+### GET /api/advisor/requests
+
+```mermaid
+sequenceDiagram
+    actor Professor
+    participant AdvisorController
+    participant AdvisorService
+    participant AdvisorRequestRepository
+
+    Professor->>AdvisorController: GET /api/advisor/requests<br/>Authorization: Bearer <staff_jwt role=Professor>
+
+    AdvisorController->>AdvisorController: extract professorUUID from SecurityContext
+
+    AdvisorController->>AdvisorService: getPendingRequestsForAdvisor(professorUUID)
+
+    AdvisorService->>AdvisorRequestRepository: findByAdvisorIdAndStatus(professorUUID, PENDING)
+    AdvisorRequestRepository-->>AdvisorService: List<AdvisorRequest> with group info
+
+    Note over AdvisorService: Empty list is valid — never 404
+    AdvisorService-->>AdvisorController: List<AdvisorRequestSummary>
+    AdvisorController-->>Professor: 200 [{requestId, groupId, groupName, termId, memberCount, sentAt}, ...]
+```
+
+---
+
+### GET /api/advisor/requests/{requestId}
+
+```mermaid
+sequenceDiagram
+    actor Professor
+    participant AdvisorController
+    participant AdvisorService
+    participant AdvisorRequestRepository
+
+    Professor->>AdvisorController: GET /api/advisor/requests/{requestId}<br/>Authorization: Bearer <staff_jwt role=Professor>
+
+    AdvisorController->>AdvisorController: extract professorUUID from SecurityContext
+    AdvisorController->>AdvisorService: getRequestDetail(requestId, professorUUID)
+
+    AdvisorService->>AdvisorRequestRepository: findById(requestId)
+    AdvisorRequestRepository-->>AdvisorService: Optional<AdvisorRequest>
+
+    alt not found
+        AdvisorService-->>AdvisorController: throw RequestNotFoundException
+        AdvisorController-->>Professor: 404 {"error": "Request not found"}
+    end
+
+    alt request.advisorId != professorUUID
+        AdvisorService-->>AdvisorController: throw ForbiddenException
+        AdvisorController-->>Professor: 403 {"error": "This request is not addressed to you"}
+    end
+
+    Note over AdvisorService: Fetch group + members for context.<br/>Proposal summary omitted until P6 is built.
+    AdvisorService-->>AdvisorController: AdvisorRequestDetailResponse
+    AdvisorController-->>Professor: 200 {requestId, group:{id, groupName, termId, status, members:[...]}, sentAt}
+```
+
+---
+
+### PATCH /api/advisor/requests/{requestId}/respond — REJECTED path
+
+```mermaid
+sequenceDiagram
+    actor Professor
+    participant AdvisorController
+    participant AdvisorService
+    participant AdvisorRequestRepository
+
+    Professor->>AdvisorController: PATCH /api/advisor/requests/{requestId}/respond<br/>{accept: false}<br/>Authorization: Bearer <staff_jwt role=Professor>
+
+    AdvisorController->>AdvisorController: extract professorUUID from SecurityContext
+    AdvisorController->>AdvisorService: respondToRequest(requestId, professorUUID, accept=false)
+
+    AdvisorService->>AdvisorRequestRepository: findById(requestId)
+    AdvisorRequestRepository-->>AdvisorService: Optional<AdvisorRequest>
+
+    alt not found
+        AdvisorService-->>AdvisorController: throw RequestNotFoundException
+        AdvisorController-->>Professor: 404 {"error": "Request not found"}
+    end
+
+    alt request.advisorId != professorUUID
+        AdvisorService-->>AdvisorController: throw ForbiddenException
+        AdvisorController-->>Professor: 403 {"error": "This request is not addressed to you"}
+    end
+
+    alt request.status != PENDING
+        AdvisorService-->>AdvisorController: throw RequestNotPendingException
+        AdvisorController-->>Professor: 400 {"error": "Request is no longer pending"}
+    end
+
+    AdvisorService->>AdvisorRequestRepository: save(request{status=REJECTED, respondedAt=now})
+    AdvisorRequestRepository-->>AdvisorService: ok
+
+    Note over AdvisorService: Group status stays TOOLS_BOUND.<br/>Group can send a new advisor request.
+    AdvisorService-->>AdvisorController: {requestId, status:"REJECTED"}
+    AdvisorController-->>Professor: 200 {requestId, status:"REJECTED"}
+```
+
+---
+
+### PATCH /api/advisor/requests/{requestId}/respond — ACCEPTED path
+
+```mermaid
+sequenceDiagram
+    actor Professor
+    participant AdvisorController
+    participant AdvisorService
+    participant AdvisorRequestRepository
+    participant ProjectGroupRepository
+
+    Professor->>AdvisorController: PATCH /api/advisor/requests/{requestId}/respond<br/>{accept: true}<br/>Authorization: Bearer <staff_jwt role=Professor>
+
+    AdvisorController->>AdvisorController: extract professorUUID from SecurityContext
+    AdvisorController->>AdvisorService: respondToRequest(requestId, professorUUID, accept=true)
+
+    AdvisorService->>AdvisorRequestRepository: findById(requestId)
+    AdvisorRequestRepository-->>AdvisorService: Optional<AdvisorRequest>
+
+    alt not found
+        AdvisorService-->>AdvisorController: throw RequestNotFoundException
+        AdvisorController-->>Professor: 404 {"error": "Request not found"}
+    end
+
+    alt request.advisorId != professorUUID
+        AdvisorService-->>AdvisorController: throw ForbiddenException
+        AdvisorController-->>Professor: 403 {"error": "This request is not addressed to you"}
+    end
+
+    alt request.status != PENDING
+        AdvisorService-->>AdvisorController: throw RequestNotPendingException
+        AdvisorController-->>Professor: 400 {"error": "Request is no longer pending"}
+    end
+
+    Note over AdvisorService: Capacity re-check INSIDE the transaction — not just at request send time.<br/>Prevents over-capacity if multiple groups sent requests simultaneously.<br/>Counts project_group rows where advisorId=professorUUID AND termId=activeTermId AND status!=DISBANDED.
+    AdvisorService->>ProjectGroupRepository: countByAdvisorIdAndTermId(professorUUID, activeTermId)
+    ProjectGroupRepository-->>AdvisorService: currentGroupCount
+
+    alt currentGroupCount >= advisor.advisorCapacity
+        AdvisorService-->>AdvisorController: throw AdvisorAtCapacityException
+        AdvisorController-->>Professor: 400 {"error": "You have reached your maximum group capacity for this term"}
+    end
+
+    Note over AdvisorService: @Transactional — all three writes are atomic.<br/>@Version on ProjectGroup guards against sanitization race condition.
+    AdvisorService->>AdvisorRequestRepository: save(request{status=ACCEPTED, respondedAt=now})
+    AdvisorRequestRepository-->>AdvisorService: ok
+
+    AdvisorService->>ProjectGroupRepository: save(group{advisorId=professorUUID, status=ADVISOR_ASSIGNED})
+    ProjectGroupRepository-->>AdvisorService: ok
+
+    Note over AdvisorService: Auto-reject ALL other PENDING requests for this group<br/>(same group, different advisors — unlikely but must be handled)
+    AdvisorService->>AdvisorRequestRepository: bulkUpdateStatus(groupId=request.groupId, status=PENDING → AUTO_REJECTED, excludeId=requestId)
+    AdvisorRequestRepository-->>AdvisorService: updatedCount
+
+    AdvisorService-->>AdvisorController: {requestId, status:"ACCEPTED", groupId, groupStatus:"ADVISOR_ASSIGNED"}
+    AdvisorController-->>Professor: 200 {requestId, status:"ACCEPTED", groupId, groupStatus:"ADVISOR_ASSIGNED"}
+```

--- a/docs/process3/sequences/3.4_sanitization_p3.md
+++ b/docs/process3/sequences/3.4_sanitization_p3.md
@@ -1,0 +1,81 @@
+# Sequence Diagram — P3 Sub-Process 3.4
+## Auto-Sanitization (Disband Unadvised Groups)
+
+> Endpoint: `POST /api/coordinator/sanitize`
+> Issues: P3-API-04
+> Two triggers: (1) scheduled job fires automatically when ADVISOR_ASSOCIATION window closes, (2) coordinator manual trigger via API.
+> Both paths call the same SanitizationService method.
+
+---
+
+### Trigger 1 — Scheduled Job (Automatic)
+
+```mermaid
+sequenceDiagram
+    participant Scheduler as Spring @Scheduled
+    participant SanitizationService
+    participant ScheduleWindowRepository
+    participant ProjectGroupRepository
+    participant AdvisorRequestRepository
+
+    Note over Scheduler: Runs on a fixed schedule (e.g. every 5 min).<br/>Checks if any ADVISOR_ASSOCIATION window just closed.
+
+    Scheduler->>SanitizationService: runSanitizationIfWindowClosed()
+
+    SanitizationService->>ScheduleWindowRepository: findWindowsClosedAfter(lastRunTime)
+    ScheduleWindowRepository-->>SanitizationService: List<ScheduleWindow> (type=ADVISOR_ASSOCIATION, closesAt <= now)
+
+    alt no newly closed windows
+        SanitizationService-->>Scheduler: return (no-op)
+    end
+
+    loop for each closed window
+        SanitizationService->>SanitizationService: runSanitization(termId, force=false)
+    end
+```
+
+---
+
+### POST /api/coordinator/sanitize (Manual Trigger)
+
+```mermaid
+sequenceDiagram
+    actor Coordinator
+    participant CoordinatorController
+    participant SanitizationService
+    participant ScheduleWindowRepository
+    participant ProjectGroupRepository
+    participant AdvisorRequestRepository
+
+    Coordinator->>CoordinatorController: POST /api/coordinator/sanitize<br/>body: {} or {force: true}<br/>Authorization: Bearer <staff_jwt role=Coordinator>
+
+    CoordinatorController->>SanitizationService: triggerManually(force)
+
+    SanitizationService->>ScheduleWindowRepository: findByTermIdAndType(termId, ADVISOR_ASSOCIATION)
+    ScheduleWindowRepository-->>SanitizationService: Optional<ScheduleWindow>
+
+    alt window is still active AND force != true
+        SanitizationService-->>CoordinatorController: throw BusinessRuleException
+        CoordinatorController-->>Coordinator: 400 {"error": "Advisor association window is still active — cannot sanitize early without confirmation"}
+    end
+
+    Note over SanitizationService: If force=true OR window is already closed — proceed
+    CoordinatorController->>SanitizationService: runSanitization(termId, force)
+
+    SanitizationService->>ProjectGroupRepository: findByTermIdAndStatusNotAndAdvisorIdIsNull(termId, DISBANDED)
+    ProjectGroupRepository-->>SanitizationService: List<ProjectGroup> (unadvised, not already disbanded)
+
+    Note over SanitizationService: @Transactional wraps the entire loop.<br/>If any group fails (e.g. OptimisticLockException from concurrent advisor accept),<br/>that group is skipped — the loop catches the exception per-group and continues.<br/>Partial success is acceptable: already-disbanded groups are safe, skipped groups<br/>will be caught on the next scheduler tick or manual trigger.
+
+    loop for each unadvised group
+        SanitizationService->>ProjectGroupRepository: save(group{status=DISBANDED})
+
+        Note over SanitizationService: Hard-delete memberships — frees students to rejoin next term
+        SanitizationService->>GroupMembershipRepository: deleteAllByGroupId(groupId)
+
+        SanitizationService->>AdvisorRequestRepository: bulkUpdateStatusByGroupId(groupId, PENDING → AUTO_REJECTED)
+    end
+
+    SanitizationService-->>CoordinatorController: SanitizationReport{disbandedCount, autoRejectedRequestCount, triggeredAt}
+    CoordinatorController-->>Coordinator: 200 {disbandedCount, autoRejectedRequestCount, triggeredAt}
+```

--- a/docs/process3/sequences/3.5_coordinator_advisor_p3.md
+++ b/docs/process3/sequences/3.5_coordinator_advisor_p3.md
@@ -1,0 +1,128 @@
+# Sequence Diagram — P3 Sub-Process 3.5
+## Coordinator Advisor Override
+
+> Endpoints: `GET /api/coordinator/advisors`, `PATCH /api/coordinator/groups/{groupId}/advisor`
+> Issues: P3-API-05
+> Auth: Staff JWT with role=Coordinator — enforced by SecurityConfig
+> Override bypasses both the schedule window check and the advisor capacity limit.
+
+---
+
+### GET /api/coordinator/advisors
+
+```mermaid
+sequenceDiagram
+    actor Coordinator
+    participant CoordinatorController
+    participant AdvisorService
+    participant TermConfigService
+    participant StaffUserRepository
+    participant ProjectGroupRepository
+
+    Coordinator->>CoordinatorController: GET /api/coordinator/advisors<br/>Authorization: Bearer <staff_jwt role=Coordinator>
+
+    CoordinatorController->>AdvisorService: getAllAdvisorsWithCapacity()
+
+    Note over AdvisorService: termId resolved server-side — never from client
+    AdvisorService->>TermConfigService: getActiveTermId()
+    TermConfigService-->>AdvisorService: termId
+
+    AdvisorService->>StaffUserRepository: findByRole(PROFESSOR)
+    StaffUserRepository-->>AdvisorService: List<StaffUser>
+
+    Note over AdvisorService: For each professor count groups where<br/>advisor_id = professor.id AND term_id = termId AND status != DISBANDED.<br/>Includes advisors AT capacity (unlike student-facing endpoint).
+    AdvisorService->>ProjectGroupRepository: countByAdvisorIdAndTermId(advisorId, termId)
+    ProjectGroupRepository-->>AdvisorService: currentGroupCount per professor
+
+    AdvisorService-->>CoordinatorController: List<AdvisorCapacityResponse>
+    CoordinatorController-->>Coordinator: 200 [{advisorId, name, mail, currentGroupCount, capacity, atCapacity}, ...]
+```
+
+---
+
+### PATCH /api/coordinator/groups/{groupId}/advisor — ASSIGN
+
+```mermaid
+sequenceDiagram
+    actor Coordinator
+    participant CoordinatorController
+    participant AdvisorService
+    participant ProjectGroupRepository
+    participant StaffUserRepository
+    participant AdvisorRequestRepository
+
+    Coordinator->>CoordinatorController: PATCH /api/coordinator/groups/{groupId}/advisor<br/>{action:"ASSIGN", advisorId:"uuid"}<br/>Authorization: Bearer <staff_jwt role=Coordinator>
+
+    alt action == ASSIGN and advisorId is null
+        CoordinatorController-->>Coordinator: 400 {"error": "advisorId is required for ASSIGN action"}
+    end
+
+    CoordinatorController->>AdvisorService: assignAdvisor(groupId, advisorId)
+
+    AdvisorService->>ProjectGroupRepository: findById(groupId)
+    ProjectGroupRepository-->>AdvisorService: Optional<ProjectGroup>
+
+    alt group not found
+        AdvisorService-->>CoordinatorController: throw GroupNotFoundException
+        CoordinatorController-->>Coordinator: 404 {"error": "Group not found"}
+    end
+
+    AdvisorService->>StaffUserRepository: findById(advisorId)
+    StaffUserRepository-->>AdvisorService: Optional<StaffUser>
+
+    alt advisor not found or not a Professor
+        AdvisorService-->>CoordinatorController: throw AdvisorNotFoundException
+        CoordinatorController-->>Coordinator: 404 {"error": "Advisor not found"}
+    end
+
+    alt group.advisorId == advisorId (already assigned)
+        AdvisorService-->>CoordinatorController: throw BusinessRuleException
+        CoordinatorController-->>Coordinator: 400 {"error": "Group already has this advisor assigned"}
+    end
+
+    Note over AdvisorService: @Transactional — group update + auto-reject atomic.<br/>No capacity check. No window check. Coordinator override.
+
+    AdvisorService->>ProjectGroupRepository: save(group{advisorId, status=ADVISOR_ASSIGNED})
+    ProjectGroupRepository-->>AdvisorService: ok
+
+    AdvisorService->>AdvisorRequestRepository: bulkUpdateStatusByGroupId(groupId, PENDING → AUTO_REJECTED)
+    AdvisorRequestRepository-->>AdvisorService: updatedCount
+
+    AdvisorService-->>CoordinatorController: {groupId, status:"ADVISOR_ASSIGNED", advisorId}
+    CoordinatorController-->>Coordinator: 200 {groupId, status:"ADVISOR_ASSIGNED", advisorId}
+```
+
+---
+
+### PATCH /api/coordinator/groups/{groupId}/advisor — REMOVE
+
+```mermaid
+sequenceDiagram
+    actor Coordinator
+    participant CoordinatorController
+    participant AdvisorService
+    participant ProjectGroupRepository
+
+    Coordinator->>CoordinatorController: PATCH /api/coordinator/groups/{groupId}/advisor<br/>{action:"REMOVE"}<br/>Authorization: Bearer <staff_jwt role=Coordinator>
+
+    CoordinatorController->>AdvisorService: removeAdvisor(groupId)
+
+    AdvisorService->>ProjectGroupRepository: findById(groupId)
+    ProjectGroupRepository-->>AdvisorService: Optional<ProjectGroup>
+
+    alt group not found
+        AdvisorService-->>CoordinatorController: throw GroupNotFoundException
+        CoordinatorController-->>Coordinator: 404 {"error": "Group not found"}
+    end
+
+    alt group.advisorId is null
+        AdvisorService-->>CoordinatorController: throw BusinessRuleException
+        CoordinatorController-->>Coordinator: 400 {"error": "Group has no advisor to remove"}
+    end
+
+    AdvisorService->>ProjectGroupRepository: save(group{advisorId=null, status=TOOLS_BOUND})
+    ProjectGroupRepository-->>AdvisorService: ok
+
+    AdvisorService-->>CoordinatorController: {groupId, status:"TOOLS_BOUND", advisorId:null}
+    CoordinatorController-->>Coordinator: 200 {groupId, status:"TOOLS_BOUND", advisorId:null}
+```

--- a/docs/red_dfd/dfd_lvl0.drawio
+++ b/docs/red_dfd/dfd_lvl0.drawio
@@ -1,0 +1,508 @@
+<mxfile host="65bd71144e">
+    <diagram id="H7xPy6XrwMVDOX9BWqra" name="Page-2">
+        <mxGraphModel dx="3708" dy="1365" grid="1" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="0" pageScale="1" pageWidth="850" pageHeight="1100" background="none" math="0" shadow="0">
+            <root>
+                <mxCell id="0"/>
+                <mxCell id="1" parent="0"/>
+                <mxCell id="WzDSdGTiCHk0TN9zid3g-5" value="Auth Data" style="edgeStyle=orthogonalEdgeStyle;html=1;exitX=0.5;exitY=0;exitDx=0;exitDy=0;entryX=0.5;entryY=1;entryDx=0;entryDy=0;orthogonal=1;labelBackgroundColor=default;" parent="1" source="UNcb3l8VgCFt9lwZonRV-1" target="F5snIL96dau0AUOztgLP-2" edge="1">
+                    <mxGeometry x="0.34" relative="1" as="geometry">
+                        <mxPoint as="offset"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="WzDSdGTiCHk0TN9zid3g-9" value="Group Requests, Bindings" style="edgeStyle=elbowEdgeStyle;html=1;exitX=1;exitY=0.25;exitDx=0;exitDy=0;orthogonal=1;labelBackgroundColor=default;entryX=0;entryY=1;entryDx=0;entryDy=0;" parent="1" source="UNcb3l8VgCFt9lwZonRV-1" target="F5snIL96dau0AUOztgLP-3" edge="1">
+                    <mxGeometry x="-0.3096" y="11" relative="1" as="geometry">
+                        <mxPoint x="-2240" y="-230" as="sourcePoint"/>
+                        <Array as="points">
+                            <mxPoint x="-2120" y="-280"/>
+                        </Array>
+                        <mxPoint x="-1" as="offset"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="WzDSdGTiCHk0TN9zid3g-13" value="Group Requests" style="edgeStyle=orthogonalEdgeStyle;html=1;exitX=1;exitY=0.75;exitDx=0;exitDy=0;orthogonal=1;labelBackgroundColor=default;" parent="1" source="UNcb3l8VgCFt9lwZonRV-1" target="F5snIL96dau0AUOztgLP-6" edge="1">
+                    <mxGeometry x="-0.0047" relative="1" as="geometry">
+                        <mxPoint x="-2270" y="-210" as="sourcePoint"/>
+                        <Array as="points">
+                            <mxPoint x="-2360" y="-184"/>
+                            <mxPoint x="-2140" y="-184"/>
+                        </Array>
+                        <mxPoint as="offset"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="WzDSdGTiCHk0TN9zid3g-19" value="Deliverable &lt;br&gt;Submissions" style="edgeStyle=orthogonalEdgeStyle;html=1;exitX=0;exitY=0;exitDx=0;exitDy=0;orthogonal=1;labelBackgroundColor=default;entryX=0.693;entryY=0.965;entryDx=0;entryDy=0;entryPerimeter=0;" parent="1" source="UNcb3l8VgCFt9lwZonRV-1" target="6vHCIuZtSWlxRlMeQgIX-1" edge="1">
+                    <mxGeometry x="-0.1272" relative="1" as="geometry">
+                        <Array as="points">
+                            <mxPoint x="-2480" y="-280"/>
+                            <mxPoint x="-2687" y="-280"/>
+                        </Array>
+                        <mxPoint x="1" as="offset"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="UNcb3l8VgCFt9lwZonRV-1" value="Student" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#ffffff;strokeColor=#000000;fontSize=13;fontStyle=1;flipH=0;labelBackgroundColor=none;" parent="1" vertex="1">
+                    <mxGeometry x="-2480" y="-240.0000000000001" width="120" height="40" as="geometry"/>
+                </mxCell>
+                <mxCell id="WzDSdGTiCHk0TN9zid3g-3" value="Professor Data,&lt;br&gt;LLM API Keys" style="edgeStyle=elbowEdgeStyle;html=1;exitX=0.5;exitY=1;exitDx=0;exitDy=0;orthogonal=1;labelBackgroundColor=default;entryX=0;entryY=0.5;entryDx=0;entryDy=0;" parent="1" source="903sCpO6xVK5vF8ryV6D-1" target="F5snIL96dau0AUOztgLP-2" edge="1">
+                    <mxGeometry x="0.0233" relative="1" as="geometry">
+                        <Array as="points">
+                            <mxPoint x="-2755" y="-495"/>
+                        </Array>
+                        <mxPoint as="offset"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="903sCpO6xVK5vF8ryV6D-1" value="Admin" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#ffffff;strokeColor=#000000;fontSize=13;fontStyle=1;flipH=0;labelBackgroundColor=none;" parent="1" vertex="1">
+                    <mxGeometry x="-2800" y="-570.0000000000001" width="100" height="40" as="geometry"/>
+                </mxCell>
+                <mxCell id="WzDSdGTiCHk0TN9zid3g-1" value="Term Configs, Rubrics,&lt;br&gt;Deadlines, Weights" style="edgeStyle=elbowEdgeStyle;html=1;exitX=0.5;exitY=1;exitDx=0;exitDy=0;orthogonal=1;labelBackgroundColor=default;entryX=1;entryY=0.5;entryDx=0;entryDy=0;" parent="1" source="903sCpO6xVK5vF8ryV6D-2" target="F5snIL96dau0AUOztgLP-1" edge="1">
+                    <mxGeometry x="-0.5054" y="5" relative="1" as="geometry">
+                        <mxPoint x="-2170" y="335.3299999999999" as="sourcePoint"/>
+                        <Array as="points">
+                            <mxPoint x="-2465" y="271"/>
+                        </Array>
+                        <mxPoint y="1" as="offset"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="WzDSdGTiCHk0TN9zid3g-16" value="Committee &amp;amp; Jury Assignments" style="edgeStyle=elbowEdgeStyle;html=1;exitX=0;exitY=0.5;exitDx=0;exitDy=0;orthogonal=1;labelBackgroundColor=default;entryX=0;entryY=0;entryDx=0;entryDy=0;" parent="1" source="903sCpO6xVK5vF8ryV6D-2" target="F5snIL96dau0AUOztgLP-5" edge="1">
+                    <mxGeometry x="-0.7382" relative="1" as="geometry">
+                        <Array as="points">
+                            <mxPoint x="-2880" y="-100"/>
+                        </Array>
+                        <mxPoint as="offset"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="YE9hbXlFpOjnMs0VjsED-4" style="edgeStyle=none;html=1;exitX=0.25;exitY=0;exitDx=0;exitDy=0;entryX=0;entryY=1;entryDx=0;entryDy=0;" parent="1" source="903sCpO6xVK5vF8ryV6D-2" target="F5snIL96dau0AUOztgLP-2" edge="1">
+                    <mxGeometry relative="1" as="geometry"/>
+                </mxCell>
+                <mxCell id="YE9hbXlFpOjnMs0VjsED-5" value="Student IDs CSV" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];" parent="YE9hbXlFpOjnMs0VjsED-4" vertex="1" connectable="0">
+                    <mxGeometry x="-0.0651" y="-4" relative="1" as="geometry">
+                        <mxPoint x="-26" y="70" as="offset"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="2" style="edgeStyle=none;html=1;exitX=1;exitY=0.75;exitDx=0;exitDy=0;entryX=0.58;entryY=0.985;entryDx=0;entryDy=0;entryPerimeter=0;" parent="1" source="903sCpO6xVK5vF8ryV6D-2" target="F5snIL96dau0AUOztgLP-3" edge="1">
+                    <mxGeometry relative="1" as="geometry">
+                        <Array as="points">
+                            <mxPoint x="-1780" y="150"/>
+                        </Array>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="3" value="Group Override Data/Commands" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];" parent="2" vertex="1" connectable="0">
+                    <mxGeometry x="-0.081" y="5" relative="1" as="geometry">
+                        <mxPoint x="21" y="-5" as="offset"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="4" style="edgeStyle=none;html=1;exitX=0.575;exitY=-0.013;exitDx=0;exitDy=0;entryX=0.107;entryY=0.809;entryDx=0;entryDy=0;entryPerimeter=0;exitPerimeter=0;" parent="1" source="903sCpO6xVK5vF8ryV6D-2" target="F5snIL96dau0AUOztgLP-6" edge="1">
+                    <mxGeometry relative="1" as="geometry">
+                        <Array as="points">
+                            <mxPoint x="-2455" y="-81"/>
+                        </Array>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="5" value="Advisor Override&amp;nbsp;&lt;div&gt;Commands&lt;/div&gt;" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];" parent="4" vertex="1" connectable="0">
+                    <mxGeometry x="0.1852" y="2" relative="1" as="geometry">
+                        <mxPoint x="53" y="2" as="offset"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="903sCpO6xVK5vF8ryV6D-2" value="Coordinator" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#ffffff;strokeColor=#000000;fontSize=13;fontStyle=1;flipH=0;labelBackgroundColor=none;" parent="1" vertex="1">
+                    <mxGeometry x="-2530" y="119.67" width="130" height="40" as="geometry"/>
+                </mxCell>
+                <mxCell id="WzDSdGTiCHk0TN9zid3g-14" value="Advisee Approvals" style="edgeStyle=elbowEdgeStyle;html=1;exitX=0;exitY=0.5;exitDx=0;exitDy=0;orthogonal=1;labelBackgroundColor=default;entryX=0;entryY=0.5;entryDx=0;entryDy=0;" parent="1" source="903sCpO6xVK5vF8ryV6D-3" target="F5snIL96dau0AUOztgLP-6" edge="1">
+                    <mxGeometry x="-0.2824" relative="1" as="geometry">
+                        <mxPoint as="offset"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="WzDSdGTiCHk0TN9zid3g-23" value="Reviews" style="edgeStyle=orthogonalEdgeStyle;html=1;exitX=0.071;exitY=0;exitDx=0;exitDy=0;orthogonal=1;labelBackgroundColor=default;entryX=0.223;entryY=0.903;entryDx=0;entryDy=0;entryPerimeter=0;exitPerimeter=0;" parent="1" source="903sCpO6xVK5vF8ryV6D-3" target="6vHCIuZtSWlxRlMeQgIX-1" edge="1">
+                    <mxGeometry x="-0.3639" y="-5" relative="1" as="geometry">
+                        <mxPoint as="offset"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="WzDSdGTiCHk0TN9zid3g-28" value="Rubric Grades" style="edgeStyle=elbowEdgeStyle;html=1;exitX=0.75;exitY=1;exitDx=0;exitDy=0;orthogonal=1;labelBackgroundColor=default;entryX=-0.009;entryY=0.379;entryDx=0;entryDy=0;entryPerimeter=0;" parent="1" source="903sCpO6xVK5vF8ryV6D-3" target="F5snIL96dau0AUOztgLP-4" edge="1">
+                    <mxGeometry x="-0.3589" y="-3" relative="1" as="geometry">
+                        <Array as="points">
+                            <mxPoint x="-2590" y="-80"/>
+                        </Array>
+                        <mxPoint as="offset"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="903sCpO6xVK5vF8ryV6D-3" value="Advisor / Jury" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#ffffff;strokeColor=#000000;fontSize=13;fontStyle=1;flipH=0;labelBackgroundColor=none;" parent="1" vertex="1">
+                    <mxGeometry x="-2800" y="-239.99999999999994" width="140" height="40" as="geometry"/>
+                </mxCell>
+                <mxCell id="WzDSdGTiCHk0TN9zid3g-7" value="User Identity" style="edgeStyle=elbowEdgeStyle;html=1;orthogonal=1;entryX=0.675;entryY=0.042;entryDx=0;entryDy=0;exitX=0;exitY=0.25;exitDx=0;exitDy=0;labelBackgroundColor=default;entryPerimeter=0;" parent="1" source="903sCpO6xVK5vF8ryV6D-4" target="F5snIL96dau0AUOztgLP-2" edge="1">
+                    <mxGeometry relative="1" as="geometry">
+                        <mxPoint x="-335" y="-659.67" as="sourcePoint"/>
+                        <mxPoint x="-2112.21825406948" y="-688.5608729652604" as="targetPoint"/>
+                        <Array as="points">
+                            <mxPoint x="-2381" y="-670"/>
+                        </Array>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="903sCpO6xVK5vF8ryV6D-4" value="External: GitHub API" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#ffe6cc;strokeColor=#d6b656;fontSize=13;fontStyle=1;flipH=0;labelBackgroundColor=none;" parent="1" vertex="1">
+                    <mxGeometry x="-2020" y="-720" width="180" height="40" as="geometry"/>
+                </mxCell>
+                <mxCell id="WzDSdGTiCHk0TN9zid3g-25" value="Active Stories, Assignees,&lt;br&gt;&amp;nbsp;Story Points" style="edgeStyle=orthogonalEdgeStyle;html=1;exitX=1;exitY=0.5;exitDx=0;exitDy=0;orthogonal=1;labelBackgroundColor=default;entryX=0.382;entryY=0.039;entryDx=0;entryDy=0;entryPerimeter=0;" parent="1" source="903sCpO6xVK5vF8ryV6D-5" target="F5snIL96dau0AUOztgLP-7" edge="1">
+                    <mxGeometry x="0.1703" relative="1" as="geometry">
+                        <mxPoint as="offset"/>
+                        <mxPoint x="-1690" y="-620" as="targetPoint"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="903sCpO6xVK5vF8ryV6D-5" value="External: JIRA API" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#ffe6cc;strokeColor=#d6b656;fontSize=13;fontStyle=1;flipH=0;labelBackgroundColor=none;" parent="1" vertex="1">
+                    <mxGeometry x="-2340" y="-610" width="160" height="40" as="geometry"/>
+                </mxCell>
+                <mxCell id="WzDSdGTiCHk0TN9zid3g-6" value="OAuth Requests" style="edgeStyle=orthogonalEdgeStyle;html=1;exitX=1;exitY=0.5;exitDx=0;exitDy=0;orthogonal=1;labelBackgroundColor=default;entryX=0.339;entryY=0.925;entryDx=0;entryDy=0;entryPerimeter=0;" parent="1" source="F5snIL96dau0AUOztgLP-2" target="903sCpO6xVK5vF8ryV6D-4" edge="1">
+                    <mxGeometry relative="1" as="geometry">
+                        <mxPoint x="-2029.3399999999997" y="-619.0400000000001" as="sourcePoint"/>
+                        <mxPoint x="-1970" y="-678" as="targetPoint"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="WzDSdGTiCHk0TN9zid3g-8" value="User Session,&lt;br&gt;&amp;nbsp;Profiles, Roles" style="edgeStyle=elbowEdgeStyle;html=1;exitX=0.451;exitY=0.01;exitDx=0;exitDy=0;orthogonal=1;labelBackgroundColor=default;entryX=1;entryY=0.5;entryDx=0;entryDy=0;entryPerimeter=0;exitPerimeter=0;" parent="1" source="F5snIL96dau0AUOztgLP-2" target="Bhhoraj-XN7D4Ivi6Yd--4" edge="1">
+                    <mxGeometry x="0.1206" relative="1" as="geometry">
+                        <mxPoint as="offset"/>
+                        <mxPoint x="-2126.2000000000003" y="-601.4900000000002" as="sourcePoint"/>
+                        <mxPoint x="-2265" y="-800" as="targetPoint"/>
+                        <Array as="points">
+                            <mxPoint x="-2431" y="-650"/>
+                        </Array>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="qCxVODThMoP1LT63TutK-6" style="edgeStyle=none;html=1;exitX=0.664;exitY=0.973;exitDx=0;exitDy=0;entryX=0.75;entryY=0;entryDx=0;entryDy=0;exitPerimeter=0;" parent="1" source="F5snIL96dau0AUOztgLP-2" target="UNcb3l8VgCFt9lwZonRV-1" edge="1">
+                    <mxGeometry relative="1" as="geometry">
+                        <Array as="points">
+                            <mxPoint x="-2390" y="-439"/>
+                        </Array>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="qCxVODThMoP1LT63TutK-7" value="Session Token" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];" parent="qCxVODThMoP1LT63TutK-6" vertex="1" connectable="0">
+                    <mxGeometry x="-0.6996" y="3" relative="1" as="geometry">
+                        <mxPoint x="12" as="offset"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="F5snIL96dau0AUOztgLP-2" value="&lt;b&gt;1.0&lt;/b&gt;&lt;br&gt;Registration &amp;amp; Authentication" style="ellipse;whiteSpace=wrap;html=1;fillColor=#dae8fc;strokeColor=#6c8ebf;fontSize=14;verticalAlign=middle;flipH=0;labelBackgroundColor=none;" parent="1" vertex="1">
+                    <mxGeometry x="-2530" y="-550" width="220" height="110" as="geometry"/>
+                </mxCell>
+                <mxCell id="WzDSdGTiCHk0TN9zid3g-10" value="PAT Queries" style="edgeStyle=orthogonalEdgeStyle;html=1;orthogonal=1;labelBackgroundColor=default;exitX=1;exitY=0.5;exitDx=0;exitDy=0;entryX=0.5;entryY=0;entryDx=0;entryDy=0;" parent="1" source="F5snIL96dau0AUOztgLP-3" target="903sCpO6xVK5vF8ryV6D-4" edge="1">
+                    <mxGeometry x="0.0279" y="-10" relative="1" as="geometry">
+                        <mxPoint as="offset"/>
+                        <mxPoint x="-1940" y="-760" as="targetPoint"/>
+                        <Array as="points">
+                            <mxPoint x="-1510" y="-369"/>
+                            <mxPoint x="-1510" y="-750"/>
+                            <mxPoint x="-1930" y="-750"/>
+                        </Array>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="WzDSdGTiCHk0TN9zid3g-11" value="Project Keys" style="edgeStyle=elbowEdgeStyle;html=1;orthogonal=1;labelBackgroundColor=default;exitX=0.5;exitY=0;exitDx=0;exitDy=0;entryX=1;entryY=1;entryDx=0;entryDy=0;" parent="1" source="F5snIL96dau0AUOztgLP-3" target="903sCpO6xVK5vF8ryV6D-5" edge="1">
+                    <mxGeometry x="0.433" relative="1" as="geometry">
+                        <mxPoint as="offset"/>
+                        <mxPoint x="-1770" y="-470" as="sourcePoint"/>
+                        <mxPoint x="-2030" y="-570" as="targetPoint"/>
+                        <Array as="points">
+                            <mxPoint x="-1797" y="-500"/>
+                        </Array>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="F5snIL96dau0AUOztgLP-3" value="&lt;b&gt;2.0&lt;/b&gt;&lt;br&gt;Group Creation &amp;amp; Tool Integration" style="ellipse;whiteSpace=wrap;html=1;fillColor=#dae8fc;strokeColor=#6c8ebf;fontSize=14;verticalAlign=middle;flipH=0;labelBackgroundColor=none;" parent="1" vertex="1">
+                    <mxGeometry x="-1907.46" y="-424.34" width="220" height="110" as="geometry"/>
+                </mxCell>
+                <mxCell id="WzDSdGTiCHk0TN9zid3g-33" value="Notifications,&lt;br&gt;Dashboards Data,&lt;br&gt;Final Grades" style="edgeStyle=orthogonalEdgeStyle;html=1;exitX=0.462;exitY=0.032;exitDx=0;exitDy=0;entryX=0.75;entryY=1;entryDx=0;entryDy=0;orthogonal=1;labelBackgroundColor=default;exitPerimeter=0;" parent="1" source="F5snIL96dau0AUOztgLP-4" target="UNcb3l8VgCFt9lwZonRV-1" edge="1">
+                    <mxGeometry x="0.4752" y="-15" relative="1" as="geometry">
+                        <Array as="points">
+                            <mxPoint x="-2278" y="-4"/>
+                            <mxPoint x="-2280" y="-4"/>
+                            <mxPoint x="-2280" y="-140"/>
+                            <mxPoint x="-2390" y="-140"/>
+                        </Array>
+                        <mxPoint as="offset"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="WzDSdGTiCHk0TN9zid3g-35" value="Live Dashboards" style="edgeStyle=orthogonalEdgeStyle;html=1;exitX=0.5;exitY=1;exitDx=0;exitDy=0;orthogonal=1;labelBackgroundColor=default;entryX=0.632;entryY=1.032;entryDx=0;entryDy=0;entryPerimeter=0;" parent="1" source="F5snIL96dau0AUOztgLP-7" target="903sCpO6xVK5vF8ryV6D-3" edge="1">
+                    <mxGeometry x="-0.1905" relative="1" as="geometry">
+                        <Array as="points">
+                            <mxPoint x="-1650" y="-50"/>
+                            <mxPoint x="-2711" y="-50"/>
+                        </Array>
+                        <mxPoint as="offset"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="YE9hbXlFpOjnMs0VjsED-13" style="edgeStyle=orthogonalEdgeStyle;html=1;exitX=0.748;exitY=0.918;exitDx=0;exitDy=0;exitPerimeter=0;entryX=1.023;entryY=0.263;entryDx=0;entryDy=0;entryPerimeter=0;" parent="1" source="F5snIL96dau0AUOztgLP-4" target="903sCpO6xVK5vF8ryV6D-2" edge="1">
+                    <mxGeometry relative="1" as="geometry">
+                        <mxPoint x="-2360" y="130" as="targetPoint"/>
+                        <Array as="points">
+                            <mxPoint x="-2215" y="130"/>
+                            <mxPoint x="-2370" y="130"/>
+                        </Array>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="YE9hbXlFpOjnMs0VjsED-14" value="Analytics, Group Statuses,&lt;br&gt;Grade Summaries" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];" parent="YE9hbXlFpOjnMs0VjsED-13" vertex="1" connectable="0">
+                    <mxGeometry x="-0.0369" y="1" relative="1" as="geometry">
+                        <mxPoint x="48" y="-21" as="offset"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="F5snIL96dau0AUOztgLP-4" value="&lt;b style=&quot;color: rgb(63, 63, 63);&quot;&gt;7.0&lt;/b&gt;&lt;div&gt;&lt;b&gt;Grading &amp;amp; Final&lt;br&gt;Calculation&lt;/b&gt;&lt;/div&gt;" style="ellipse;whiteSpace=wrap;html=1;fillColor=#dae8fc;strokeColor=#6c8ebf;fontSize=14;verticalAlign=middle;flipH=0;labelBackgroundColor=none;" parent="1" vertex="1">
+                    <mxGeometry x="-2380" y="-20" width="220" height="110" as="geometry"/>
+                </mxCell>
+                <mxCell id="WzDSdGTiCHk0TN9zid3g-17" value="Updated Committee&lt;br&gt;&amp;nbsp;Link" style="edgeStyle=orthogonalEdgeStyle;html=1;exitX=1;exitY=0.5;exitDx=0;exitDy=0;orthogonal=1;labelBackgroundColor=default;entryX=0;entryY=0.5;entryDx=0;entryDy=0;entryPerimeter=0;" parent="1" source="F5snIL96dau0AUOztgLP-5" target="Bhhoraj-XN7D4Ivi6Yd--2" edge="1">
+                    <mxGeometry x="-0.0701" y="3" relative="1" as="geometry">
+                        <mxPoint as="offset"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="WzDSdGTiCHk0TN9zid3g-18" value="Assigned Groups" style="edgeStyle=orthogonalEdgeStyle;html=1;exitX=0;exitY=0.5;exitDx=0;exitDy=0;entryX=0.62;entryY=0.012;entryDx=0;entryDy=0;orthogonal=1;labelBackgroundColor=default;entryPerimeter=0;" parent="1" source="F5snIL96dau0AUOztgLP-5" target="903sCpO6xVK5vF8ryV6D-3" edge="1">
+                    <mxGeometry x="0.018" relative="1" as="geometry">
+                        <mxPoint as="offset"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="F5snIL96dau0AUOztgLP-5" value="&lt;b&gt;4.0&lt;/b&gt;&lt;br&gt;Committee Assignment" style="ellipse;whiteSpace=wrap;html=1;fillColor=#dae8fc;strokeColor=#6c8ebf;fontSize=14;verticalAlign=middle;flipH=0;labelBackgroundColor=none;" parent="1" vertex="1">
+                    <mxGeometry x="-2380" y="-370" width="220" height="110" as="geometry"/>
+                </mxCell>
+                <mxCell id="F5snIL96dau0AUOztgLP-6" value="&lt;b&gt;3.0&lt;/b&gt;&lt;br&gt;Advisor &lt;br&gt;Association &amp;amp; Sanitization" style="ellipse;whiteSpace=wrap;html=1;fillColor=#dae8fc;strokeColor=#6c8ebf;fontSize=14;verticalAlign=middle;flipH=0;labelBackgroundColor=none;" parent="1" vertex="1">
+                    <mxGeometry x="-2250" y="-170" width="220" height="110" as="geometry"/>
+                </mxCell>
+                <mxCell id="WzDSdGTiCHk0TN9zid3g-24" value="Fetch Requests" style="edgeStyle=elbowEdgeStyle;html=1;orthogonal=1;labelBackgroundColor=default;exitX=0.5;exitY=0;exitDx=0;exitDy=0;entryX=0.5;entryY=0;entryDx=0;entryDy=0;" parent="1" source="F5snIL96dau0AUOztgLP-7" target="903sCpO6xVK5vF8ryV6D-5" edge="1">
+                    <mxGeometry x="-0.1989" relative="1" as="geometry">
+                        <mxPoint as="offset"/>
+                        <mxPoint x="-1640" y="-520" as="sourcePoint"/>
+                        <Array as="points">
+                            <mxPoint x="-1630" y="-640"/>
+                        </Array>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="YE9hbXlFpOjnMs0VjsED-7" value="Issue Descriptions,&lt;br&gt;PR Comments,&lt;br&gt;File Diffs" style="edgeStyle=none;html=1;exitX=0.947;exitY=0.771;exitDx=0;exitDy=0;entryX=0;entryY=0.75;entryDx=0;entryDy=0;exitPerimeter=0;" parent="1" source="F5snIL96dau0AUOztgLP-7" target="YE9hbXlFpOjnMs0VjsED-6" edge="1">
+                    <mxGeometry x="0.1777" y="-18" relative="1" as="geometry">
+                        <mxPoint as="offset"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="YE9hbXlFpOjnMs0VjsED-11" style="edgeStyle=none;html=1;exitX=1;exitY=0;exitDx=0;exitDy=0;entryX=1;entryY=0;entryDx=0;entryDy=0;" parent="1" source="F5snIL96dau0AUOztgLP-7" target="903sCpO6xVK5vF8ryV6D-4" edge="1">
+                    <mxGeometry relative="1" as="geometry">
+                        <Array as="points">
+                            <mxPoint x="-1575" y="-720"/>
+                        </Array>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="YE9hbXlFpOjnMs0VjsED-12" value="Branch/PR&lt;br&gt;Queries" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];" parent="YE9hbXlFpOjnMs0VjsED-11" vertex="1" connectable="0">
+                    <mxGeometry x="-0.4022" y="-1" relative="1" as="geometry">
+                        <mxPoint x="14" y="28" as="offset"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="F5snIL96dau0AUOztgLP-7" value="&lt;b style=&quot;color: rgb(63, 63, 63); scrollbar-color: rgb(226, 226, 226) rgb(251, 251, 251);&quot;&gt;5.0&lt;br style=&quot;color: rgb(63, 63, 63); scrollbar-color: rgb(226, 226, 226) rgb(251, 251, 251);&quot;&gt;&lt;/b&gt;&lt;span style=&quot;color: rgb(0, 0, 0);&quot;&gt;Sprint Tracking,&lt;/span&gt;&lt;br style=&quot;color: rgb(63, 63, 63); scrollbar-color: rgb(226, 226, 226) rgb(251, 251, 251);&quot;&gt;&lt;span style=&quot;color: rgb(0, 0, 0);&quot;&gt;Scrum Grading &amp;amp; AI Validation&lt;/span&gt;" style="ellipse;whiteSpace=wrap;html=1;fillColor=#dae8fc;strokeColor=#6c8ebf;fontSize=14;verticalAlign=middle;flipH=0;labelBackgroundColor=none;" parent="1" vertex="1">
+                    <mxGeometry x="-1760" y="-534.34" width="220" height="110" as="geometry"/>
+                </mxCell>
+                <mxCell id="WzDSdGTiCHk0TN9zid3g-22" value="Read-only &lt;br&gt;Submissions" style="edgeStyle=orthogonalEdgeStyle;html=1;exitX=0.409;exitY=1.009;exitDx=0;exitDy=0;orthogonal=1;labelBackgroundColor=default;exitPerimeter=0;entryX=0.357;entryY=0.025;entryDx=0;entryDy=0;entryPerimeter=0;" parent="1" source="6vHCIuZtSWlxRlMeQgIX-1" target="903sCpO6xVK5vF8ryV6D-3" edge="1">
+                    <mxGeometry x="-0.2922" y="4" relative="1" as="geometry">
+                        <mxPoint as="offset"/>
+                        <mxPoint x="-2730.000000000001" y="-240.00000000000009" as="sourcePoint"/>
+                        <mxPoint x="-2750" y="-390" as="targetPoint"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="qCxVODThMoP1LT63TutK-4" style="edgeStyle=orthogonalEdgeStyle;html=1;exitX=1;exitY=0.5;exitDx=0;exitDy=0;entryX=0.212;entryY=0.011;entryDx=0;entryDy=0;entryPerimeter=0;" parent="1" source="6vHCIuZtSWlxRlMeQgIX-1" target="UNcb3l8VgCFt9lwZonRV-1" edge="1">
+                    <mxGeometry relative="1" as="geometry">
+                        <mxPoint x="-2631" y="-424.34" as="sourcePoint"/>
+                        <mxPoint x="-2452.7200000000003" y="-239.58" as="targetPoint"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="qCxVODThMoP1LT63TutK-5" value="Review Feedback" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];" parent="qCxVODThMoP1LT63TutK-4" vertex="1" connectable="0">
+                    <mxGeometry x="-0.0234" y="-1" relative="1" as="geometry">
+                        <mxPoint x="-97" as="offset"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="6vHCIuZtSWlxRlMeQgIX-1" value="&lt;b style=&quot;color: rgb(63, 63, 63); scrollbar-color: rgb(226, 226, 226) rgb(251, 251, 251);&quot;&gt;6.0&lt;/b&gt;&lt;br style=&quot;color: rgb(63, 63, 63); scrollbar-color: rgb(226, 226, 226) rgb(251, 251, 251);&quot;&gt;&lt;b style=&quot;color: rgb(63, 63, 63); scrollbar-color: rgb(226, 226, 226) rgb(251, 251, 251);&quot;&gt;DeliverableSubmission &amp;amp; Review&lt;/b&gt;" style="ellipse;whiteSpace=wrap;html=1;fillColor=#dae8fc;strokeColor=#6c8ebf;fontSize=14;verticalAlign=middle;flipH=0;labelBackgroundColor=none;" parent="1" vertex="1">
+                    <mxGeometry x="-2840" y="-480" width="220" height="110" as="geometry"/>
+                </mxCell>
+                <mxCell id="WzDSdGTiCHk0TN9zid3g-30" value="Deliverable Documents" style="edgeStyle=elbowEdgeStyle;html=1;orthogonal=1;labelBackgroundColor=default;entryX=0.077;entryY=0.791;entryDx=0;entryDy=0;entryPerimeter=0;exitX=0.413;exitY=0.996;exitDx=0;exitDy=0;exitPerimeter=0;" parent="1" source="Bhhoraj-XN7D4Ivi6Yd--1" target="F5snIL96dau0AUOztgLP-4" edge="1">
+                    <mxGeometry x="-0.4555" relative="1" as="geometry">
+                        <mxPoint as="offset"/>
+                        <mxPoint x="-2760" y="40" as="sourcePoint"/>
+                        <Array as="points">
+                            <mxPoint x="-2760" y="80"/>
+                        </Array>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="Bhhoraj-XN7D4Ivi6Yd--1" value="D4: Suubmissions (Documents)" style="shape=cylinder3;whiteSpace=wrap;html=1;boundedLbl=1;backgroundOutline=1;size=15;fillColor=#d5e8d4;strokeColor=#82b366;flipH=0;labelBackgroundColor=none;" parent="1" vertex="1">
+                    <mxGeometry x="-2820" y="-39.669999999999945" width="150" height="80" as="geometry"/>
+                </mxCell>
+                <mxCell id="qCxVODThMoP1LT63TutK-1" style="edgeStyle=orthogonalEdgeStyle;html=1;exitX=1;exitY=1;exitDx=0;exitDy=-15;exitPerimeter=0;entryX=0.841;entryY=0.912;entryDx=0;entryDy=0;entryPerimeter=0;" parent="1" source="Bhhoraj-XN7D4Ivi6Yd--2" target="F5snIL96dau0AUOztgLP-7" edge="1">
+                    <mxGeometry relative="1" as="geometry">
+                        <mxPoint x="-1599.5217391304345" y="-219.60869565217376" as="targetPoint"/>
+                        <Array as="points">
+                            <mxPoint x="-1799" y="-190"/>
+                            <mxPoint x="-1575" y="-190"/>
+                        </Array>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="qCxVODThMoP1LT63TutK-2" value="PATs, Project Keys,&lt;br&gt;Group IDs" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];labelBackgroundColor=default;" parent="qCxVODThMoP1LT63TutK-1" vertex="1" connectable="0">
+                    <mxGeometry x="0.2974" y="-4" relative="1" as="geometry">
+                        <mxPoint x="-3" y="2" as="offset"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="qCxVODThMoP1LT63TutK-3" value="Group Structures, Advisor Links" style="edgeStyle=orthogonalEdgeStyle;html=1;exitX=0.855;exitY=1;exitDx=0;exitDy=-4.35;exitPerimeter=0;entryX=1;entryY=1;entryDx=0;entryDy=0;" parent="1" source="Bhhoraj-XN7D4Ivi6Yd--2" target="F5snIL96dau0AUOztgLP-4" edge="1">
+                    <mxGeometry x="0.2138" relative="1" as="geometry">
+                        <mxPoint x="-1691.03" y="-129.00000000000023" as="sourcePoint"/>
+                        <mxPoint x="-1955.9982540694793" y="76.12912703473991" as="targetPoint"/>
+                        <Array as="points">
+                            <mxPoint x="-1828" y="-209"/>
+                            <mxPoint x="-1828" y="74"/>
+                        </Array>
+                        <mxPoint as="offset"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="Bhhoraj-XN7D4Ivi6Yd--2" value="D3: Groups &amp;amp;&lt;br&gt;Committees" style="shape=cylinder3;whiteSpace=wrap;html=1;boundedLbl=1;backgroundOutline=1;size=15;fillColor=#d5e8d4;strokeColor=#82b366;flipH=0;labelBackgroundColor=none;" parent="1" vertex="1">
+                    <mxGeometry x="-1949" y="-284.67" width="150" height="80" as="geometry"/>
+                </mxCell>
+                <mxCell id="YE9hbXlFpOjnMs0VjsED-1" style="edgeStyle=orthogonalEdgeStyle;html=1;exitX=0;exitY=0.5;exitDx=0;exitDy=0;exitPerimeter=0;entryX=0;entryY=0.5;entryDx=0;entryDy=0;" parent="1" source="Bhhoraj-XN7D4Ivi6Yd--3" target="6vHCIuZtSWlxRlMeQgIX-1" edge="1">
+                    <mxGeometry relative="1" as="geometry">
+                        <Array as="points">
+                            <mxPoint x="-2976" y="215"/>
+                            <mxPoint x="-2976" y="-296"/>
+                            <mxPoint x="-2896" y="-296"/>
+                            <mxPoint x="-2896" y="-425"/>
+                        </Array>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="YE9hbXlFpOjnMs0VjsED-2" value="Deadlines" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];" parent="YE9hbXlFpOjnMs0VjsED-1" vertex="1" connectable="0">
+                    <mxGeometry x="0.4416" y="-3" relative="1" as="geometry">
+                        <mxPoint x="-40" y="48" as="offset"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="Bhhoraj-XN7D4Ivi6Yd--3" value="D1: Term Config&lt;br&gt;(Rubrics, Rules)" style="shape=cylinder3;whiteSpace=wrap;html=1;boundedLbl=1;backgroundOutline=1;size=15;fillColor=#d5e8d4;strokeColor=#82b366;flipH=0;labelBackgroundColor=none;" parent="1" vertex="1">
+                    <mxGeometry x="-2955" y="175.00000000000006" width="150" height="80" as="geometry"/>
+                </mxCell>
+                <mxCell id="Bhhoraj-XN7D4Ivi6Yd--4" value="D2: Users&lt;br&gt;(Profiles, Roles)" style="shape=cylinder3;whiteSpace=wrap;html=1;boundedLbl=1;backgroundOutline=1;size=15;fillColor=#d5e8d4;strokeColor=#82b366;flipH=0;labelBackgroundColor=none;" parent="1" vertex="1">
+                    <mxGeometry x="-2690" y="-690" width="150" height="80" as="geometry"/>
+                </mxCell>
+                <mxCell id="WzDSdGTiCHk0TN9zid3g-31" value="&lt;br&gt;Story Points, &lt;br&gt;AI Validation Results&lt;div&gt;&lt;br&gt;&lt;/div&gt;" style="edgeStyle=orthogonalEdgeStyle;html=1;exitX=0.788;exitY=0.997;exitDx=0;exitDy=0;exitPerimeter=0;orthogonal=1;labelBackgroundColor=default;entryX=0.941;entryY=0.293;entryDx=0;entryDy=0;entryPerimeter=0;" parent="1" source="Bhhoraj-XN7D4Ivi6Yd--5" target="F5snIL96dau0AUOztgLP-4" edge="1">
+                    <mxGeometry x="0.5831" relative="1" as="geometry">
+                        <mxPoint as="offset"/>
+                        <Array as="points">
+                            <mxPoint x="-1972" y="12"/>
+                        </Array>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="WzDSdGTiCHk0TN9zid3g-32" value="&lt;br&gt;Computed &lt;br&gt;Final Grades&lt;div&gt;&lt;br&gt;&lt;/div&gt;" style="edgeStyle=elbowEdgeStyle;html=1;exitX=0;exitY=0.5;exitDx=0;exitDy=0;exitPerimeter=0;orthogonal=1;labelBackgroundColor=default;entryX=0.5;entryY=0;entryDx=0;entryDy=0;" parent="1" source="Bhhoraj-XN7D4Ivi6Yd--5" target="F5snIL96dau0AUOztgLP-5" edge="1">
+                    <mxGeometry x="-0.0692" relative="1" as="geometry">
+                        <mxPoint as="offset"/>
+                        <mxPoint x="-1977.4601075847759" y="-319.5930769230769" as="targetPoint"/>
+                        <Array as="points">
+                            <mxPoint x="-2270" y="-400"/>
+                        </Array>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="Bhhoraj-XN7D4Ivi6Yd--5" value="D5: Sprint &amp;amp;&lt;br&gt;Grading Logs" style="shape=cylinder3;whiteSpace=wrap;html=1;boundedLbl=1;backgroundOutline=1;size=15;fillColor=#d5e8d4;strokeColor=#82b366;flipH=0;labelBackgroundColor=none;" parent="1" vertex="1">
+                    <mxGeometry x="-2090" y="-435.00000000000006" width="150" height="80" as="geometry"/>
+                </mxCell>
+                <mxCell id="WzDSdGTiCHk0TN9zid3g-2" value="Term Rules, Rubrics,&lt;br&gt;&amp;nbsp;Weights" style="edgeStyle=orthogonalEdgeStyle;html=1;exitX=0;exitY=0.5;exitDx=0;exitDy=0;orthogonal=1;labelBackgroundColor=default;entryX=0.145;entryY=1;entryDx=0;entryDy=-4.35;entryPerimeter=0;" parent="1" source="F5snIL96dau0AUOztgLP-1" target="Bhhoraj-XN7D4Ivi6Yd--3" edge="1">
+                    <mxGeometry x="-0.0769" relative="1" as="geometry">
+                        <mxPoint x="-1527.46" y="515.33" as="targetPoint"/>
+                        <mxPoint as="offset"/>
+                        <Array as="points">
+                            <mxPoint x="-2933" y="275"/>
+                        </Array>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="WzDSdGTiCHk0TN9zid3g-12" value="Group Details,&lt;br&gt;&amp;nbsp;Bound Tokens" style="edgeStyle=orthogonalEdgeStyle;html=1;orthogonal=1;exitX=1;exitY=1;exitDx=0;exitDy=0;labelBackgroundColor=default;entryX=1;entryY=0.5;entryDx=0;entryDy=0;entryPerimeter=0;" parent="1" source="F5snIL96dau0AUOztgLP-3" target="Bhhoraj-XN7D4Ivi6Yd--2" edge="1">
+                    <mxGeometry x="-0.4004" relative="1" as="geometry">
+                        <mxPoint x="-2042.46" y="885.6600000000001" as="targetPoint"/>
+                        <mxPoint y="-1" as="offset"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="WzDSdGTiCHk0TN9zid3g-15" value="Updated Advisor Link" style="edgeStyle=orthogonalEdgeStyle;html=1;exitX=1;exitY=0.5;exitDx=0;exitDy=0;orthogonal=1;labelBackgroundColor=default;entryX=0.5;entryY=1;entryDx=0;entryDy=0;entryPerimeter=0;" parent="1" source="F5snIL96dau0AUOztgLP-6" target="Bhhoraj-XN7D4Ivi6Yd--2" edge="1">
+                    <mxGeometry x="0.4735" y="10" relative="1" as="geometry">
+                        <mxPoint as="offset"/>
+                        <mxPoint x="-2047.46" y="45.33" as="targetPoint"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="WzDSdGTiCHk0TN9zid3g-20" value="Proposal,&lt;br&gt;SoW Documents,&lt;br&gt;Reviews" style="edgeStyle=orthogonalEdgeStyle;html=1;entryX=0.5;entryY=0;entryDx=0;entryDy=0;entryPerimeter=0;orthogonal=1;labelBackgroundColor=default;exitX=0;exitY=1;exitDx=0;exitDy=0;" parent="1" source="6vHCIuZtSWlxRlMeQgIX-1" target="Bhhoraj-XN7D4Ivi6Yd--1" edge="1">
+                    <mxGeometry x="0.3782" y="-3" relative="1" as="geometry">
+                        <mxPoint x="-1312" y="420" as="sourcePoint"/>
+                        <Array as="points">
+                            <mxPoint x="-2808" y="-132"/>
+                            <mxPoint x="-2803" y="-132"/>
+                            <mxPoint x="-2803" y="-130"/>
+                            <mxPoint x="-2745" y="-130"/>
+                        </Array>
+                        <mxPoint as="offset"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="WzDSdGTiCHk0TN9zid3g-21" value="&lt;br&gt;Deliverable &lt;br&gt;Documents&lt;div&gt;&lt;br&gt;&lt;/div&gt;" style="edgeStyle=orthogonalEdgeStyle;html=1;entryX=0;entryY=0;entryDx=0;entryDy=0;orthogonal=1;labelBackgroundColor=default;exitX=0;exitY=0.5;exitDx=0;exitDy=0;exitPerimeter=0;" parent="1" source="Bhhoraj-XN7D4Ivi6Yd--1" target="6vHCIuZtSWlxRlMeQgIX-1" edge="1">
+                    <mxGeometry x="-0.2065" y="-3" relative="1" as="geometry">
+                        <mxPoint as="offset"/>
+                        <mxPoint x="-2730" y="-40" as="sourcePoint"/>
+                        <Array as="points">
+                            <mxPoint x="-2930"/>
+                            <mxPoint x="-2930" y="-464"/>
+                        </Array>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="WzDSdGTiCHk0TN9zid3g-26" value="PR Diffs,&lt;br&gt;PR Comments" style="edgeStyle=elbowEdgeStyle;html=1;exitX=1;exitY=0.5;exitDx=0;exitDy=0;orthogonal=1;labelBackgroundColor=default;entryX=0.75;entryY=0.094;entryDx=0;entryDy=0;entryPerimeter=0;" parent="1" source="903sCpO6xVK5vF8ryV6D-4" target="F5snIL96dau0AUOztgLP-7" edge="1">
+                    <mxGeometry x="-0.3466" relative="1" as="geometry">
+                        <mxPoint x="-422.46000000000004" y="-574.3399999999999" as="targetPoint"/>
+                        <mxPoint as="offset"/>
+                        <Array as="points">
+                            <mxPoint x="-1595" y="-610"/>
+                        </Array>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="WzDSdGTiCHk0TN9zid3g-27" value="&lt;div&gt;Story Points,&lt;br&gt;AI Validation Results&lt;/div&gt;" style="edgeStyle=elbowEdgeStyle;html=1;exitX=0.011;exitY=0.394;exitDx=0;exitDy=0;orthogonal=1;labelBackgroundColor=default;entryX=0.5;entryY=0;entryDx=0;entryDy=0;entryPerimeter=0;exitPerimeter=0;" parent="1" source="F5snIL96dau0AUOztgLP-7" target="Bhhoraj-XN7D4Ivi6Yd--5" edge="1">
+                    <mxGeometry x="-0.2188" relative="1" as="geometry">
+                        <mxPoint x="-1717.46" y="-460.00000000000017" as="sourcePoint"/>
+                        <mxPoint x="-2015" y="-445.66" as="targetPoint"/>
+                        <Array as="points">
+                            <mxPoint x="-1890" y="-490"/>
+                        </Array>
+                        <mxPoint as="offset"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="WzDSdGTiCHk0TN9zid3g-29" value="Term Rules, Weights" style="edgeStyle=elbowEdgeStyle;html=1;exitX=1;exitY=0.5;exitDx=0;exitDy=0;exitPerimeter=0;entryX=0.015;entryY=0.639;entryDx=0;entryDy=0;orthogonal=1;labelBackgroundColor=default;entryPerimeter=0;" parent="1" source="Bhhoraj-XN7D4Ivi6Yd--3" target="F5snIL96dau0AUOztgLP-4" edge="1">
+                    <mxGeometry x="-0.2243" relative="1" as="geometry">
+                        <Array as="points">
+                            <mxPoint x="-2590" y="130"/>
+                        </Array>
+                        <mxPoint as="offset"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="F5snIL96dau0AUOztgLP-1" value="&lt;b&gt;0.0&lt;br&gt;&lt;/b&gt;Coordinator Setup&lt;b&gt;&lt;/b&gt;" style="ellipse;whiteSpace=wrap;html=1;fillColor=#dae8fc;strokeColor=#6c8ebf;fontSize=14;verticalAlign=middle;flipH=0;labelBackgroundColor=none;" parent="1" vertex="1">
+                    <mxGeometry x="-2757" y="220.00000000000003" width="220" height="110" as="geometry"/>
+                </mxCell>
+                <mxCell id="0EFEJRTbpYjj15akenVm-1" value="Registered User Data" style="edgeStyle=orthogonalEdgeStyle;html=1;exitX=0.855;exitY=1;exitDx=0;exitDy=-4.35;exitPerimeter=0;entryX=0.202;entryY=0.118;entryDx=0;entryDy=0;entryPerimeter=0;labelBackgroundColor=default;" parent="1" source="Bhhoraj-XN7D4Ivi6Yd--4" target="F5snIL96dau0AUOztgLP-2" edge="1">
+                    <mxGeometry x="0.2702" y="-8" relative="1" as="geometry">
+                        <mxPoint as="offset"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="YE9hbXlFpOjnMs0VjsED-9" style="edgeStyle=none;html=1;exitX=0;exitY=0;exitDx=0;exitDy=0;entryX=1;entryY=0.5;entryDx=0;entryDy=0;" parent="1" source="YE9hbXlFpOjnMs0VjsED-6" target="F5snIL96dau0AUOztgLP-7" edge="1">
+                    <mxGeometry relative="1" as="geometry"/>
+                </mxCell>
+                <mxCell id="YE9hbXlFpOjnMs0VjsED-10" value="Validation Results &lt;br&gt;(PASS/WARN/FAIL)" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];" parent="YE9hbXlFpOjnMs0VjsED-9" vertex="1" connectable="0">
+                    <mxGeometry x="0.152" y="-4" relative="1" as="geometry">
+                        <mxPoint x="31" y="-5" as="offset"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="YE9hbXlFpOjnMs0VjsED-6" value="&lt;span style=&quot;font-family: monospace; font-size: 0px; font-weight: 400; text-align: start; text-wrap-mode: nowrap;&quot;&gt;%3CmxGraphModel%3E%3Croot%3E%3CmxCell%20id%3D%220%22%2F%3E%3CmxCell%20id%3D%221%22%20parent%3D%220%22%2F%3E%3CmxCell%20id%3D%222%22%20value%3D%22External%3A%20JIRA%20API%22%20style%3D%22rounded%3D1%3BwhiteSpace%3Dwrap%3Bhtml%3D1%3BfillColor%3D%23ffe6cc%3BstrokeColor%3D%23d6b656%3BfontSize%3D13%3BfontStyle%3D1%3BflipH%3D0%3BlabelBackgroundColor%3Dnone%3B%22%20vertex%3D%221%22%20parent%3D%221%22%3E%3CmxGeometry%20x%3D%22-2340%22%20y%3D%22-610%22%20width%3D%22160%22%20height%3D%2240%22%20as%3D%22geometry%22%2F%3E%3C%2FmxCell%3E%3C%2Froot%3E%3C%2FmxGraphModel%3E&lt;/span&gt;External: AI Service" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#ffe6cc;strokeColor=#d6b656;fontSize=13;fontStyle=1;flipH=0;labelBackgroundColor=none;" parent="1" vertex="1">
+                    <mxGeometry x="-1374" y="-480" width="160" height="40" as="geometry"/>
+                </mxCell>
+                <mxCell id="YE9hbXlFpOjnMs0VjsED-16" style="edgeStyle=orthogonalEdgeStyle;html=1;exitX=0.848;exitY=0.992;exitDx=0;exitDy=0;entryX=0.667;entryY=0.964;entryDx=0;entryDy=0;entryPerimeter=0;exitPerimeter=0;" parent="1" source="903sCpO6xVK5vF8ryV6D-3" target="F5snIL96dau0AUOztgLP-7" edge="1">
+                    <mxGeometry relative="1" as="geometry">
+                        <mxPoint x="-2720" y="-197.38" as="sourcePoint"/>
+                        <mxPoint x="-1618.2400000000002" y="-427.0000000000001" as="targetPoint"/>
+                        <Array as="points">
+                            <mxPoint x="-2681" y="-34"/>
+                            <mxPoint x="-1613" y="-34"/>
+                        </Array>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="YE9hbXlFpOjnMs0VjsED-17" value="Sprint Grades" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];" parent="YE9hbXlFpOjnMs0VjsED-16" vertex="1" connectable="0">
+                    <mxGeometry x="0.406" y="5" relative="1" as="geometry">
+                        <mxPoint as="offset"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="6" style="edgeStyle=none;html=1;exitX=0.046;exitY=0.314;exitDx=0;exitDy=0;entryX=1;entryY=0.5;entryDx=0;entryDy=0;exitPerimeter=0;" edge="1" parent="1" target="903sCpO6xVK5vF8ryV6D-1">
+                    <mxGeometry relative="1" as="geometry">
+                        <mxPoint x="-2520" y="-515" as="sourcePoint"/>
+                        <mxPoint x="-2740" y="-550" as="targetPoint"/>
+                        <Array as="points">
+                            <mxPoint x="-2520" y="-550"/>
+                        </Array>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="7" value="Generated Password Reset Link&amp;nbsp;" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];" vertex="1" connectable="0" parent="6">
+                    <mxGeometry x="0.0768" y="-3" relative="1" as="geometry">
+                        <mxPoint x="7" y="-7" as="offset"/>
+                    </mxGeometry>
+                </mxCell>
+            </root>
+        </mxGraphModel>
+    </diagram>
+</mxfile>

--- a/docs/red_dfd/process2_dfd_lvl1.drawio
+++ b/docs/red_dfd/process2_dfd_lvl1.drawio
@@ -1,0 +1,539 @@
+<mxfile host="65bd71144e">
+    <diagram id="dfd-level-1" name="Group Management Architecture">
+        <mxGraphModel dx="1913" dy="1169" grid="1" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="1" pageScale="1" pageWidth="1600" pageHeight="1200" background="#F9F9F9" math="0" shadow="1">
+            <root>
+                <mxCell id="0"/>
+                <mxCell id="1" parent="0"/>
+                <mxCell id="title" value="&lt;font style=&quot;font-size: 24px;&quot;&gt;&lt;b&gt;P2 Level 1 DFD: Group Management &amp;amp; Integration&lt;/b&gt;&lt;/font&gt;" style="text;html=1;strokeColor=none;fillColor=none;align=left;verticalAlign=middle;rounded=0;fontFamily=Helvetica;fontColor=#333333;whiteSpace=wrap;textShadow=0;" parent="1" vertex="1">
+                    <mxGeometry x="20" y="10" width="600" height="40" as="geometry"/>
+                </mxCell>
+                <mxCell id="legend" value="&lt;b&gt;Legend&lt;/b&gt;&lt;br&gt;&lt;br&gt;&lt;div style=&quot;text-align: left;&quot;&gt;&lt;span style=&quot;background-color: #dae8fc; border: 1px solid #6c8ebf; padding: 2px 5px;&quot;&gt; External Actors &lt;/span&gt;&lt;br&gt;&lt;br&gt;&lt;span style=&quot;background-color: #ffe6cc; border: 1px solid #d79b00; padding: 2px 5px;&quot;&gt; Sub-Processes &lt;/span&gt;&lt;br&gt;&lt;br&gt;&lt;span style=&quot;background-color: #d5e8d4; border: 1px solid #82b366; padding: 2px 5px;&quot;&gt; Data Stores &lt;/span&gt;&lt;br&gt;&lt;br&gt;&lt;span style=&quot;background-color: #e1d5e7; border: 1px solid #9673a6; padding: 2px 5px;&quot;&gt; External APIs &lt;/span&gt;&lt;/div&gt;" style="rounded=1;html=1;fillColor=#ffffff;strokeColor=#cccccc;align=left;verticalAlign=top;spacingLeft=10;spacingTop=10;fontFamily=Helvetica;fontColor=#333333;whiteSpace=wrap;textShadow=0;" parent="1" vertex="1">
+                    <mxGeometry x="1400" y="20" width="130" height="160" as="geometry"/>
+                </mxCell>
+                <mxCell id="actor_student" value="&lt;b&gt;STUDENT&lt;/b&gt;&lt;br&gt;(Student / Team Leader)" style="rounded=1;html=1;fillColor=#dae8fc;strokeColor=#6c8ebf;fontFamily=Helvetica;fontColor=#333333;whiteSpace=wrap;textShadow=0;" parent="1" vertex="1">
+                    <mxGeometry x="90" y="499.28000000000003" width="140" height="60" as="geometry"/>
+                </mxCell>
+                <mxCell id="actor_coordinator" value="&lt;b&gt;COORDINATOR&lt;/b&gt;" style="rounded=1;html=1;fillColor=#dae8fc;strokeColor=#6c8ebf;fontFamily=Helvetica;fontColor=#333333;whiteSpace=wrap;textShadow=0;" parent="1" vertex="1">
+                    <mxGeometry x="90" y="970" width="140" height="60" as="geometry"/>
+                </mxCell>
+                <mxCell id="16" style="edgeStyle=none;html=1;exitX=1;exitY=0.5;exitDx=0;exitDy=0;entryX=0.008;entryY=0.169;entryDx=0;entryDy=0;entryPerimeter=0;textShadow=0;" parent="1" source="p31" target="ds_groups" edge="1">
+                    <mxGeometry relative="1" as="geometry">
+                        <Array as="points">
+                            <mxPoint x="660" y="265"/>
+                            <mxPoint x="660" y="330"/>
+                            <mxPoint x="900" y="330"/>
+                            <mxPoint x="900" y="600"/>
+                        </Array>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="17" value="Group record + TEAM_LEADER membership" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];textShadow=0;" parent="16" vertex="1" connectable="0">
+                    <mxGeometry x="0.0545" y="-3" relative="1" as="geometry">
+                        <mxPoint x="-107" y="-32" as="offset"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="p31" value="&lt;b&gt;2.1&lt;/b&gt;&lt;br&gt;Validate Schedule&lt;br&gt;&amp;amp; Create Group" style="ellipse;html=1;fillColor=#ffe6cc;strokeColor=#d79b00;fontFamily=Helvetica;fontColor=#333333;whiteSpace=wrap;textShadow=0;" parent="1" vertex="1">
+                    <mxGeometry x="460" y="220" width="160" height="90" as="geometry"/>
+                </mxCell>
+                <mxCell id="18" style="edgeStyle=none;html=1;textShadow=0;exitX=0.801;exitY=0.123;exitDx=0;exitDy=0;exitPerimeter=0;entryX=0.005;entryY=0.212;entryDx=0;entryDy=0;entryPerimeter=0;" parent="1" source="p32" target="ds_students" edge="1">
+                    <mxGeometry relative="1" as="geometry">
+                        <mxPoint x="659" y="370" as="sourcePoint"/>
+                        <mxPoint x="980" y="411.09652892561985" as="targetPoint"/>
+                        <Array as="points">
+                            <mxPoint x="820" y="380"/>
+                        </Array>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="19" value="Target student lookup" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];textShadow=0;" parent="18" vertex="1" connectable="0">
+                    <mxGeometry x="-0.1882" y="-2" relative="1" as="geometry">
+                        <mxPoint x="-58" y="-12" as="offset"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="23" style="edgeStyle=none;html=1;exitX=1;exitY=1;exitDx=0;exitDy=0;entryX=0.218;entryY=-0.001;entryDx=0;entryDy=0;textShadow=0;entryPerimeter=0;" parent="1" target="ds_groups" edge="1">
+                    <mxGeometry relative="1" as="geometry">
+                        <mxPoint x="606.7537080814132" y="436.71530745726045" as="sourcePoint"/>
+                        <mxPoint x="980" y="1015" as="targetPoint"/>
+                        <Array as="points">
+                            <mxPoint x="620" y="440"/>
+                            <mxPoint x="620" y="460"/>
+                            <mxPoint x="680" y="460"/>
+                            <mxPoint x="890" y="460"/>
+                            <mxPoint x="1020" y="460"/>
+                        </Array>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="26" value="Invitation record " style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];textShadow=0;" parent="23" vertex="1" connectable="0">
+                    <mxGeometry x="-0.7085" y="-2" relative="1" as="geometry">
+                        <mxPoint x="4" y="-12" as="offset"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="p32" value="&lt;b&gt;2.2&lt;/b&gt;&lt;br&gt;Search Student&lt;br&gt;&amp;amp; Send Invitation" style="ellipse;html=1;fillColor=#ffe6cc;strokeColor=#d79b00;fontFamily=Helvetica;fontColor=#333333;whiteSpace=wrap;textShadow=0;" parent="1" vertex="1">
+                    <mxGeometry x="460" y="370" width="160" height="90" as="geometry"/>
+                </mxCell>
+                <mxCell id="29" style="edgeStyle=none;html=1;exitX=0.995;exitY=0.565;exitDx=0;exitDy=0;entryX=0.112;entryY=-0.008;entryDx=0;entryDy=0;textShadow=0;entryPerimeter=0;exitPerimeter=0;" parent="1" source="p33" target="ds_groups" edge="1">
+                    <mxGeometry relative="1" as="geometry">
+                        <mxPoint x="569.9985424949239" y="559.2798051533948" as="sourcePoint"/>
+                        <mxPoint x="943.43" y="1010.68" as="targetPoint"/>
+                        <Array as="points">
+                            <mxPoint x="1000" y="550"/>
+                        </Array>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="30" value="Updated invitation status" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];textShadow=0;" parent="29" vertex="1" connectable="0">
+                    <mxGeometry x="-0.6253" y="3" relative="1" as="geometry">
+                        <mxPoint x="25" y="-8" as="offset"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="p33" value="&lt;b&gt;2.3&lt;/b&gt;&lt;br&gt;Process Invitation&lt;br&gt;Response" style="ellipse;html=1;fillColor=#ffe6cc;strokeColor=#d79b00;fontFamily=Helvetica;fontColor=#333333;whiteSpace=wrap;textShadow=0;" parent="1" vertex="1">
+                    <mxGeometry x="460" y="499.28" width="160" height="90" as="geometry"/>
+                </mxCell>
+                <mxCell id="36" style="edgeStyle=none;html=1;textShadow=0;exitX=0.631;exitY=0.982;exitDx=0;exitDy=0;exitPerimeter=0;entryX=0.134;entryY=1.012;entryDx=0;entryDy=0;entryPerimeter=0;" parent="1" source="p34" target="ds_groups" edge="1">
+                    <mxGeometry relative="1" as="geometry">
+                        <mxPoint x="540" y="750" as="sourcePoint"/>
+                        <mxPoint x="1018.2843810046666" y="639.28" as="targetPoint"/>
+                        <Array as="points">
+                            <mxPoint x="570" y="750"/>
+                            <mxPoint x="670" y="750"/>
+                            <mxPoint x="800" y="750"/>
+                            <mxPoint x="1004" y="750"/>
+                        </Array>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="37" value="encryptedJiraToken, URL, projectKey" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];textShadow=0;" parent="36" vertex="1" connectable="0">
+                    <mxGeometry x="-0.5528" y="3" relative="1" as="geometry">
+                        <mxPoint x="34" y="-8" as="offset"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="p34" value="&lt;b&gt;2.4&lt;/b&gt;&lt;br&gt;Validate &amp;amp;&lt;br&gt;Bind JIRA" style="ellipse;html=1;fillColor=#ffe6cc;strokeColor=#d79b00;fontFamily=Helvetica;fontColor=#333333;whiteSpace=wrap;textShadow=0;" parent="1" vertex="1">
+                    <mxGeometry x="460" y="670" width="160" height="90" as="geometry"/>
+                </mxCell>
+                <mxCell id="42" style="edgeStyle=none;html=1;exitX=0.909;exitY=0.758;exitDx=0;exitDy=0;entryX=0.283;entryY=1.01;entryDx=0;entryDy=0;textShadow=0;entryPerimeter=0;exitPerimeter=0;" parent="1" source="p35" target="ds_groups" edge="1">
+                    <mxGeometry relative="1" as="geometry">
+                        <mxPoint x="1152.3400000000001" y="440.44999999999993" as="targetPoint"/>
+                        <mxPoint x="609.9999999999982" y="885" as="sourcePoint"/>
+                        <Array as="points">
+                            <mxPoint x="1031" y="890"/>
+                        </Array>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="43" value="Status → TOOLS_BOUND" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];textShadow=0;" parent="42" vertex="1" connectable="0">
+                    <mxGeometry x="-0.823" y="5" relative="1" as="geometry">
+                        <mxPoint x="34" y="-3" as="offset"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="58" style="edgeStyle=none;html=1;exitX=0.221;exitY=0.917;exitDx=0;exitDy=0;exitPerimeter=0;textShadow=0;" parent="1" source="p35" target="api_github" edge="1">
+                    <mxGeometry relative="1" as="geometry">
+                        <mxPoint x="1454.7999999999997" y="820" as="targetPoint"/>
+                        <mxPoint x="473.4314575050739" y="893.2998051533959" as="sourcePoint"/>
+                        <Array as="points">
+                            <mxPoint x="495" y="920"/>
+                            <mxPoint x="420" y="920"/>
+                            <mxPoint x="420" y="1170"/>
+                            <mxPoint x="1340" y="1170"/>
+                        </Array>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="59" value="Org + repo-scope test call" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];textShadow=0;" parent="58" vertex="1" connectable="0">
+                    <mxGeometry x="0.3693" y="1" relative="1" as="geometry">
+                        <mxPoint x="-109" y="-9" as="offset"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="p35" value="&lt;b&gt;2.5&lt;/b&gt;&lt;br&gt;Validate &amp;amp;&lt;br&gt;Bind GitHub" style="ellipse;html=1;fillColor=#ffe6cc;strokeColor=#d79b00;fontFamily=Helvetica;fontColor=#333333;whiteSpace=wrap;textShadow=0;" parent="1" vertex="1">
+                    <mxGeometry x="460" y="820" width="160" height="90" as="geometry"/>
+                </mxCell>
+                <mxCell id="49" style="edgeStyle=none;html=1;exitX=0.968;exitY=0.672;exitDx=0;exitDy=0;textShadow=0;entryX=0.379;entryY=0.98;entryDx=0;entryDy=0;entryPerimeter=0;exitPerimeter=0;" parent="1" source="p36" target="ds_groups" edge="1">
+                    <mxGeometry relative="1" as="geometry">
+                        <Array as="points">
+                            <mxPoint x="900" y="1030"/>
+                            <mxPoint x="1050" y="1030"/>
+                            <mxPoint x="1050" y="920"/>
+                        </Array>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="50" value="Updated membership" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];textShadow=0;" parent="49" vertex="1" connectable="0">
+                    <mxGeometry x="-0.8656" y="-3" relative="1" as="geometry">
+                        <mxPoint x="42" y="-13" as="offset"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="p36" value="&lt;b&gt;2.6&lt;/b&gt;&lt;br&gt;Coordinator&lt;br&gt;Group Override" style="ellipse;html=1;fillColor=#ffe6cc;strokeColor=#d79b00;fontFamily=Helvetica;fontColor=#333333;whiteSpace=wrap;textShadow=0;" parent="1" vertex="1">
+                    <mxGeometry x="460" y="970" width="160" height="90" as="geometry"/>
+                </mxCell>
+                <mxCell id="ds_schedule" value="D1: Term Config" style="shape=partialRectangle;right=0;left=0;html=1;fillColor=#d5e8d4;strokeColor=#82b366;fontFamily=Helvetica;fontColor=#333333;fontStyle=1;whiteSpace=wrap;textShadow=0;" parent="1" vertex="1">
+                    <mxGeometry x="980" y="220" width="180" height="50" as="geometry"/>
+                </mxCell>
+                <mxCell id="ds_students" value="D2: Users (Profiles, Roles)" style="shape=partialRectangle;right=0;left=0;html=1;fillColor=#d5e8d4;strokeColor=#82b366;fontFamily=Helvetica;fontColor=#333333;fontStyle=1;whiteSpace=wrap;textShadow=0;" parent="1" vertex="1">
+                    <mxGeometry x="981" y="370" width="180" height="50" as="geometry"/>
+                </mxCell>
+                <mxCell id="44" style="edgeStyle=none;html=1;entryX=0.913;entryY=0.205;entryDx=0;entryDy=0;textShadow=0;exitX=0.01;exitY=0.786;exitDx=0;exitDy=0;exitPerimeter=0;entryPerimeter=0;" parent="1" source="ds_groups" target="p36" edge="1">
+                    <mxGeometry relative="1" as="geometry">
+                        <mxPoint x="1025" y="438" as="sourcePoint"/>
+                        <mxPoint x="620" y="1003" as="targetPoint"/>
+                        <Array as="points">
+                            <mxPoint x="860" y="630"/>
+                            <mxPoint x="860" y="990"/>
+                        </Array>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="45" value="Current membership" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];textShadow=0;" parent="44" vertex="1" connectable="0">
+                    <mxGeometry x="0.6982" y="-3" relative="1" as="geometry">
+                        <mxPoint x="-21" y="-10" as="offset"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="ds_groups" value="D3: Groups &amp;amp; Committees,&lt;div&gt;&lt;span style=&quot;background-color: transparent; color: rgb(51, 51, 51);&quot;&gt;Bound Tokens&lt;/span&gt;&lt;/div&gt;" style="shape=partialRectangle;right=0;left=0;html=1;fillColor=#d5e8d4;strokeColor=#82b366;fontFamily=Helvetica;fontColor=#333333;fontStyle=1;whiteSpace=wrap;textShadow=0;" parent="1" vertex="1">
+                    <mxGeometry x="980" y="589.28" width="180" height="50" as="geometry"/>
+                </mxCell>
+                <mxCell id="api_jira" value="&lt;b&gt;JIRA REST API&lt;/b&gt;" style="rounded=1;html=1;fillColor=#e1d5e7;strokeColor=#9673a6;fontFamily=Helvetica;fontColor=#333333;whiteSpace=wrap;textShadow=0;" parent="1" vertex="1">
+                    <mxGeometry x="1260" y="650" width="140" height="60" as="geometry"/>
+                </mxCell>
+                <mxCell id="60" style="edgeStyle=none;html=1;exitX=0.25;exitY=1;exitDx=0;exitDy=0;entryX=0.329;entryY=0.933;entryDx=0;entryDy=0;entryPerimeter=0;textShadow=0;" parent="1" source="api_github" target="p35" edge="1">
+                    <mxGeometry relative="1" as="geometry">
+                        <mxPoint x="468.84033956579765" y="903.5871816570645" as="targetPoint"/>
+                        <mxPoint x="1389.0322580645159" y="840" as="sourcePoint"/>
+                        <Array as="points">
+                            <mxPoint x="1300" y="1140"/>
+                            <mxPoint x="440" y="1140"/>
+                            <mxPoint x="440" y="940"/>
+                            <mxPoint x="513" y="940"/>
+                        </Array>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="61" value="200 / 401 / 403 / 404" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];textShadow=0;" parent="60" vertex="1" connectable="0">
+                    <mxGeometry x="-0.1415" y="-5" relative="1" as="geometry">
+                        <mxPoint x="-471" y="-5" as="offset"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="api_github" value="&lt;b&gt;GitHub REST API&lt;/b&gt;" style="rounded=1;html=1;fillColor=#e1d5e7;strokeColor=#9673a6;fontFamily=Helvetica;fontColor=#333333;whiteSpace=wrap;textShadow=0;" parent="1" vertex="1">
+                    <mxGeometry x="1260" y="760" width="140" height="60" as="geometry"/>
+                </mxCell>
+                <mxCell id="e_stu_p31" style="edgeStyle=orthogonalEdgeStyle;rounded=1;html=1;strokeColor=#545B64;exitX=0.355;exitY=0;exitDx=0;exitDy=0;exitPerimeter=0;entryX=-0.001;entryY=0.564;entryDx=0;entryDy=0;entryPerimeter=0;textShadow=0;" parent="1" source="actor_student" edge="1">
+                    <mxGeometry relative="1" as="geometry">
+                        <Array as="points">
+                            <mxPoint x="140" y="270.28"/>
+                        </Array>
+                        <mxPoint x="140" y="499.28000000000003" as="sourcePoint"/>
+                        <mxPoint x="459.8399999999999" y="270.03999999999985" as="targetPoint"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="l_stu_p31" value="groupName,&amp;nbsp;&lt;span style=&quot;color: rgb(63, 63, 63); background-color: light-dark(rgb(255, 255, 255), rgb(18, 18, 18));&quot;&gt;termId, studentId&lt;/span&gt;" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];labelBackgroundColor=#ffffff;fontFamily=Helvetica;fontSize=11;textShadow=0;" parent="e_stu_p31" vertex="1" connectable="0">
+                    <mxGeometry x="0.2" relative="1" as="geometry">
+                        <mxPoint x="50" y="10" as="offset"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="e_p31_stu" style="edgeStyle=orthogonalEdgeStyle;rounded=1;html=1;strokeColor=#545B64;entryX=0.219;entryY=0.078;entryDx=0;entryDy=0;entryPerimeter=0;exitX=0.061;exitY=0.342;exitDx=0;exitDy=0;exitPerimeter=0;textShadow=0;" parent="1" target="actor_student" edge="1">
+                    <mxGeometry relative="1" as="geometry">
+                        <Array as="points">
+                            <mxPoint x="121" y="250.28"/>
+                        </Array>
+                        <mxPoint x="469.76" y="250.05999999999997" as="sourcePoint"/>
+                        <mxPoint x="120.03999999999989" y="499.28000000000003" as="targetPoint"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="l_p31_stu" value="GroupResponse (id, status=FORMING)" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];labelBackgroundColor=#ffffff;fontFamily=Helvetica;fontSize=11;textShadow=0;" parent="e_p31_stu" vertex="1" connectable="0">
+                    <mxGeometry x="0.2" relative="1" as="geometry">
+                        <mxPoint x="160" y="-22" as="offset"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="e_ds0_p31" style="edgeStyle=orthogonalEdgeStyle;rounded=1;html=1;strokeColor=#545B64;textShadow=0;exitX=-0.008;exitY=0.589;exitDx=0;exitDy=0;exitPerimeter=0;" parent="1" source="ds_schedule" edge="1">
+                    <mxGeometry relative="1" as="geometry">
+                        <Array as="points">
+                            <mxPoint x="950" y="250"/>
+                            <mxPoint x="950" y="210"/>
+                            <mxPoint x="580" y="210"/>
+                        </Array>
+                        <mxPoint x="945.62" y="212.5" as="sourcePoint"/>
+                        <mxPoint x="580.0447233265651" y="230" as="targetPoint"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="l_ds0_p31" value="Active window check" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];labelBackgroundColor=#ffffff;fontFamily=Helvetica;fontSize=11;textShadow=0;" parent="e_ds0_p31" vertex="1" connectable="0">
+                    <mxGeometry x="-0.1" relative="1" as="geometry">
+                        <mxPoint x="-32" y="-10" as="offset"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="e_stu_p32" style="edgeStyle=orthogonalEdgeStyle;rounded=1;html=1;strokeColor=#545B64;exitX=0.718;exitY=0;exitDx=0;exitDy=0;exitPerimeter=0;entryX=0.021;entryY=0.453;entryDx=0;entryDy=0;entryPerimeter=0;textShadow=0;" parent="1" source="actor_student" edge="1">
+                    <mxGeometry relative="1" as="geometry">
+                        <Array as="points">
+                            <mxPoint x="191" y="410.28000000000003"/>
+                        </Array>
+                        <mxPoint x="190.5" y="499.28000000000003" as="sourcePoint"/>
+                        <mxPoint x="463.3599999999999" y="410.05" as="targetPoint"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="l_stu_p32" value="targetStudentId, groupId" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];labelBackgroundColor=#ffffff;fontFamily=Helvetica;fontSize=11;textShadow=0;" parent="e_stu_p32" vertex="1" connectable="0">
+                    <mxGeometry x="0.1" relative="1" as="geometry">
+                        <mxPoint x="-10" y="20" as="offset"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="e_p32_stu" style="edgeStyle=orthogonalEdgeStyle;rounded=1;html=1;strokeColor=#545B64;entryX=0.571;entryY=0.072;entryDx=0;entryDy=0;entryPerimeter=0;exitX=0.111;exitY=0.227;exitDx=0;exitDy=0;exitPerimeter=0;textShadow=0;" parent="1" target="actor_student" edge="1">
+                    <mxGeometry relative="1" as="geometry">
+                        <Array as="points">
+                            <mxPoint x="170" y="389.28000000000003"/>
+                        </Array>
+                        <mxPoint x="477.76" y="389.70999999999987" as="sourcePoint"/>
+                        <mxPoint x="170" y="499.28000000000003" as="targetPoint"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="l_p32_stu" value="InvitationResponse" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];labelBackgroundColor=#ffffff;fontFamily=Helvetica;fontSize=11;textShadow=0;" parent="e_p32_stu" vertex="1" connectable="0">
+                    <mxGeometry x="0.1" relative="1" as="geometry">
+                        <mxPoint x="24" y="-10" as="offset"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="e_stu_p33" style="edgeStyle=orthogonalEdgeStyle;rounded=1;html=1;strokeColor=#545B64;exitX=0.976;exitY=0.478;exitDx=0;exitDy=0;exitPerimeter=0;entryX=0.006;entryY=0.406;entryDx=0;entryDy=0;entryPerimeter=0;textShadow=0;" parent="1" target="p33" edge="1">
+                    <mxGeometry relative="1" as="geometry">
+                        <Array as="points"/>
+                        <mxPoint x="226.64" y="536.1" as="sourcePoint"/>
+                        <mxPoint x="460.00002321995805" y="552.4542857142857" as="targetPoint"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="12" value="&lt;span style=&quot;color: rgb(0, 0, 0);&quot;&gt;invitationId, ACCEPTED | DECLINED&lt;/span&gt;" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];textShadow=0;" parent="e_stu_p33" vertex="1" connectable="0">
+                    <mxGeometry x="-0.1434" y="-1" relative="1" as="geometry">
+                        <mxPoint x="3" y="-11" as="offset"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="e_stu_p34" style="edgeStyle=orthogonalEdgeStyle;rounded=1;html=1;strokeColor=#545B64;exitX=0.712;exitY=0.994;exitDx=0;exitDy=0;exitPerimeter=0;entryX=-0.001;entryY=0.432;entryDx=0;entryDy=0;entryPerimeter=0;textShadow=0;" parent="1" source="actor_student" target="p34" edge="1">
+                    <mxGeometry relative="1" as="geometry">
+                        <Array as="points">
+                            <mxPoint x="190" y="708"/>
+                            <mxPoint x="460" y="708"/>
+                        </Array>
+                        <mxPoint x="190" y="559.28" as="sourcePoint"/>
+                        <mxPoint x="470" y="709" as="targetPoint"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="l_stu_p34" value="jiraSpaceUrl,&amp;nbsp;&lt;span style=&quot;color: rgb(63, 63, 63); background-color: light-dark(rgb(255, 255, 255), rgb(18, 18, 18));&quot;&gt;projectKey, token&lt;/span&gt;" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];labelBackgroundColor=#ffffff;fontFamily=Helvetica;fontSize=11;textShadow=0;" parent="e_stu_p34" vertex="1" connectable="0">
+                    <mxGeometry x="0.1" relative="1" as="geometry">
+                        <mxPoint x="43" y="-10" as="offset"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="e_p34_stu" style="edgeStyle=orthogonalEdgeStyle;rounded=1;html=1;strokeColor=#545B64;entryX=0.574;entryY=0.928;entryDx=0;entryDy=0;entryPerimeter=0;exitX=0.045;exitY=0.675;exitDx=0;exitDy=0;exitPerimeter=0;textShadow=0;" parent="1" source="p34" target="actor_student" edge="1">
+                    <mxGeometry relative="1" as="geometry">
+                        <Array as="points">
+                            <mxPoint x="467" y="729"/>
+                            <mxPoint x="170" y="729"/>
+                        </Array>
+                        <mxPoint x="460" y="730" as="sourcePoint"/>
+                        <mxPoint x="170" y="559.28" as="targetPoint"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="l_p34_stu" value="Bind confirmation or error" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];labelBackgroundColor=#ffffff;fontFamily=Helvetica;fontSize=11;textShadow=0;" parent="e_p34_stu" vertex="1" connectable="0">
+                    <mxGeometry x="0.2" relative="1" as="geometry">
+                        <mxPoint x="130" y="10" as="offset"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="e_stu_p35" style="edgeStyle=orthogonalEdgeStyle;rounded=1;html=1;strokeColor=#545B64;exitX=0.362;exitY=0.978;exitDx=0;exitDy=0;exitPerimeter=0;entryX=0.026;entryY=0.444;entryDx=0;entryDy=0;entryPerimeter=0;textShadow=0;" parent="1" source="actor_student" edge="1">
+                    <mxGeometry relative="1" as="geometry">
+                        <Array as="points">
+                            <mxPoint x="141" y="859.28"/>
+                        </Array>
+                        <mxPoint x="139.5" y="559.28" as="sourcePoint"/>
+                        <mxPoint x="464.15999999999985" y="859.24" as="targetPoint"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="l_stu_p35" value="githubOrgName, org_owner_githubPAT" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];labelBackgroundColor=#ffffff;fontFamily=Helvetica;fontSize=11;textShadow=0;" parent="e_stu_p35" vertex="1" connectable="0">
+                    <mxGeometry x="0.2" relative="1" as="geometry">
+                        <mxPoint x="88" y="-10" as="offset"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="e_p35_stu" style="edgeStyle=orthogonalEdgeStyle;rounded=1;html=1;strokeColor=#545B64;entryX=0.214;entryY=1;entryDx=0;entryDy=0;entryPerimeter=0;exitX=0.059;exitY=0.676;exitDx=0;exitDy=0;exitPerimeter=0;textShadow=0;" parent="1" target="actor_student" edge="1">
+                    <mxGeometry relative="1" as="geometry">
+                        <Array as="points">
+                            <mxPoint x="120" y="880.28"/>
+                        </Array>
+                        <mxPoint x="469.4399999999998" y="880.1199999999999" as="sourcePoint"/>
+                        <mxPoint x="120" y="559.28" as="targetPoint"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="l_p35_stu" value="Bind confirmation or error" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];labelBackgroundColor=#ffffff;fontFamily=Helvetica;fontSize=11;textShadow=0;" parent="e_p35_stu" vertex="1" connectable="0">
+                    <mxGeometry x="0.2" relative="1" as="geometry">
+                        <mxPoint x="170" y="64" as="offset"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="e_coor_p36" style="edgeStyle=orthogonalEdgeStyle;rounded=1;html=1;strokeColor=#545B64;entryX=0.139;entryY=0.213;entryDx=0;entryDy=0;entryPerimeter=0;exitX=0.979;exitY=0.367;exitDx=0;exitDy=0;exitPerimeter=0;textShadow=0;" parent="1" source="actor_coordinator" target="p36" edge="1">
+                    <mxGeometry relative="1" as="geometry">
+                        <Array as="points">
+                            <mxPoint x="227" y="990"/>
+                            <mxPoint x="300" y="990"/>
+                        </Array>
+                        <mxPoint x="250" y="980" as="sourcePoint"/>
+                        <mxPoint x="470" y="977" as="targetPoint"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="l_coor_p36" value="groupId, studentId" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];labelBackgroundColor=#ffffff;fontFamily=Helvetica;fontSize=11;textShadow=0;" parent="e_coor_p36" vertex="1" connectable="0">
+                    <mxGeometry x="-0.1" relative="1" as="geometry">
+                        <mxPoint x="-2" y="-10" as="offset"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="e_p36_coor" style="edgeStyle=orthogonalEdgeStyle;rounded=1;html=1;strokeColor=#545B64;exitX=0.019;exitY=0.484;exitDx=0;exitDy=0;exitPerimeter=0;entryX=1;entryY=0.75;entryDx=0;entryDy=0;textShadow=0;" parent="1" source="p36" target="actor_coordinator" edge="1">
+                    <mxGeometry relative="1" as="geometry">
+                        <Array as="points">
+                            <mxPoint x="463" y="1015"/>
+                        </Array>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="l_p36_coor" value="Updated GroupDetail" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];labelBackgroundColor=#ffffff;fontFamily=Helvetica;fontSize=11;textShadow=0;" parent="e_p36_coor" vertex="1" connectable="0">
+                    <mxGeometry x="0.1" relative="1" as="geometry">
+                        <mxPoint x="-3" y="15" as="offset"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="14" style="edgeStyle=none;html=1;exitX=0.213;exitY=-0.018;exitDx=0;exitDy=0;entryX=0.933;entryY=0.261;entryDx=0;entryDy=0;entryPerimeter=0;textShadow=0;exitPerimeter=0;" parent="1" source="ds_students" edge="1">
+                    <mxGeometry relative="1" as="geometry">
+                        <mxPoint x="994.2400000000002" y="413.24" as="sourcePoint"/>
+                        <mxPoint x="620" y="250" as="targetPoint"/>
+                        <Array as="points">
+                            <mxPoint x="1020" y="320"/>
+                            <mxPoint x="940" y="320"/>
+                            <mxPoint x="940" y="280"/>
+                            <mxPoint x="700" y="280"/>
+                            <mxPoint x="700" y="250"/>
+                        </Array>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="15" value="Creator student record" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];textShadow=0;" parent="14" vertex="1" connectable="0">
+                    <mxGeometry x="0.2528" y="2" relative="1" as="geometry">
+                        <mxPoint x="-18" y="-12" as="offset"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="21" style="edgeStyle=none;html=1;entryX=1;entryY=0;entryDx=0;entryDy=0;textShadow=0;exitX=-0.01;exitY=0.358;exitDx=0;exitDy=0;exitPerimeter=0;" parent="1" source="ds_groups" edge="1">
+                    <mxGeometry relative="1" as="geometry">
+                        <mxPoint x="979.9999999999999" y="596.73" as="sourcePoint"/>
+                        <mxPoint x="614.4170149517724" y="420.24132782874824" as="targetPoint"/>
+                        <Array as="points">
+                            <mxPoint x="854" y="607"/>
+                            <mxPoint x="854.42" y="420"/>
+                            <mxPoint x="767.74" y="420"/>
+                        </Array>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="22" value="Membership check" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];textShadow=0;" parent="21" vertex="1" connectable="0">
+                    <mxGeometry x="0.2838" y="3" relative="1" as="geometry">
+                        <mxPoint x="-101" y="-16" as="offset"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="27" style="edgeStyle=none;html=1;exitX=0.166;exitY=-0.059;exitDx=0;exitDy=0;entryX=0.926;entryY=0.222;entryDx=0;entryDy=0;entryPerimeter=0;textShadow=0;exitPerimeter=0;" parent="1" source="ds_groups" target="p33" edge="1">
+                    <mxGeometry relative="1" as="geometry">
+                        <mxPoint x="1085.0000000000002" y="569.3499999999999" as="sourcePoint"/>
+                        <mxPoint x="590" y="509.99999999999994" as="targetPoint"/>
+                        <Array as="points">
+                            <mxPoint x="1010" y="520"/>
+                        </Array>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="28" value="Pending invitation record" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];textShadow=0;" parent="27" vertex="1" connectable="0">
+                    <mxGeometry x="0.6633" y="2" relative="1" as="geometry">
+                        <mxPoint x="10" y="-12" as="offset"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="31" style="edgeStyle=none;html=1;exitX=0.765;exitY=0.919;exitDx=0;exitDy=0;entryX=0.035;entryY=0.393;entryDx=0;entryDy=0;exitPerimeter=0;textShadow=0;entryPerimeter=0;" parent="1" source="p33" edge="1">
+                    <mxGeometry relative="1" as="geometry">
+                        <Array as="points">
+                            <mxPoint x="580" y="620"/>
+                            <mxPoint x="834.6999999999999" y="619.3"/>
+                            <mxPoint x="934.6999999999999" y="619.3"/>
+                        </Array>
+                        <mxPoint x="609.9" y="562.6399999999999" as="sourcePoint"/>
+                        <mxPoint x="981.0000000000001" y="618.23" as="targetPoint"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="32" value="GroupMembership (role=MEMBER)" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];textShadow=0;" parent="31" vertex="1" connectable="0">
+                    <mxGeometry x="-0.3699" relative="1" as="geometry">
+                        <mxPoint x="16" y="-11" as="offset"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="33" style="edgeStyle=none;html=1;exitX=0.058;exitY=0.983;exitDx=0;exitDy=0;entryX=0.97;entryY=0.53;entryDx=0;entryDy=0;entryPerimeter=0;textShadow=0;exitPerimeter=0;" parent="1" source="ds_groups" target="p34" edge="1">
+                    <mxGeometry relative="1" as="geometry">
+                        <Array as="points">
+                            <mxPoint x="990" y="720"/>
+                        </Array>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="34" value="TEAM_LEADER check" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];textShadow=0;" parent="33" vertex="1" connectable="0">
+                    <mxGeometry x="0.7482" relative="1" as="geometry">
+                        <mxPoint x="48" y="-8" as="offset"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="38" style="edgeStyle=none;html=1;textShadow=0;exitX=0.057;exitY=0.971;exitDx=0;exitDy=0;exitPerimeter=0;entryX=0.97;entryY=0.33;entryDx=0;entryDy=0;entryPerimeter=0;" parent="1" source="ds_groups" target="p35" edge="1">
+                    <mxGeometry relative="1" as="geometry">
+                        <mxPoint x="1161.44" y="430" as="sourcePoint"/>
+                        <mxPoint x="620" y="850" as="targetPoint"/>
+                        <Array as="points">
+                            <mxPoint x="990" y="850"/>
+                        </Array>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="39" value="TEAM_LEADER check" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];textShadow=0;" parent="38" vertex="1" connectable="0">
+                    <mxGeometry x="0.7482" relative="1" as="geometry">
+                        <mxPoint x="21" y="-10" as="offset"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="40" style="edgeStyle=none;html=1;exitX=0.715;exitY=0.049;exitDx=0;exitDy=0;textShadow=0;exitPerimeter=0;entryX=0.213;entryY=1.01;entryDx=0;entryDy=0;entryPerimeter=0;" parent="1" source="p35" target="ds_groups" edge="1">
+                    <mxGeometry relative="1" as="geometry">
+                        <mxPoint x="1033.23" y="639.28" as="targetPoint"/>
+                        <Array as="points">
+                            <mxPoint x="574" y="800"/>
+                            <mxPoint x="1020" y="800"/>
+                        </Array>
+                        <mxPoint x="559.9994945571289" y="830.9236333590501" as="sourcePoint"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="41" value="encryptedGithubPAT, orgName" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];textShadow=0;" parent="40" vertex="1" connectable="0">
+                    <mxGeometry x="-0.433" relative="1" as="geometry">
+                        <mxPoint x="-36" y="-8" as="offset"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="47" style="edgeStyle=none;html=1;textShadow=0;exitX=1.013;exitY=0.585;exitDx=0;exitDy=0;exitPerimeter=0;entryX=0.578;entryY=0.965;entryDx=0;entryDy=0;entryPerimeter=0;" parent="1" source="ds_students" target="p36" edge="1">
+                    <mxGeometry relative="1" as="geometry">
+                        <Array as="points">
+                            <mxPoint x="1200" y="399"/>
+                            <mxPoint x="1200" y="1090"/>
+                            <mxPoint x="1100" y="1090"/>
+                            <mxPoint x="810" y="1090"/>
+                            <mxPoint x="820" y="1090"/>
+                            <mxPoint x="550" y="1090"/>
+                        </Array>
+                        <mxPoint x="1160" y="406.6700000000001" as="sourcePoint"/>
+                        <mxPoint x="740" y="1030" as="targetPoint"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="48" value="T&lt;span style=&quot;color: rgb(63, 63, 63); background-color: light-dark(#ffffff, var(--ge-dark-color, #121212));&quot;&gt;arget student lookup&lt;/span&gt;" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];textShadow=0;" parent="47" vertex="1" connectable="0">
+                    <mxGeometry x="0.5616" y="-3" relative="1" as="geometry">
+                        <mxPoint x="-169" y="-7" as="offset"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="51" style="edgeStyle=orthogonalEdgeStyle;rounded=1;html=1;strokeColor=#545B64;textShadow=0;" parent="1" source="p34" target="api_jira" edge="1">
+                    <mxGeometry relative="1" as="geometry">
+                        <mxPoint x="610" y="660" as="sourcePoint"/>
+                        <mxPoint x="1360" y="600" as="targetPoint"/>
+                        <Array as="points">
+                            <mxPoint x="528" y="640"/>
+                            <mxPoint x="440" y="640"/>
+                            <mxPoint x="440" y="190"/>
+                            <mxPoint x="1280" y="190"/>
+                            <mxPoint x="1280" y="680"/>
+                        </Array>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="52" value="Validation test call" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];labelBackgroundColor=#ffffff;fontFamily=Helvetica;fontSize=11;textShadow=0;" parent="51" vertex="1" connectable="0">
+                    <mxGeometry x="-0.3" relative="1" as="geometry">
+                        <mxPoint x="624" y="-10" as="offset"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="53" style="edgeStyle=none;html=1;exitX=0.5;exitY=0;exitDx=0;exitDy=0;entryX=0.149;entryY=0.254;entryDx=0;entryDy=0;entryPerimeter=0;textShadow=0;" parent="1" source="api_jira" target="p34" edge="1">
+                    <mxGeometry relative="1" as="geometry">
+                        <Array as="points">
+                            <mxPoint x="1330" y="160"/>
+                            <mxPoint x="430" y="160"/>
+                            <mxPoint x="430" y="660"/>
+                            <mxPoint x="484" y="660"/>
+                        </Array>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="55" value="200 OK or error" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];textShadow=0;" parent="53" vertex="1" connectable="0">
+                    <mxGeometry x="0.6035" y="3" relative="1" as="geometry">
+                        <mxPoint x="47" y="-205" as="offset"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="67" value="System Boundary&lt;div&gt;&lt;br/&gt;&lt;/div&gt;" style="rounded=0;whiteSpace=wrap;html=1;fillColor=none;strokeColor=#FF0000;strokeWidth=2;dashed=1;align=right;verticalAlign=top;spacingRight=10;spacingTop=10;fontStyle=1;fontSize=14;" parent="1" vertex="1">
+                    <mxGeometry x="420" y="90" width="530" height="1100" as="geometry"/>
+                </mxCell>
+            </root>
+        </mxGraphModel>
+    </diagram>
+</mxfile>

--- a/docs/red_dfd/process3_dfd_lvl1.drawio
+++ b/docs/red_dfd/process3_dfd_lvl1.drawio
@@ -1,0 +1,365 @@
+<mxfile host="65bd71144e">
+    <diagram id="dfd-level-1-p3" name="P3 Advisor Association Architecture">
+        <mxGraphModel dx="1339" dy="818" grid="1" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="1" pageScale="1" pageWidth="1600" pageHeight="1200" background="#F9F9F9" math="0" shadow="1">
+            <root>
+                <mxCell id="0"/>
+                <mxCell id="1" parent="0"/>
+                <mxCell id="title" value="&lt;font style=&quot;font-size: 24px;&quot;&gt;&lt;b&gt;P3 Level 1 DFD: Advisor Association &amp;amp; Sanitization&lt;/b&gt;&lt;/font&gt;" style="text;html=1;strokeColor=none;fillColor=none;align=left;verticalAlign=middle;rounded=0;fontFamily=Helvetica;fontColor=#333333;whiteSpace=wrap;textShadow=0;" parent="1" vertex="1">
+                    <mxGeometry x="20" y="10" width="800" height="40" as="geometry"/>
+                </mxCell>
+                <mxCell id="legend" value="&lt;b&gt;Legend&lt;/b&gt;&lt;br&gt;&lt;br&gt;&lt;div style=&quot;text-align: left;&quot;&gt;&lt;span style=&quot;background-color: #dae8fc; border: 1px solid #6c8ebf; padding: 2px 5px;&quot;&gt; External Actors &lt;/span&gt;&lt;br&gt;&lt;br&gt;&lt;span style=&quot;background-color: #ffe6cc; border: 1px solid #d79b00; padding: 2px 5px;&quot;&gt; Sub-Processes &lt;/span&gt;&lt;br&gt;&lt;br&gt;&lt;span style=&quot;background-color: #d5e8d4; border: 1px solid #82b366; padding: 2px 5px;&quot;&gt; Data Stores &lt;/span&gt;&lt;/div&gt;" style="rounded=1;html=1;fillColor=#ffffff;strokeColor=#cccccc;align=left;verticalAlign=top;spacingLeft=10;spacingTop=10;fontFamily=Helvetica;fontColor=#333333;whiteSpace=wrap;textShadow=0;" parent="1" vertex="1">
+                    <mxGeometry x="1420" y="20" width="120" height="140" as="geometry"/>
+                </mxCell>
+                <mxCell id="actor_student" value="&lt;b&gt;STUDENT&lt;/b&gt;&lt;br&gt;(Team Leader)" style="rounded=1;html=1;fillColor=#dae8fc;strokeColor=#6c8ebf;fontFamily=Helvetica;fontColor=#333333;whiteSpace=wrap;textShadow=0;" parent="1" vertex="1">
+                    <mxGeometry x="60" y="197" width="140" height="60" as="geometry"/>
+                </mxCell>
+                <mxCell id="actor_advisor" value="&lt;b&gt;ADVISOR&lt;/b&gt;&lt;br&gt;(Professor)" style="rounded=1;html=1;fillColor=#dae8fc;strokeColor=#6c8ebf;fontFamily=Helvetica;fontColor=#333333;whiteSpace=wrap;textShadow=0;" parent="1" vertex="1">
+                    <mxGeometry x="60" y="452" width="140" height="60" as="geometry"/>
+                </mxCell>
+                <mxCell id="actor_coordinator" value="&lt;b&gt;COORDINATOR&lt;/b&gt;" style="rounded=1;html=1;fillColor=#dae8fc;strokeColor=#6c8ebf;fontFamily=Helvetica;fontColor=#333333;whiteSpace=wrap;textShadow=0;" parent="1" vertex="1">
+                    <mxGeometry x="60" y="952" width="140" height="60" as="geometry"/>
+                </mxCell>
+                <mxCell id="p41" value="&lt;b&gt;3.1&lt;/b&gt;&lt;br&gt;Browse Advisors&lt;br&gt;&amp;amp; Send Request" style="ellipse;html=1;fillColor=#ffe6cc;strokeColor=#d79b00;fontFamily=Helvetica;fontColor=#333333;whiteSpace=wrap;textShadow=0;" parent="1" vertex="1">
+                    <mxGeometry x="450" y="182" width="160" height="90" as="geometry"/>
+                </mxCell>
+                <mxCell id="p42" value="&lt;b&gt;3.2&lt;/b&gt;&lt;br&gt;Advisor Reviews&lt;br&gt;Pending Requests" style="ellipse;html=1;fillColor=#ffe6cc;strokeColor=#d79b00;fontFamily=Helvetica;fontColor=#333333;whiteSpace=wrap;textShadow=0;" parent="1" vertex="1">
+                    <mxGeometry x="450" y="402" width="160" height="90" as="geometry"/>
+                </mxCell>
+                <mxCell id="p43" value="&lt;b&gt;3.3&lt;/b&gt;&lt;br&gt;Process Association&lt;br&gt;Response" style="ellipse;html=1;fillColor=#ffe6cc;strokeColor=#d79b00;fontFamily=Helvetica;fontColor=#333333;whiteSpace=wrap;textShadow=0;" parent="1" vertex="1">
+                    <mxGeometry x="450" y="590" width="160" height="90" as="geometry"/>
+                </mxCell>
+                <mxCell id="p44" value="&lt;b&gt;3.4&lt;/b&gt;&lt;br&gt;Auto-Sanitization&lt;br&gt;(Disband Unadvised)" style="ellipse;html=1;fillColor=#ffe6cc;strokeColor=#d79b00;fontFamily=Helvetica;fontColor=#333333;whiteSpace=wrap;textShadow=0;" parent="1" vertex="1">
+                    <mxGeometry x="450" y="750" width="160" height="90" as="geometry"/>
+                </mxCell>
+                <mxCell id="p45" value="&lt;b&gt;3.5&lt;/b&gt;&lt;br&gt;Coordinator&lt;br&gt;Advisor Override" style="ellipse;html=1;fillColor=#ffe6cc;strokeColor=#d79b00;fontFamily=Helvetica;fontColor=#333333;whiteSpace=wrap;textShadow=0;" parent="1" vertex="1">
+                    <mxGeometry x="450" y="930" width="160" height="90" as="geometry"/>
+                </mxCell>
+                <mxCell id="ds_term" value="D1: Term Config" style="shape=partialRectangle;right=0;left=0;html=1;fillColor=#d5e8d4;strokeColor=#82b366;fontFamily=Helvetica;fontColor=#333333;fontStyle=1;whiteSpace=wrap;textShadow=0;" parent="1" vertex="1">
+                    <mxGeometry x="990" y="147" width="180" height="50" as="geometry"/>
+                </mxCell>
+                <mxCell id="ds_users" value="D2: Users (Profiles, Roles)" style="shape=partialRectangle;right=0;left=0;html=1;fillColor=#d5e8d4;strokeColor=#82b366;fontFamily=Helvetica;fontColor=#333333;fontStyle=1;whiteSpace=wrap;textShadow=0;" parent="1" vertex="1">
+                    <mxGeometry x="990" y="320" width="180" height="50" as="geometry"/>
+                </mxCell>
+                <mxCell id="ds_groups" value="D3: Groups &amp;amp; Committees" style="shape=partialRectangle;right=0;left=0;html=1;fillColor=#d5e8d4;strokeColor=#82b366;fontFamily=Helvetica;fontColor=#333333;fontStyle=1;whiteSpace=wrap;textShadow=0;" parent="1" vertex="1">
+                    <mxGeometry x="990" y="620" width="180" height="50" as="geometry"/>
+                </mxCell>
+                <mxCell id="e_stu_p41" style="edgeStyle=orthogonalEdgeStyle;rounded=1;html=1;strokeColor=#545B64;exitX=1;exitY=0.75;exitDx=0;exitDy=0;entryX=0.056;entryY=0.721;entryDx=0;entryDy=0;textShadow=0;entryPerimeter=0;" parent="1" target="p41" edge="1">
+                    <mxGeometry relative="1" as="geometry">
+                        <mxPoint x="200" y="247.0000000000001" as="sourcePoint"/>
+                        <mxPoint x="449.9999999999998" y="232.0000000000001" as="targetPoint"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="l_stu_p41" value="groupId, targetAdvisorId" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];labelBackgroundColor=#ffffff;fontFamily=Helvetica;fontSize=11;textShadow=0;" parent="e_stu_p41" vertex="1" connectable="0">
+                    <mxGeometry x="0.1" relative="1" as="geometry">
+                        <mxPoint y="-12" as="offset"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="e_p41_stu" style="edgeStyle=orthogonalEdgeStyle;rounded=1;html=1;strokeColor=#545B64;exitX=0;exitY=0.3;exitDx=0;exitDy=0;entryX=1;entryY=0.25;entryDx=0;entryDy=0;textShadow=0;" parent="1" source="p41" target="actor_student" edge="1">
+                    <mxGeometry relative="1" as="geometry">
+                        <Array as="points">
+                            <mxPoint x="200" y="210"/>
+                        </Array>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="l_p41_stu" value="RequestResponse (id, PENDING)" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];labelBackgroundColor=#ffffff;fontFamily=Helvetica;fontSize=11;textShadow=0;" parent="e_p41_stu" vertex="1" connectable="0">
+                    <mxGeometry x="0.1" relative="1" as="geometry">
+                        <mxPoint x="15" y="-13" as="offset"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="e_d1_p41" style="edgeStyle=orthogonalEdgeStyle;rounded=1;html=1;strokeColor=#545B64;exitX=0;exitY=0.5;exitDx=0;exitDy=0;entryX=0.823;entryY=0.09;entryDx=0;entryDy=0;textShadow=0;entryPerimeter=0;" parent="1" target="p41" edge="1">
+                    <mxGeometry relative="1" as="geometry">
+                        <mxPoint x="990" y="160.02" as="sourcePoint"/>
+                        <mxPoint x="601.6475870816591" y="160.0008212565953" as="targetPoint"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="l_d1_p41" value="Active window check" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];labelBackgroundColor=#ffffff;fontFamily=Helvetica;fontSize=11;textShadow=0;" parent="e_d1_p41" vertex="1" connectable="0">
+                    <mxGeometry x="0.1" relative="1" as="geometry">
+                        <mxPoint x="-87" y="-10" as="offset"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="e_d2_p41" style="edgeStyle=orthogonalEdgeStyle;rounded=1;html=1;strokeColor=#545B64;exitX=0.001;exitY=0.442;exitDx=0;exitDy=0;textShadow=0;entryX=0.913;entryY=0.227;entryDx=0;entryDy=0;entryPerimeter=0;exitPerimeter=0;" parent="1" source="ds_users" target="p41" edge="1">
+                    <mxGeometry relative="1" as="geometry">
+                        <Array as="points">
+                            <mxPoint x="990" y="340"/>
+                            <mxPoint x="950" y="340"/>
+                            <mxPoint x="950" y="202"/>
+                        </Array>
+                        <mxPoint x="990" y="434" as="sourcePoint"/>
+                        <mxPoint x="598.96" y="201.67999999999995" as="targetPoint"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="l_d2_p41" value="Available advisors (below capacity)" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];labelBackgroundColor=#ffffff;fontFamily=Helvetica;fontSize=11;textShadow=0;" parent="e_d2_p41" vertex="1" connectable="0">
+                    <mxGeometry x="0.7" relative="1" as="geometry">
+                        <mxPoint x="17" y="-8" as="offset"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="e_d3_p41" style="edgeStyle=orthogonalEdgeStyle;rounded=1;html=1;strokeColor=#545B64;textShadow=0;exitX=0.5;exitY=0;exitDx=0;exitDy=0;" parent="1" source="ds_groups" target="p41" edge="1">
+                    <mxGeometry relative="1" as="geometry">
+                        <Array as="points">
+                            <mxPoint x="1080" y="500"/>
+                            <mxPoint x="920" y="500"/>
+                            <mxPoint x="920" y="240"/>
+                        </Array>
+                        <mxPoint x="1170" y="640" as="sourcePoint"/>
+                        <mxPoint x="579.9972586110688" y="269.4244161685707" as="targetPoint"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="l_d3_p41" value="TOOLS_BOUND check + no PENDING request" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];labelBackgroundColor=#ffffff;fontFamily=Helvetica;fontSize=11;textShadow=0;" parent="e_d3_p41" vertex="1" connectable="0">
+                    <mxGeometry x="0.8" relative="1" as="geometry">
+                        <mxPoint x="81" y="-10" as="offset"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="e_p41_d3" style="edgeStyle=orthogonalEdgeStyle;rounded=1;html=1;strokeColor=#545B64;textShadow=0;" parent="1" source="p41" edge="1">
+                    <mxGeometry relative="1" as="geometry">
+                        <Array as="points">
+                            <mxPoint x="530" y="280"/>
+                            <mxPoint x="900" y="280"/>
+                            <mxPoint x="900" y="520"/>
+                            <mxPoint x="1040" y="520"/>
+                        </Array>
+                        <mxPoint x="640.0002068630711" y="246.97084334042688" as="sourcePoint"/>
+                        <mxPoint x="1040.31" y="620" as="targetPoint"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="l_p41_d3" value="AdvisorRequest record (PENDING)" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];labelBackgroundColor=#ffffff;fontFamily=Helvetica;fontSize=11;textShadow=0;" parent="e_p41_d3" vertex="1" connectable="0">
+                    <mxGeometry x="0.2" relative="1" as="geometry">
+                        <mxPoint x="-150" y="-145" as="offset"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="e_adv_p42" style="edgeStyle=orthogonalEdgeStyle;rounded=1;html=1;strokeColor=#545B64;textShadow=0;exitX=0.643;exitY=-0.033;exitDx=0;exitDy=0;exitPerimeter=0;entryX=0.441;entryY=0.006;entryDx=0;entryDy=0;entryPerimeter=0;" parent="1" target="p42" edge="1">
+                    <mxGeometry relative="1" as="geometry">
+                        <mxPoint x="120.01999999999998" y="447.45" as="sourcePoint"/>
+                        <mxPoint x="436" y="422.0199999999999" as="targetPoint"/>
+                        <Array as="points">
+                            <mxPoint x="120" y="370"/>
+                            <mxPoint x="520" y="370"/>
+                            <mxPoint x="520" y="403"/>
+                        </Array>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="l_adv_p42" value="advisorId" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];labelBackgroundColor=#ffffff;fontFamily=Helvetica;fontSize=11;textShadow=0;" parent="e_adv_p42" vertex="1" connectable="0">
+                    <mxGeometry x="0.1" relative="1" as="geometry">
+                        <mxPoint x="137" y="-8" as="offset"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="e_p42_adv" style="edgeStyle=orthogonalEdgeStyle;rounded=1;html=1;strokeColor=#545B64;entryX=1;entryY=0.7;entryDx=0;entryDy=0;textShadow=0;" parent="1" source="p42" edge="1">
+                    <mxGeometry relative="1" as="geometry">
+                        <mxPoint x="396.59" y="433.6199999999999" as="sourcePoint"/>
+                        <mxPoint x="140.03" y="452" as="targetPoint"/>
+                        <Array as="points">
+                            <mxPoint x="140" y="434"/>
+                        </Array>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="l_p42_adv" value="RequestListResponse" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];labelBackgroundColor=#ffffff;fontFamily=Helvetica;fontSize=11;textShadow=0;" parent="e_p42_adv" vertex="1" connectable="0">
+                    <mxGeometry x="0.1" relative="1" as="geometry">
+                        <mxPoint x="-71" y="-12" as="offset"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="e_d3_p42" style="edgeStyle=orthogonalEdgeStyle;rounded=1;html=1;strokeColor=#545B64;exitX=0.188;exitY=-0.063;exitDx=0;exitDy=0;entryX=0.92;entryY=0.813;entryDx=0;entryDy=0;textShadow=0;exitPerimeter=0;entryPerimeter=0;" parent="1" source="ds_groups" target="p42" edge="1">
+                    <mxGeometry relative="1" as="geometry">
+                        <Array as="points">
+                            <mxPoint x="1024" y="560"/>
+                            <mxPoint x="880" y="560"/>
+                            <mxPoint x="880" y="475"/>
+                        </Array>
+                        <mxPoint x="990" y="644.65" as="sourcePoint"/>
+                        <mxPoint x="604.3236102995718" y="430.0015112928959" as="targetPoint"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="l_d3_p42" value="PENDING requests + group summary" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];labelBackgroundColor=#ffffff;fontFamily=Helvetica;fontSize=11;textShadow=0;" parent="e_d3_p42" vertex="1" connectable="0">
+                    <mxGeometry x="0.7" relative="1" as="geometry">
+                        <mxPoint x="38" y="-15" as="offset"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="e_adv_p43" style="edgeStyle=orthogonalEdgeStyle;rounded=1;html=1;strokeColor=#545B64;exitX=0.75;exitY=1;exitDx=0;exitDy=0;entryX=0.024;entryY=0.322;entryDx=0;entryDy=0;textShadow=0;entryPerimeter=0;" parent="1" target="p43" edge="1">
+                    <mxGeometry relative="1" as="geometry">
+                        <Array as="points">
+                            <mxPoint x="140" y="619"/>
+                        </Array>
+                        <mxPoint x="140.04" y="512" as="sourcePoint"/>
+                        <mxPoint x="430.41890388135295" y="618.7780225829028" as="targetPoint"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="l_adv_p43" value="requestId, ACCEPTED | REJECTED" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];labelBackgroundColor=#ffffff;fontFamily=Helvetica;fontSize=11;textShadow=0;" parent="e_adv_p43" vertex="1" connectable="0">
+                    <mxGeometry x="0.5" relative="1" as="geometry">
+                        <mxPoint x="2" y="-10" as="offset"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="e_p43_adv" style="edgeStyle=orthogonalEdgeStyle;rounded=1;html=1;strokeColor=#545B64;exitX=0;exitY=0.7;exitDx=0;exitDy=0;textShadow=0;" parent="1" target="actor_advisor" edge="1">
+                    <mxGeometry relative="1" as="geometry">
+                        <Array as="points">
+                            <mxPoint x="455" y="650"/>
+                            <mxPoint x="120" y="650"/>
+                        </Array>
+                        <mxPoint x="455.3789038813529" y="651.2219774170972" as="sourcePoint"/>
+                        <mxPoint x="130" y="512" as="targetPoint"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="l_p43_adv" value="AssociationResponse" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];labelBackgroundColor=#ffffff;fontFamily=Helvetica;fontSize=11;textShadow=0;" parent="e_p43_adv" vertex="1" connectable="0">
+                    <mxGeometry x="0.5" relative="1" as="geometry">
+                        <mxPoint x="60" y="7" as="offset"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="e_d3_p43" style="edgeStyle=orthogonalEdgeStyle;rounded=1;html=1;strokeColor=#545B64;exitX=-0.002;exitY=0.13;exitDx=0;exitDy=0;textShadow=0;exitPerimeter=0;" parent="1" source="ds_groups" target="p43" edge="1">
+                    <mxGeometry relative="1" as="geometry">
+                        <mxPoint x="990" y="631.66" as="sourcePoint"/>
+                        <mxPoint x="604.3173449666999" y="610.0026640591881" as="targetPoint"/>
+                        <Array as="points">
+                            <mxPoint x="990" y="627"/>
+                            <mxPoint x="990" y="627"/>
+                        </Array>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="l_d3_p43" value="Pending request record" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];labelBackgroundColor=#ffffff;fontFamily=Helvetica;fontSize=11;textShadow=0;" parent="e_d3_p43" vertex="1" connectable="0">
+                    <mxGeometry x="0.1" relative="1" as="geometry">
+                        <mxPoint x="-76" y="-12" as="offset"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="e_p43_d3" style="edgeStyle=orthogonalEdgeStyle;rounded=1;html=1;strokeColor=#545B64;exitX=1;exitY=0.7;exitDx=0;exitDy=0;textShadow=0;" parent="1" source="p43" target="ds_groups" edge="1">
+                    <mxGeometry relative="1" as="geometry">
+                        <Array as="points">
+                            <mxPoint x="900" y="652"/>
+                            <mxPoint x="900" y="652"/>
+                        </Array>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="l_p43_d3" value="advisorId + ADVISOR_ASSIGNED + AUTO_REJECT others" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];labelBackgroundColor=#ffffff;fontFamily=Helvetica;fontSize=11;textShadow=0;" parent="e_p43_d3" vertex="1" connectable="0">
+                    <mxGeometry x="0.1" relative="1" as="geometry">
+                        <mxPoint y="12" as="offset"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="e_d1_p44" style="edgeStyle=orthogonalEdgeStyle;rounded=1;html=1;strokeColor=#545B64;textShadow=0;" parent="1" target="p44" edge="1">
+                    <mxGeometry relative="1" as="geometry">
+                        <Array as="points">
+                            <mxPoint x="1208" y="150"/>
+                            <mxPoint x="1208" y="780"/>
+                        </Array>
+                        <mxPoint x="1170" y="150.00000000000006" as="sourcePoint"/>
+                        <mxPoint x="610.0002068630711" y="778.0291566595731" as="targetPoint"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="l_d1_p44" value="Closed window check" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];labelBackgroundColor=#ffffff;fontFamily=Helvetica;fontSize=11;textShadow=0;" parent="e_d1_p44" vertex="1" connectable="0">
+                    <mxGeometry x="0.9" relative="1" as="geometry">
+                        <mxPoint x="13" y="-15" as="offset"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="e_d3_p44" style="edgeStyle=orthogonalEdgeStyle;rounded=1;html=1;strokeColor=#545B64;exitX=0.17;exitY=1.046;exitDx=0;exitDy=0;entryX=1;entryY=0.5;entryDx=0;entryDy=0;textShadow=0;exitPerimeter=0;" parent="1" source="ds_groups" edge="1">
+                    <mxGeometry relative="1" as="geometry">
+                        <Array as="points">
+                            <mxPoint x="1021" y="810"/>
+                        </Array>
+                        <mxPoint x="980" y="670" as="sourcePoint"/>
+                        <mxPoint x="600" y="810" as="targetPoint"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="l_d3_p44" value="Groups without advisorId" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];labelBackgroundColor=#ffffff;fontFamily=Helvetica;fontSize=11;textShadow=0;" parent="e_d3_p44" vertex="1" connectable="0">
+                    <mxGeometry x="0.5" relative="1" as="geometry">
+                        <mxPoint x="-60" y="-15" as="offset"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="e_p44_d3" style="edgeStyle=orthogonalEdgeStyle;rounded=1;html=1;strokeColor=#545B64;exitX=0.77;exitY=0.916;exitDx=0;exitDy=0;entryX=0.069;entryY=1.032;entryDx=0;entryDy=0;textShadow=0;entryPerimeter=0;exitPerimeter=0;" parent="1" source="p44" target="ds_groups" edge="1">
+                    <mxGeometry relative="1" as="geometry">
+                        <Array as="points">
+                            <mxPoint x="573" y="835"/>
+                            <mxPoint x="1002" y="835"/>
+                        </Array>
+                        <mxPoint x="580" y="835" as="sourcePoint"/>
+                        <mxPoint x="960" y="700" as="targetPoint"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="l_p44_d3" value="status → DISBANDED" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];labelBackgroundColor=#ffffff;fontFamily=Helvetica;fontSize=11;textShadow=0;" parent="e_p44_d3" vertex="1" connectable="0">
+                    <mxGeometry x="0.5" relative="1" as="geometry">
+                        <mxPoint x="-332" y="6" as="offset"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="e_p44_coord" style="edgeStyle=orthogonalEdgeStyle;rounded=1;html=1;strokeColor=#545B64;exitX=0;exitY=0.7;exitDx=0;exitDy=0;entryX=0.735;entryY=0.056;entryDx=0;entryDy=0;textShadow=0;entryPerimeter=0;" parent="1" source="p44" target="actor_coordinator" edge="1">
+                    <mxGeometry relative="1" as="geometry">
+                        <Array as="points">
+                            <mxPoint x="455" y="813"/>
+                            <mxPoint x="163" y="813"/>
+                        </Array>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="l_p44_coord" value="SanitizationReport" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];labelBackgroundColor=#ffffff;fontFamily=Helvetica;fontSize=11;textShadow=0;" parent="e_p44_coord" vertex="1" connectable="0">
+                    <mxGeometry x="0.5" relative="1" as="geometry">
+                        <mxPoint x="197" y="-46" as="offset"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="e_coord_p45" style="edgeStyle=orthogonalEdgeStyle;rounded=1;html=1;strokeColor=#545B64;exitX=1;exitY=0.3;exitDx=0;exitDy=0;entryX=0;entryY=0.5;entryDx=0;entryDy=0;textShadow=0;" parent="1" source="actor_coordinator" target="p45" edge="1">
+                    <mxGeometry relative="1" as="geometry">
+                        <Array as="points">
+                            <mxPoint x="450" y="970"/>
+                        </Array>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="l_coord_p45" value="groupId, advisorId, ASSIGN | REMOVE" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];labelBackgroundColor=#ffffff;fontFamily=Helvetica;fontSize=11;textShadow=0;" parent="e_coord_p45" vertex="1" connectable="0">
+                    <mxGeometry x="0.1" relative="1" as="geometry">
+                        <mxPoint x="5" y="-23" as="offset"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="e_p45_coord" style="edgeStyle=orthogonalEdgeStyle;rounded=1;html=1;strokeColor=#545B64;exitX=0;exitY=0.7;exitDx=0;exitDy=0;entryX=1;entryY=0.7;entryDx=0;entryDy=0;textShadow=0;" parent="1" source="p45" target="actor_coordinator" edge="1">
+                    <mxGeometry relative="1" as="geometry">
+                        <Array as="points">
+                            <mxPoint x="456" y="994"/>
+                        </Array>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="l_p45_coord" value="Updated GroupDetail" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];labelBackgroundColor=#ffffff;fontFamily=Helvetica;fontSize=11;textShadow=0;" parent="e_p45_coord" vertex="1" connectable="0">
+                    <mxGeometry x="0.1" relative="1" as="geometry">
+                        <mxPoint x="44" y="-12" as="offset"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="e_d3_p45" style="edgeStyle=orthogonalEdgeStyle;rounded=1;html=1;strokeColor=#545B64;exitX=0.289;exitY=1.008;exitDx=0;exitDy=0;entryX=1;entryY=0.3;entryDx=0;entryDy=0;textShadow=0;exitPerimeter=0;" parent="1" source="ds_groups" target="p45" edge="1">
+                    <mxGeometry relative="1" as="geometry">
+                        <Array as="points">
+                            <mxPoint x="1040" y="670"/>
+                            <mxPoint x="1040" y="880"/>
+                            <mxPoint x="850" y="880"/>
+                            <mxPoint x="850" y="957"/>
+                            <mxPoint x="610" y="957"/>
+                            <mxPoint x="610" y="958"/>
+                        </Array>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="l_d3_p45" value="Current advisor assignment" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];labelBackgroundColor=#ffffff;fontFamily=Helvetica;fontSize=11;textShadow=0;" parent="e_d3_p45" vertex="1" connectable="0">
+                    <mxGeometry x="0.8" relative="1" as="geometry">
+                        <mxPoint x="285" y="-87" as="offset"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="e_d2_p45" style="edgeStyle=orthogonalEdgeStyle;rounded=1;html=1;strokeColor=#545B64;exitX=1;exitY=0.7;exitDx=0;exitDy=0;entryX=0.942;entryY=0.71;entryDx=0;entryDy=0;textShadow=0;entryPerimeter=0;" parent="1" source="ds_users" target="p45" edge="1">
+                    <mxGeometry relative="1" as="geometry">
+                        <Array as="points">
+                            <mxPoint x="1190" y="355"/>
+                            <mxPoint x="1190" y="994"/>
+                        </Array>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="l_d2_p45" value="Advisor lookup (Professor role)" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];labelBackgroundColor=#ffffff;fontFamily=Helvetica;fontSize=11;textShadow=0;" parent="e_d2_p45" vertex="1" connectable="0">
+                    <mxGeometry x="0.9" relative="1" as="geometry">
+                        <mxPoint x="432" y="-11" as="offset"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="e_p45_d3" style="edgeStyle=orthogonalEdgeStyle;rounded=1;html=1;strokeColor=#545B64;exitX=1;exitY=0.5;exitDx=0;exitDy=0;textShadow=0;" parent="1" edge="1">
+                    <mxGeometry relative="1" as="geometry">
+                        <Array as="points">
+                            <mxPoint x="880" y="980"/>
+                            <mxPoint x="880" y="930"/>
+                            <mxPoint x="1060" y="930"/>
+                        </Array>
+                        <mxPoint x="610" y="980" as="sourcePoint"/>
+                        <mxPoint x="1060" y="670" as="targetPoint"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="l_p45_d3" value="Updated advisorId + status" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];labelBackgroundColor=#ffffff;fontFamily=Helvetica;fontSize=11;textShadow=0;" parent="e_p45_d3" vertex="1" connectable="0">
+                    <mxGeometry x="0.2" relative="1" as="geometry">
+                        <mxPoint x="-36" y="-14" as="offset"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="5" value="System Boundary&lt;div&gt;&lt;br/&gt;&lt;/div&gt;" style="rounded=0;whiteSpace=wrap;html=1;fillColor=none;strokeColor=#FF0000;strokeWidth=2;dashed=1;align=right;verticalAlign=top;spacingRight=10;spacingTop=10;fontStyle=1;fontSize=14;" parent="1" vertex="1">
+                    <mxGeometry x="430" y="90" width="540" height="970" as="geometry"/>
+                </mxCell>
+            </root>
+        </mxGraphModel>
+    </diagram>
+</mxfile>

--- a/docs/red_dfd/process4_dfd_lvl1.drawio
+++ b/docs/red_dfd/process4_dfd_lvl1.drawio
@@ -1,0 +1,270 @@
+<mxfile host="65bd71144e">
+    <diagram name="Page-1" id="ithBPqRbUHNm2KRGZnu1">
+        <mxGraphModel dx="283" dy="824" grid="1" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="1" pageScale="1" pageWidth="827" pageHeight="1169" math="0" shadow="0">
+            <root>
+                <mxCell id="0"/>
+                <mxCell id="1" parent="0"/>
+                <mxCell id="uVrLvxiQGZz85al0NEaj-178" value="&lt;font style=&quot;font-size: 24px;&quot;&gt;&lt;b&gt;P4 Level 1 DFD: Committee Assignment (5.0 DFD0 )&lt;/b&gt;&lt;/font&gt;" style="text;html=1;strokeColor=none;fillColor=none;align=left;verticalAlign=middle;rounded=0;fontFamily=Helvetica;fontColor=#333333;whiteSpace=wrap;textShadow=0;" parent="1" vertex="1">
+                    <mxGeometry width="600" height="40" as="geometry"/>
+                </mxCell>
+                <mxCell id="uVrLvxiQGZz85al0NEaj-179" value="&lt;b&gt;Legend&lt;/b&gt;&lt;br&gt;&lt;br&gt;&lt;div style=&quot;text-align: left;&quot;&gt;&lt;span style=&quot;background-color: #dae8fc; border: 1px solid #6c8ebf; padding: 2px 5px;&quot;&gt; External Actors &lt;/span&gt;&lt;br&gt;&lt;br&gt;&lt;span style=&quot;background-color: #ffe6cc; border: 1px solid #d79b00; padding: 2px 5px;&quot;&gt; Sub-Processes &lt;/span&gt;&lt;br&gt;&lt;br&gt;&lt;span style=&quot;background-color: #d5e8d4; border: 1px solid #82b366; padding: 2px 5px;&quot;&gt; Data Stores &lt;/span&gt;&lt;br&gt;&lt;br&gt;&lt;span style=&quot;background-color: #e1d5e7; border: 1px solid #9673a6; padding: 2px 5px;&quot;&gt; External APIs &lt;/span&gt;&lt;/div&gt;" style="rounded=1;html=1;fillColor=#ffffff;strokeColor=#cccccc;align=left;verticalAlign=top;spacingLeft=10;spacingTop=10;fontFamily=Helvetica;fontColor=#333333;whiteSpace=wrap;textShadow=0;" parent="1" vertex="1">
+                    <mxGeometry x="1390" width="120" height="150" as="geometry"/>
+                </mxCell>
+                <mxCell id="uVrLvxiQGZz85al0NEaj-180" value="&lt;b&gt;COORDINATOR&lt;/b&gt;" style="rounded=1;html=1;fillColor=#dae8fc;strokeColor=#6c8ebf;fontFamily=Helvetica;fontColor=#333333;whiteSpace=wrap;textShadow=0;" parent="1" vertex="1">
+                    <mxGeometry x="50" y="245" width="140" height="60" as="geometry"/>
+                </mxCell>
+                <mxCell id="uVrLvxiQGZz85al0NEaj-181" value="&lt;b&gt;PROFESSOR&lt;/b&gt;&lt;br&gt;(Advisor / Jury)" style="rounded=1;html=1;fillColor=#dae8fc;strokeColor=#6c8ebf;fontFamily=Helvetica;fontColor=#333333;whiteSpace=wrap;textShadow=0;" parent="1" vertex="1">
+                    <mxGeometry x="70" y="625" width="140" height="60" as="geometry"/>
+                </mxCell>
+                <mxCell id="uVrLvxiQGZz85al0NEaj-182" value="D1: Term Config" style="shape=partialRectangle;right=0;left=0;html=1;fillColor=#d5e8d4;strokeColor=#82b366;fontFamily=Helvetica;fontColor=#333333;fontStyle=1;whiteSpace=wrap;textShadow=0;" parent="1" vertex="1">
+                    <mxGeometry x="950" y="110" width="180" height="50" as="geometry"/>
+                </mxCell>
+                <mxCell id="uVrLvxiQGZz85al0NEaj-183" value="D2: Users&amp;nbsp;" style="shape=partialRectangle;right=0;left=0;html=1;fillColor=#d5e8d4;strokeColor=#82b366;fontFamily=Helvetica;fontColor=#333333;fontStyle=1;whiteSpace=wrap;textShadow=0;" parent="1" vertex="1">
+                    <mxGeometry x="950" y="255" width="180" height="50" as="geometry"/>
+                </mxCell>
+                <mxCell id="uVrLvxiQGZz85al0NEaj-184" value="D3: Groups &amp;amp; Committees" style="shape=partialRectangle;right=0;left=0;html=1;fillColor=#d5e8d4;strokeColor=#82b366;fontFamily=Helvetica;fontColor=#333333;fontStyle=1;whiteSpace=wrap;textShadow=0;" parent="1" vertex="1">
+                    <mxGeometry x="950" y="410" width="180" height="50" as="geometry"/>
+                </mxCell>
+                <mxCell id="uVrLvxiQGZz85al0NEaj-186" value="&lt;b&gt;4.1&lt;/b&gt;&lt;br&gt;Create Committee" style="ellipse;html=1;fillColor=#ffe6cc;strokeColor=#d79b00;fontFamily=Helvetica;fontColor=#333333;whiteSpace=wrap;textShadow=0;" parent="1" vertex="1">
+                    <mxGeometry x="500" y="90" width="160" height="90" as="geometry"/>
+                </mxCell>
+                <mxCell id="uVrLvxiQGZz85al0NEaj-187" value="&lt;b&gt;4.2&lt;/b&gt;&lt;br&gt;Assign Committee&lt;br&gt;Members" style="ellipse;html=1;fillColor=#ffe6cc;strokeColor=#d79b00;fontFamily=Helvetica;fontColor=#333333;whiteSpace=wrap;textShadow=0;" parent="1" vertex="1">
+                    <mxGeometry x="500" y="235" width="160" height="90" as="geometry"/>
+                </mxCell>
+                <mxCell id="uVrLvxiQGZz85al0NEaj-188" value="&lt;b&gt;4.3&lt;/b&gt;&lt;br&gt;Validate and Assign&lt;br&gt;Groups &amp;amp; Notification" style="ellipse;html=1;fillColor=#ffe6cc;strokeColor=#d79b00;fontFamily=Helvetica;fontColor=#333333;whiteSpace=wrap;textShadow=0;" parent="1" vertex="1">
+                    <mxGeometry x="500" y="450" width="160" height="90" as="geometry"/>
+                </mxCell>
+                <mxCell id="uVrLvxiQGZz85al0NEaj-190" value="&lt;b&gt;4.4&lt;/b&gt;&lt;div&gt;&lt;span style=&quot;background-color: transparent; color: rgb(63, 63, 63);&quot;&gt;View Dashboard &amp;amp;&lt;br&gt;Grade Groups&lt;/span&gt;&lt;/div&gt;" style="ellipse;html=1;fillColor=#ffe6cc;strokeColor=#d79b00;fontFamily=Helvetica;fontColor=#333333;whiteSpace=wrap;textShadow=0;" parent="1" vertex="1">
+                    <mxGeometry x="510" y="660" width="160" height="90" as="geometry"/>
+                </mxCell>
+                <mxCell id="uVrLvxiQGZz85al0NEaj-191" style="edgeStyle=orthogonalEdgeStyle;rounded=1;html=1;strokeColor=#545B64;" parent="1" source="uVrLvxiQGZz85al0NEaj-180" target="uVrLvxiQGZz85al0NEaj-186" edge="1">
+                    <mxGeometry relative="1" as="geometry">
+                        <Array as="points">
+                            <mxPoint x="280" y="250"/>
+                            <mxPoint x="280" y="125"/>
+                        </Array>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="uVrLvxiQGZz85al0NEaj-192" value="committeeName, termId" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];labelBackgroundColor=#ffffff;fontFamily=Helvetica;fontSize=11;" parent="uVrLvxiQGZz85al0NEaj-191" connectable="0" vertex="1">
+                    <mxGeometry x="-0.3" relative="1" as="geometry">
+                        <mxPoint y="-10" as="offset"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="uVrLvxiQGZz85al0NEaj-193" style="edgeStyle=orthogonalEdgeStyle;rounded=1;html=1;strokeColor=#545B64;" parent="1" source="uVrLvxiQGZz85al0NEaj-180" target="uVrLvxiQGZz85al0NEaj-187" edge="1">
+                    <mxGeometry relative="1" as="geometry">
+                        <Array as="points">
+                            <mxPoint x="260" y="280"/>
+                            <mxPoint x="260" y="280"/>
+                        </Array>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="uVrLvxiQGZz85al0NEaj-194" value="committeeId, advisorId, professorId[]" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];labelBackgroundColor=#ffffff;fontFamily=Helvetica;fontSize=11;" parent="uVrLvxiQGZz85al0NEaj-193" connectable="0" vertex="1">
+                    <mxGeometry x="-0.1" relative="1" as="geometry">
+                        <mxPoint x="30" y="-10" as="offset"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="uVrLvxiQGZz85al0NEaj-195" style="edgeStyle=orthogonalEdgeStyle;rounded=1;html=1;strokeColor=#545B64;" parent="1" source="uVrLvxiQGZz85al0NEaj-180" target="uVrLvxiQGZz85al0NEaj-188" edge="1">
+                    <mxGeometry relative="1" as="geometry">
+                        <Array as="points">
+                            <mxPoint x="130" y="475"/>
+                        </Array>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="uVrLvxiQGZz85al0NEaj-196" value="committeeId, groupId[]" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];labelBackgroundColor=#ffffff;fontFamily=Helvetica;fontSize=11;" parent="uVrLvxiQGZz85al0NEaj-195" connectable="0" vertex="1">
+                    <mxGeometry x="-0.3" relative="1" as="geometry">
+                        <mxPoint x="71" y="-15" as="offset"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="uVrLvxiQGZz85al0NEaj-197" style="edgeStyle=orthogonalEdgeStyle;rounded=1;html=1;strokeColor=#545B64;" parent="1" source="uVrLvxiQGZz85al0NEaj-186" target="uVrLvxiQGZz85al0NEaj-184" edge="1">
+                    <mxGeometry relative="1" as="geometry">
+                        <Array as="points">
+                            <mxPoint x="840" y="160"/>
+                            <mxPoint x="840" y="190"/>
+                            <mxPoint x="1160" y="190"/>
+                            <mxPoint x="1160" y="430"/>
+                        </Array>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="uVrLvxiQGZz85al0NEaj-198" value="Create Committee Record" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];labelBackgroundColor=#ffffff;fontFamily=Helvetica;fontSize=11;" parent="uVrLvxiQGZz85al0NEaj-197" connectable="0" vertex="1">
+                    <mxGeometry x="-0.6" relative="1" as="geometry">
+                        <mxPoint x="-56" y="10" as="offset"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="uVrLvxiQGZz85al0NEaj-199" style="edgeStyle=orthogonalEdgeStyle;rounded=1;html=1;strokeColor=#545B64;dashed=0;" parent="1" source="uVrLvxiQGZz85al0NEaj-183" target="uVrLvxiQGZz85al0NEaj-187" edge="1">
+                    <mxGeometry relative="1" as="geometry">
+                        <Array as="points"/>
+                        <mxPoint x="1040" y="235" as="sourcePoint"/>
+                        <mxPoint x="580" y="240" as="targetPoint"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="uVrLvxiQGZz85al0NEaj-200" value="Validate Professor Exists&amp;nbsp;" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];labelBackgroundColor=#ffffff;fontFamily=Helvetica;fontSize=11;" parent="uVrLvxiQGZz85al0NEaj-199" connectable="0" vertex="1">
+                    <mxGeometry x="-0.3" relative="1" as="geometry">
+                        <mxPoint x="-69" y="-10" as="offset"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="uVrLvxiQGZz85al0NEaj-201" style="edgeStyle=orthogonalEdgeStyle;rounded=1;html=1;strokeColor=#545B64;" parent="1" source="uVrLvxiQGZz85al0NEaj-187" target="uVrLvxiQGZz85al0NEaj-184" edge="1">
+                    <mxGeometry relative="1" as="geometry">
+                        <Array as="points">
+                            <mxPoint x="610" y="350"/>
+                            <mxPoint x="1040" y="350"/>
+                        </Array>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="uVrLvxiQGZz85al0NEaj-202" value="Members to Committee Record" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];labelBackgroundColor=#ffffff;fontFamily=Helvetica;fontSize=11;" parent="uVrLvxiQGZz85al0NEaj-201" connectable="0" vertex="1">
+                    <mxGeometry x="-0.4" relative="1" as="geometry">
+                        <mxPoint x="-7" y="-15" as="offset"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="uVrLvxiQGZz85al0NEaj-203" style="edgeStyle=orthogonalEdgeStyle;rounded=1;html=1;strokeColor=#545B64;dashed=0;" parent="1" source="uVrLvxiQGZz85al0NEaj-184" target="uVrLvxiQGZz85al0NEaj-188" edge="1">
+                    <mxGeometry relative="1" as="geometry">
+                        <Array as="points">
+                            <mxPoint x="1070" y="510"/>
+                        </Array>
+                        <mxPoint x="1070" y="450" as="sourcePoint"/>
+                        <mxPoint x="580" y="450" as="targetPoint"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="uVrLvxiQGZz85al0NEaj-204" value="Existing group assignments records&amp;nbsp;" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];labelBackgroundColor=#ffffff;fontFamily=Helvetica;fontSize=11;" parent="uVrLvxiQGZz85al0NEaj-203" connectable="0" vertex="1">
+                    <mxGeometry x="-0.2" relative="1" as="geometry">
+                        <mxPoint x="-140" y="20" as="offset"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="uVrLvxiQGZz85al0NEaj-205" style="edgeStyle=orthogonalEdgeStyle;rounded=1;html=1;strokeColor=#545B64;" parent="1" source="uVrLvxiQGZz85al0NEaj-188" target="uVrLvxiQGZz85al0NEaj-184" edge="1">
+                    <mxGeometry relative="1" as="geometry">
+                        <Array as="points">
+                            <mxPoint x="1020" y="490"/>
+                        </Array>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="uVrLvxiQGZz85al0NEaj-206" value="Comitee and groups match" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];labelBackgroundColor=#ffffff;fontFamily=Helvetica;fontSize=11;" parent="uVrLvxiQGZz85al0NEaj-205" connectable="0" vertex="1">
+                    <mxGeometry x="-0.2" relative="1" as="geometry">
+                        <mxPoint x="-5" y="-10" as="offset"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="uVrLvxiQGZz85al0NEaj-213" style="edgeStyle=orthogonalEdgeStyle;rounded=1;html=1;strokeColor=#545B64;dashed=0;" parent="1" source="uVrLvxiQGZz85al0NEaj-188" target="uVrLvxiQGZz85al0NEaj-181" edge="1">
+                    <mxGeometry relative="1" as="geometry">
+                        <Array as="points">
+                            <mxPoint x="540" y="605"/>
+                            <mxPoint x="140" y="605"/>
+                        </Array>
+                        <mxPoint x="440" y="580" as="sourcePoint"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="uVrLvxiQGZz85al0NEaj-214" value="System Notification /&amp;nbsp; Assigned Groups" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];labelBackgroundColor=#ffffff;fontFamily=Helvetica;fontSize=11;" parent="uVrLvxiQGZz85al0NEaj-213" connectable="0" vertex="1">
+                    <mxGeometry x="0.1" relative="1" as="geometry">
+                        <mxPoint x="39" y="-10" as="offset"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="uVrLvxiQGZz85al0NEaj-215" style="edgeStyle=orthogonalEdgeStyle;rounded=1;html=1;strokeColor=#545B64;" parent="1" source="uVrLvxiQGZz85al0NEaj-181" target="uVrLvxiQGZz85al0NEaj-190" edge="1">
+                    <mxGeometry relative="1" as="geometry">
+                        <Array as="points">
+                            <mxPoint x="160" y="710"/>
+                        </Array>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="uVrLvxiQGZz85al0NEaj-216" value="Request Dashboard (professorId)" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];labelBackgroundColor=#ffffff;fontFamily=Helvetica;fontSize=11;" parent="uVrLvxiQGZz85al0NEaj-215" connectable="0" vertex="1">
+                    <mxGeometry x="0.2" relative="1" as="geometry">
+                        <mxPoint x="-61" y="-10" as="offset"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="uVrLvxiQGZz85al0NEaj-217" style="edgeStyle=orthogonalEdgeStyle;rounded=1;html=1;strokeColor=#545B64;dashed=0;" parent="1" source="uVrLvxiQGZz85al0NEaj-184" target="uVrLvxiQGZz85al0NEaj-190" edge="1">
+                    <mxGeometry relative="1" as="geometry">
+                        <Array as="points">
+                            <mxPoint x="1110" y="680"/>
+                        </Array>
+                        <mxPoint x="1110.066666666667" y="470" as="sourcePoint"/>
+                        <mxPoint x="600" y="670" as="targetPoint"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="uVrLvxiQGZz85al0NEaj-218" value="Fetch Assigned Groups" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];labelBackgroundColor=#ffffff;fontFamily=Helvetica;fontSize=11;" parent="uVrLvxiQGZz85al0NEaj-217" connectable="0" vertex="1">
+                    <mxGeometry x="-0.4" relative="1" as="geometry">
+                        <mxPoint x="-320" y="8" as="offset"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="uVrLvxiQGZz85al0NEaj-219" style="edgeStyle=orthogonalEdgeStyle;rounded=1;html=1;strokeColor=#545B64;dashed=0;" parent="1" source="uVrLvxiQGZz85al0NEaj-182" target="uVrLvxiQGZz85al0NEaj-190" edge="1">
+                    <mxGeometry relative="1" as="geometry">
+                        <Array as="points">
+                            <mxPoint x="1040" y="90"/>
+                            <mxPoint x="1200" y="90"/>
+                            <mxPoint x="1200" y="700"/>
+                        </Array>
+                        <mxPoint x="1130.7" y="90" as="sourcePoint"/>
+                        <mxPoint x="670.004486134673" y="675.9209231729508" as="targetPoint"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="uVrLvxiQGZz85al0NEaj-220" value="Fetch Active Rubrics &amp;amp; Schedules" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];labelBackgroundColor=#ffffff;fontFamily=Helvetica;fontSize=11;" parent="uVrLvxiQGZz85al0NEaj-219" connectable="0" vertex="1">
+                    <mxGeometry x="-0.2" relative="1" as="geometry">
+                        <mxPoint x="-400" y="272" as="offset"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="uVrLvxiQGZz85al0NEaj-221" style="edgeStyle=orthogonalEdgeStyle;rounded=1;html=1;strokeColor=#545B64;" parent="1" source="uVrLvxiQGZz85al0NEaj-190" target="uVrLvxiQGZz85al0NEaj-181" edge="1">
+                    <mxGeometry relative="1" as="geometry">
+                        <Array as="points">
+                            <mxPoint x="130" y="740"/>
+                        </Array>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="uVrLvxiQGZz85al0NEaj-222" value="Dashboard View Data" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];labelBackgroundColor=#ffffff;fontFamily=Helvetica;fontSize=11;" parent="uVrLvxiQGZz85al0NEaj-221" connectable="0" vertex="1">
+                    <mxGeometry x="0.1" relative="1" as="geometry">
+                        <mxPoint x="16" y="10" as="offset"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="uVrLvxiQGZz85al0NEaj-223" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=0.5;exitY=1;exitDx=0;exitDy=0;" parent="1" source="uVrLvxiQGZz85al0NEaj-180" target="uVrLvxiQGZz85al0NEaj-180" edge="1">
+                    <mxGeometry relative="1" as="geometry"/>
+                </mxCell>
+                <mxCell id="wf-5XCFYFlu-Ppf5nMq--1" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=0.5;exitY=1;exitDx=0;exitDy=0;" parent="1" source="uVrLvxiQGZz85al0NEaj-183" target="uVrLvxiQGZz85al0NEaj-183" edge="1">
+                    <mxGeometry relative="1" as="geometry"/>
+                </mxCell>
+                <mxCell id="wf-5XCFYFlu-Ppf5nMq--9" style="edgeStyle=orthogonalEdgeStyle;rounded=1;html=1;strokeColor=#545B64;dashed=0;" parent="1" source="uVrLvxiQGZz85al0NEaj-184" target="uVrLvxiQGZz85al0NEaj-187" edge="1">
+                    <mxGeometry relative="1" as="geometry">
+                        <Array as="points">
+                            <mxPoint x="550" y="420"/>
+                        </Array>
+                        <mxPoint x="970" y="410" as="sourcePoint"/>
+                        <mxPoint x="570" y="325" as="targetPoint"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="wf-5XCFYFlu-Ppf5nMq--10" value="E&lt;span style=&quot;background-color: light-dark(rgb(255, 255, 255), rgb(18, 18, 18)); color: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));&quot;&gt;xisting comitee assigments&lt;/span&gt;" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];labelBackgroundColor=#ffffff;fontFamily=Helvetica;fontSize=11;" parent="wf-5XCFYFlu-Ppf5nMq--9" connectable="0" vertex="1">
+                    <mxGeometry x="-0.2" relative="1" as="geometry">
+                        <mxPoint x="-120" y="-10" as="offset"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="wf-5XCFYFlu-Ppf5nMq--19" style="edgeStyle=orthogonalEdgeStyle;rounded=1;html=1;strokeColor=#545B64;" parent="1" source="uVrLvxiQGZz85al0NEaj-184" target="uVrLvxiQGZz85al0NEaj-187" edge="1">
+                    <mxGeometry relative="1" as="geometry">
+                        <Array as="points">
+                            <mxPoint x="1010" y="380"/>
+                            <mxPoint x="570" y="380"/>
+                        </Array>
+                        <mxPoint x="940" y="380" as="sourcePoint"/>
+                        <mxPoint x="1322" y="490" as="targetPoint"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="wf-5XCFYFlu-Ppf5nMq--20" value="Existing Advisor" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];labelBackgroundColor=#ffffff;fontFamily=Helvetica;fontSize=11;" parent="wf-5XCFYFlu-Ppf5nMq--19" connectable="0" vertex="1">
+                    <mxGeometry x="-0.4" relative="1" as="geometry">
+                        <mxPoint x="-219" y="-10" as="offset"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="12" style="edgeStyle=orthogonalEdgeStyle;rounded=1;html=1;strokeColor=#545B64;" parent="1" source="uVrLvxiQGZz85al0NEaj-184" target="uVrLvxiQGZz85al0NEaj-186" edge="1">
+                    <mxGeometry relative="1" as="geometry">
+                        <Array as="points">
+                            <mxPoint x="1170" y="440"/>
+                            <mxPoint x="1170" y="170"/>
+                            <mxPoint x="855" y="170"/>
+                            <mxPoint x="855" y="120"/>
+                        </Array>
+                        <mxPoint x="1064.58" y="320" as="sourcePoint"/>
+                        <mxPoint x="660.0047233265651" y="60" as="targetPoint"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="13" value="ValidCommittee" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];labelBackgroundColor=#ffffff;fontFamily=Helvetica;fontSize=11;" parent="12" connectable="0" vertex="1">
+                    <mxGeometry x="-0.6" relative="1" as="geometry">
+                        <mxPoint x="-400" y="-196" as="offset"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="21" value="System Boundary&lt;div&gt;&lt;br/&gt;&lt;/div&gt;" style="rounded=0;whiteSpace=wrap;html=1;fillColor=none;strokeColor=#FF0000;strokeWidth=2;dashed=1;align=right;verticalAlign=top;spacingRight=10;spacingTop=10;fontStyle=1;fontSize=14;" parent="1" vertex="1">
+                    <mxGeometry x="400" y="40" width="510" height="765" as="geometry"/>
+                </mxCell>
+            </root>
+        </mxGraphModel>
+    </diagram>
+</mxfile>

--- a/docs/shared-p2-p3/endpoints_summary_p2_p3.md
+++ b/docs/shared-p2-p3/endpoints_summary_p2_p3.md
@@ -1,0 +1,44 @@
+
+
+> **Note:** The SP column here is a per-endpoint difficulty score used for planning, not GitHub issue story points. P2 issue total = 29 SP; P3 issue total = 15 SP.
+
+## Process-2 Endpoint Summary Table
+
+| # | Method | Path | Auth | Sub-process | Issue | SP | Difficulty |
+|---|--------|------|------|-------------|-------|----|------------|
+| 1 | POST | `/api/groups` | Student | 2.1 | API-01 | 3 | Medium |
+| 2 | GET | `/api/groups/my` | Student | 2.1 | API-01 | 1 | Easy |
+| 3 | GET | `/api/students/search?q=` | Student | 2.2 | API-02 | 2 | Easy |
+| 4 | POST | `/api/groups/{groupId}/invitations` | Student (TEAM_LEADER) | 2.2 | API-02 | 3 | Medium |
+| 5 | GET | `/api/groups/{groupId}/invitations` | Student (TEAM_LEADER) | 2.2 | API-02 | 1 | Easy |
+| 6 | DELETE | `/api/invitations/{invitationId}` | Student (TEAM_LEADER) | 2.2 | API-02 | 2 | Easy |
+| 7 | GET | `/api/invitations/pending` | Student | 2.3 | API-03 | 1 | Easy |
+| 8 | PATCH | `/api/invitations/{invitationId}/respond` | Student (invitee) | 2.3 | API-03 | 5 | Hard |
+| 9 | POST | `/api/groups/{groupId}/jira` | Student (TEAM_LEADER) | 2.4 | API-04 | 5 | Hard |
+| 10 | POST | `/api/groups/{groupId}/github` | Student (TEAM_LEADER) | 2.5 | API-05 | 5 | Hard |
+| 11 | GET | `/api/coordinator/groups` | Staff (Coordinator) | 2.6 | API-06 | 2 | Easy |
+| 12 | GET | `/api/coordinator/groups/{groupId}` | Staff (Coordinator) | 2.6 | API-06 | 1 | Easy |
+| 13 | PATCH | `/api/coordinator/groups/{groupId}/members` | Staff (Coordinator) | 2.6 | API-06 | 3 | Medium |
+| 14 | PATCH | `/api/coordinator/groups/{groupId}/disband` | Staff (Coordinator) | 2.6 | API-06 | 3 | Medium |
+
+**Total SP: 37**
+
+
+--- 
+
+## Process-3 Endpoint Summary Table
+
+| # | Method | Path | Auth | Sub-process | Issue | SP | Difficulty |
+|---|--------|------|------|-------------|-------|----|------------|
+| 1 | GET | `/api/advisors` | Student | 3.1 | P3-API-01 | 2 | Easy |
+| 2 | POST | `/api/groups/{groupId}/advisor-request` | Student (TEAM_LEADER) | 3.1 | P3-API-01 | 5 | Hard |
+| 3 | GET | `/api/groups/{groupId}/advisor-request` | Student (member) | 3.1 | P3-API-01 | 1 | Easy |
+| 4 | DELETE | `/api/groups/{groupId}/advisor-request` | Student (TEAM_LEADER) | 3.1 | P3-API-01 | 2 | Easy |
+| 5 | GET | `/api/advisor/requests` | Staff (Professor) | 3.2 | P3-API-02 | 2 | Easy |
+| 6 | GET | `/api/advisor/requests/{requestId}` | Staff (Professor) | 3.2 | P3-API-02 | 2 | Easy |
+| 7 | PATCH | `/api/advisor/requests/{requestId}/respond` | Staff (Professor) | 3.3 | P3-API-03 | 5 | Hard |
+| 8 | POST | `/api/coordinator/sanitize` | Staff (Coordinator) | 3.4 | P3-API-04 | 3 | Medium |
+| 9 | GET | `/api/coordinator/advisors` | Staff (Coordinator) | 3.5 | P3-API-05 | 1 | Easy |
+| 10 | PATCH | `/api/coordinator/groups/{groupId}/advisor` | Staff (Coordinator) | 3.5 | P3-API-05 | 3 | Medium |
+
+**Total SP: 26**

--- a/docs/shared-p2-p3/er_p2_p3.md
+++ b/docs/shared-p2-p3/er_p2_p3.md
@@ -1,0 +1,190 @@
+# ER Diagram — P0/P1 (existing) + P2 + P3
+
+---
+
+## Diagram 1 — Existing Tables (Blue Team: P0 / P1)
+
+> **Note:** Diagram 1 is preserved for context only. Blue Team PKs are actually UUID (BINARY(16)), not bigint — see Diagram 2 for the corrected representation used by Red Team.
+
+```mermaid
+erDiagram
+
+    staff_user {
+        bigint id PK
+        varchar mail
+        varchar password_hash
+        enum role
+        tinyint first_login
+    }
+
+    student {
+        bigint id PK
+        varchar github_username
+        varchar student_id
+    }
+
+    password_reset_token {
+        bigint id PK
+        varchar token
+        tinyint used
+        datetime created_at
+        datetime expires_at
+        bigint staff_id FK
+    }
+
+    sprint {
+        bigint id PK
+        date start_date
+        date end_date
+        int story_point_target
+    } 
+
+
+
+    rubric_criterion {
+        bigint id PK
+        varchar criterion_name
+        enum grading_type
+        decimal weight
+        bigint deliverable_id FK
+    }
+
+    deliverable {
+        bigint id PK
+        varchar name
+        enum type
+        decimal weight
+        datetime submission_deadline
+        datetime review_deadline
+    }
+
+    sprint_deliverable_mapping {
+        bigint id PK
+        decimal contribution_percentage
+        bigint deliverable_id FK
+        bigint sprint_id FK
+        bigint student_id FK
+    }
+
+    staff_user              ||--o{ password_reset_token      : "has"
+    deliverable             ||--o{ rubric_criterion           : "has"
+    sprint                  ||--o{ sprint_deliverable_mapping : "mapped in"
+    student                 ||--o{ sprint_deliverable_mapping : "mapped in"
+    deliverable             ||--o{ sprint_deliverable_mapping : "mapped in"
+
+```
+
+---
+
+## Diagram 2 — New Tables (P2: Group Creation + P3: Advisor Association)
+
+> `staff_user` and `student` are carried over from P0/P1 (shown here as anchors only).
+
+```mermaid
+erDiagram
+
+    %% ── Anchors from P0/P1 (Blue Team) ──
+    %% Blue Team stores UUIDs as BINARY(16) in MySQL — Java type is UUID
+    staff_user {
+        uuid id PK "stored as BINARY(16)"
+        enum role "COORDINATOR | PROFESSOR | ADMIN"
+        int advisor_capacity "added by Red Team for P3 — default 5"
+    }
+
+    student {
+        uuid id PK "stored as BINARY(16) — internal UUID, not the studentId string"
+        varchar student_id "university ID string e.g. 23070006036"
+        varchar github_username
+    }
+
+    %% ── P2 ──
+    schedule_window {
+        uuid id PK
+        varchar term_id
+        enum type "GROUP_CREATION | ADVISOR_ASSOCIATION"
+        datetime opens_at
+        datetime closes_at
+    }
+
+    project_group {
+        uuid id PK
+        varchar group_name
+        varchar term_id
+        enum status "FORMING | TOOLS_PENDING | TOOLS_BOUND | ADVISOR_ASSIGNED | DISBANDED"
+        datetime created_at
+        varchar jira_space_url
+        varchar jira_project_key
+        varchar encrypted_jira_token "length=1024"
+        varchar github_org_name
+        varchar encrypted_github_pat "length=1024"
+        uuid advisor_id FK "NULLABLE — set on ADVISOR_ASSIGNED"
+        bigint version "Optimistic Lock — @Version"
+    }
+
+    group_membership {
+        uuid id PK
+        uuid group_id FK
+        uuid student_id FK "UNIQUE — one active group per student (uq_gm_student)"
+        enum role "TEAM_LEADER | MEMBER"
+        datetime joined_at
+    }
+
+    group_invitation {
+        uuid id PK
+        uuid group_id FK
+        uuid invitee_student_id FK
+        enum status "PENDING | ACCEPTED | DECLINED | AUTO_DENIED | CANCELLED"
+        datetime sent_at
+        datetime responded_at "NULLABLE"
+    }
+
+    %% ── P3 ──
+    advisor_request {
+        uuid id PK
+        uuid group_id FK
+        uuid advisor_id FK "FK to staff_user.id"
+        enum status "PENDING | ACCEPTED | REJECTED | AUTO_REJECTED | CANCELLED"
+        datetime sent_at
+        datetime responded_at "NULLABLE"
+    }
+
+    %% ── Relationships (declared top-to-bottom to guide vertical layout) ──
+    staff_user          ||--o{ project_group      : "advises (nullable)"
+    student             ||--o{ group_membership   : "joins"
+    student             ||--o{ group_invitation   : "receives"
+
+    project_group       ||--o{ group_membership   : "has members"
+    project_group       ||--o{ group_invitation   : "sends"
+    project_group       ||--o{ advisor_request    : "submits"
+
+    staff_user          ||--o{ advisor_request    : "receives"
+```
+
+---
+
+## Diagram 3 — Shared Config Table (owned by Red Team)
+
+> Red Team creates and seeds this table. Blue Team adds their own config keys as rows — no separate table needed.
+
+```mermaid
+erDiagram
+    system_config {
+        varchar config_key PK "e.g. active_term_id, max_team_size"
+        varchar config_value "e.g. 2024-FALL, 5"
+    }
+```
+
+---
+
+## Notes
+
+| Entity | Process | Key constraint |
+|---|---|---|
+| `schedule_window` | P2 + P3 | No FK to term table — `term_id` string stamped by backend via `TermConfigService` |
+| `group_membership` | P2 | TWO unique constraints: `uq_gm_group_student (groupId, studentId)` + `uq_gm_student (studentId)` |
+| `group_invitation` | P2 | One PENDING per student per group — service-layer 409 |
+| `advisor_request` | P3 | One active PENDING per group — service-layer 409 |
+| `project_group.advisor_id` | P3 | NULLABLE FK to `staff_user`; set on `ADVISOR_ASSIGNED` only |
+| `project_group.version` | P3 | `@Version` Optimistic Lock — prevents sanitization race condition |
+| `staff_user.advisor_capacity` | P3 | Column added to existing table; default 5; enforced at service layer |
+| `system_config` | P2+P3 | **Red Team table** — seeded with `active_term_id` and `max_team_size`; Blue Team adds their own rows |

--- a/docs/shared-p2-p3/usecases_p2_p3.md
+++ b/docs/shared-p2-p3/usecases_p2_p3.md
@@ -1,0 +1,240 @@
+# Use Cases — Process 2 & Process 3
+
+---
+
+## Process 2 — Group Creation & Tool Integration
+
+---
+
+### 2.1 — Create a Group
+
+**Actor:** Student (becomes Team Leader)
+
+> A student opens the app during the group creation window and creates a new group for their term.
+
+**Happy path:**
+1. Student submits a group name. `termId` is resolved server-side — not sent by the client.
+2. System checks the group creation window is open.
+3. System checks the student is not already in a group.
+4. Group is created with status `FORMING`. Student is automatically set as `TEAM_LEADER`.
+
+**Fails if:**
+- The group creation window is closed while process. 
+- The student is already in a group.
+- The group name already exists for that term.
+
+---
+
+### 2.2 — Invite a Member
+
+**Actor:** Team Leader
+
+> The Team Leader searches for classmates by student ID and sends them an invitation.
+
+**Happy path:**
+1. Team Leader searches for a student by partial student ID (min 3 chars).
+2. System returns students who are not yet in any group.
+3. Team Leader sends an invitation to a chosen student.
+4. Invitation is created with status `PENDING`.
+5. Team Leader can cancel a pending invitation at any time.
+
+**Fails if:**
+- Caller is not the Team Leader.
+- Target student is already in a group.
+- A pending invitation to the same student already exists.
+
+---
+
+### 2.3 — Respond to an Invitation
+
+**Actor:** Invited Student
+
+> The invited student sees their pending invitations and accepts or declines.
+
+**Happy path (Accept):**
+1. Student views their pending invitations.
+2. Student accepts one invitation.
+3. Student is added to the group as `MEMBER`.
+4. All other pending invitations the student received are automatically denied.
+
+**Happy path (Decline):**
+1. Student declines the invitation.
+2. Only that invitation is updated to `DECLINED`. Nothing else changes.
+
+**Fails if:**
+- The invitation does not belong to the authenticated student.
+- The invitation is no longer pending (already accepted, declined, or cancelled).
+- Group status is `TOOLS_BOUND` or higher — student accept is blocked (roster lock). Coordinator force-add bypasses this.
+
+---
+
+### 2.4 — Bind JIRA
+
+**Actor:** Team Leader
+
+> The Team Leader connects the group's JIRA workspace so sprint data can be pulled later.
+
+**Happy path:**
+1. Team Leader submits JIRA space URL, project key, and API token.
+2. System makes a live test call to JIRA to validate all three.
+3. Token is encrypted (AES-256) before saving. URL and key saved as plaintext.
+4. If GitHub is already bound → group status becomes `TOOLS_BOUND`.
+5. If GitHub is not yet bound → group status becomes `TOOLS_PENDING`.
+
+**Fails if:**
+- JIRA URL is unreachable.
+- Project key is not found in that JIRA space.
+- API token is invalid or expired.
+
+---
+
+### 2.5 — Bind GitHub
+
+**Actor:** Team Leader
+
+> The Team Leader connects the group's GitHub organization so PR and code data can be pulled later.
+
+**Happy path:**
+1. Team Leader submits GitHub organization name and Personal Access Token (PAT).
+2. System calls GitHub to verify the org exists and the PAT is valid.
+3. System checks the PAT has `repo` scope (second call).
+4. PAT is encrypted before saving. Org name saved as plaintext.
+5. If JIRA is already bound → group status becomes `TOOLS_BOUND`.
+6. If JIRA is not yet bound → group status becomes `TOOLS_PENDING`.
+
+**Fails if:**
+- PAT is invalid or expired.
+- PAT does not have `repo` scope.
+- Organization name does not exist on GitHub.
+
+---
+
+### 2.6 — Coordinator Group Override
+
+**Actor:** Coordinator
+
+> The Coordinator can inspect all groups for a term and intervene when needed.
+
+**Sub-cases:**
+
+| Action | Description |
+|---|---|
+| List groups | View all groups for a term with status and tool binding summary. |
+| View group detail | See full member list and tool binding state for one group. |
+| Add / remove member | Bypass the invitation flow — add or remove a student directly. Removing the Team Leader is blocked. Force-add is rejected if (current members + pending outbound invitations) >= max team size. Force-add also bulk auto-denies all other PENDING invitations for the added student (same transaction). |
+| Disband group | Set group status to `DISBANDED`. All pending invitations for members are auto-denied. All pending advisor requests for the group are auto-rejected. All GroupMembership rows are hard-deleted. |
+
+---
+
+## Process 3 — Advisor Association & Sanitization
+
+> Only groups with status `TOOLS_BOUND` can request an advisor. The `ADVISOR_ASSOCIATION` schedule window must be open.
+
+---
+
+### 3.1 — Browse Advisors & Send Request
+
+**Actor:** Team Leader
+
+> The Team Leader browses available professors and sends one advisor request at a time.
+
+**Happy path:**
+1. Team Leader views the list of professors who are below their group capacity for the term.
+2. Team Leader sends a request to one advisor.
+3. `AdvisorRequest` is created with status `PENDING`.
+4. Team Leader can cancel the pending request and send a new one if needed.
+
+**Fails if:**
+- Advisor association window is not open.
+- Group status is not `TOOLS_BOUND`.
+- Group already has an active `PENDING` request (one at a time).
+- Target advisor has reached their maximum capacity.
+
+---
+
+### 3.2 — Advisor Reviews Requests
+
+**Actor:** Advisor (Professor)
+
+> The advisor sees all pending requests addressed to them and can review each group before deciding.
+
+**Happy path:**
+1. Advisor views their list of pending requests (group name, member count, term).
+2. Advisor opens a specific request to see full group detail and member list.
+3. No state changes — this step is read-only.
+
+---
+
+### 3.3 — Advisor Responds to a Request
+
+**Actor:** Advisor (Professor)
+
+> The advisor accepts or rejects a group's request.
+
+**Happy path (Accept):**
+1. Advisor accepts the request.
+2. `group.advisorId` is set. Group status → `ADVISOR_ASSIGNED`.
+3. Any other pending requests from the same group to other advisors are auto-rejected.
+4. All changes happen in one atomic transaction.
+
+**Happy path (Reject):**
+1. Advisor rejects the request.
+2. Only that request is marked `REJECTED`. Group status stays `TOOLS_BOUND`.
+3. Team Leader is free to send a new request to any advisor.
+
+---
+
+### 3.4 — Auto-Sanitization (Disband Unadvised Groups)
+
+**Actor:** System Scheduler / Coordinator (manual trigger)
+
+> When the advisor association window closes, any group that still has no advisor is automatically disbanded.
+
+**Happy path:**
+1. Scheduled job fires when the `ADVISOR_ASSOCIATION` window `closesAt` passes.
+2. All groups without an assigned advisor (`FORMING`, `TOOLS_PENDING`, `TOOLS_BOUND`) are disbanded.
+3. All pending advisor requests for those groups are auto-rejected.
+4. A sanitization report (count of disbanded groups, count of rejected requests) is returned.
+
+**Manual trigger:**
+- Coordinator can fire this early via `POST /api/coordinator/sanitize`.
+- Requires `force: true` if the window is still active.
+
+---
+
+### 3.5 — Coordinator Advisor Override
+
+**Actor:** Coordinator
+
+> The Coordinator can assign or remove an advisor from any group, bypassing the normal request flow.
+
+**Sub-cases:**
+
+| Action | Description |
+|---|---|
+| List advisors | See all professors with current group count and capacity for the term (including those at capacity). |
+| Assign advisor | Directly sets `group.advisorId` → status `ADVISOR_ASSIGNED`. No window check, no capacity limit. Auto-rejects any pending requests for the group. |
+| Remove advisor | Clears `group.advisorId` → status reverts to `TOOLS_BOUND`. Group can re-enter the request flow. |
+
+---
+
+## Group Status Flow (P2 → P3)
+
+```
+FORMING
+  │ (first tool bound)
+  ▼
+TOOLS_PENDING
+  │ (second tool bound)
+  ▼
+TOOLS_BOUND
+  │ (advisor accepts OR coordinator assigns)
+  ▼
+ADVISOR_ASSIGNED
+  │ (coordinator removes advisor)
+  └──► TOOLS_BOUND
+
+FORMING / TOOLS_PENDING / TOOLS_BOUND ──(sanitization — no advisor at window close)──► DISBANDED
+Any state ──(coordinator disbands)──► DISBANDED
+Note: ADVISOR_ASSIGNED groups are NOT affected by sanitization — only coordinator disband can reach DISBANDED from that state.
+```


### PR DESCRIPTION
## Summary

- Adds `GroupCreationIntegrationTest` covering the full POST `/api/groups` flow end-to-end against a real database
- Tests all closed-window variants (no window, not yet open, expired) and verifies each produces a 400
- Tests duplicate group name (409) and already-grouped student (400)
- Happy path directly queries the DB to assert both `ProjectGroup` and `GroupMembership` records exist with correct values (FORMING status, TEAM_LEADER role)

## Test Results

| Test | Scenario | Expected |
|---|---|---|
| `@Order(1)` | Active window | 201 + DB has 1 `ProjectGroup` + 1 `GroupMembership` (TEAM_LEADER) |
| `@Order(2)` | No window row | 400 + no DB rows |
| `@Order(3)` | Window not yet open | 400 + no DB rows |
| `@Order(4)` | Window expired | 400 + no DB rows |
| `@Order(5)` | Duplicate name | 409 + only pre-seeded group remains |
| `@Order(6)` | Student already in group | 400 + original membership unchanged |
| `@Order(7)` | No JWT token | 4xx + no DB rows |
 
resolves #44 