### PR TITLE
Test/issue 53 advisor controller integration tests

### DIFF
--- a/backend/src/main/java/com/senior/spm/config/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/senior/spm/config/GlobalExceptionHandler.java
@@ -14,6 +14,7 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 import com.senior.spm.controller.response.ErrorMessage;
 import com.senior.spm.exception.AdvisorAtCapacityException;
+import com.senior.spm.exception.RepositoryException;
 import com.senior.spm.exception.AdvisorNotFoundException;
 import com.senior.spm.exception.AlreadyInGroupException;
 import com.senior.spm.exception.BusinessRuleException;
@@ -48,6 +49,12 @@ public class GlobalExceptionHandler {
         var message = "Access denied: " + authority.getAuthority()
                 + " does not have permission to access this resource.";
         return ResponseEntity.status(HttpStatus.FORBIDDEN).body(new ErrorMessage(message));
+    }
+
+    @ExceptionHandler(RepositoryException.class)
+    public ResponseEntity<ErrorMessage> handleRepositoryException(RepositoryException ex) {
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                .body(new ErrorMessage("An unexpected error occurred: " + ex.getMessage()));
     }
 
     @ExceptionHandler(HttpMessageNotReadableException.class)

--- a/backend/src/main/java/com/senior/spm/config/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/senior/spm/config/GlobalExceptionHandler.java
@@ -14,7 +14,6 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 import com.senior.spm.controller.response.ErrorMessage;
 import com.senior.spm.exception.AdvisorAtCapacityException;
-import com.senior.spm.exception.RepositoryException;
 import com.senior.spm.exception.AdvisorNotFoundException;
 import com.senior.spm.exception.AlreadyInGroupException;
 import com.senior.spm.exception.BusinessRuleException;
@@ -49,12 +48,6 @@ public class GlobalExceptionHandler {
         var message = "Access denied: " + authority.getAuthority()
                 + " does not have permission to access this resource.";
         return ResponseEntity.status(HttpStatus.FORBIDDEN).body(new ErrorMessage(message));
-    }
-
-    @ExceptionHandler(RepositoryException.class)
-    public ResponseEntity<ErrorMessage> handleRepositoryException(RepositoryException ex) {
-        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
-                .body(new ErrorMessage("An unexpected error occurred: " + ex.getMessage()));
     }
 
     @ExceptionHandler(HttpMessageNotReadableException.class)

--- a/backend/src/test/java/com/senior/spm/AdvisorControllerIntegrationTest.java
+++ b/backend/src/test/java/com/senior/spm/AdvisorControllerIntegrationTest.java
@@ -28,6 +28,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
+import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.web.servlet.MockMvc;
 
 import java.time.LocalDateTime;
@@ -45,8 +46,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 /**
  * Black-box integration tests for AdvisorController (P3-API-02 & P3-API-03).
  *
- * Tests compile and run now. All will fail with 404 until AdvisorController is
- * implemented. Once the controller is wired, all tests should pass green.
+ * All 20 tests pass green against the full Spring Boot context and H2 in-memory DB.
  *
  * Endpoints covered:
  *   GET  /api/advisor/requests
@@ -58,6 +58,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @SpringBootTest
 @AutoConfigureMockMvc
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+@TestPropertySource(locations = "classpath:test.properties")
 class AdvisorControllerIntegrationTest {
 
     @Autowired MockMvc mockMvc;

--- a/backend/src/test/java/com/senior/spm/AdvisorControllerIntegrationTest.java
+++ b/backend/src/test/java/com/senior/spm/AdvisorControllerIntegrationTest.java
@@ -1,0 +1,504 @@
+package com.senior.spm;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.senior.spm.entity.AdvisorRequest;
+import com.senior.spm.entity.AdvisorRequest.RequestStatus;
+import com.senior.spm.entity.GroupMembership;
+import com.senior.spm.entity.GroupMembership.MemberRole;
+import com.senior.spm.entity.ProjectGroup;
+import com.senior.spm.entity.ProjectGroup.GroupStatus;
+import com.senior.spm.entity.StaffUser;
+import com.senior.spm.entity.StaffUser.Role;
+import com.senior.spm.entity.Student;
+import com.senior.spm.entity.SystemConfig;
+import com.senior.spm.repository.AdvisorRequestRepository;
+import com.senior.spm.repository.GroupInvitationRepository;
+import com.senior.spm.repository.GroupMembershipRepository;
+import com.senior.spm.repository.ProjectGroupRepository;
+import com.senior.spm.repository.StaffUserRepository;
+import com.senior.spm.repository.StudentRepository;
+import com.senior.spm.repository.SystemConfigRepository;
+import com.senior.spm.service.JWTService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * Black-box integration tests for AdvisorController (P3-API-02 & P3-API-03).
+ *
+ * Tests compile and run now. All will fail with 404 until AdvisorController is
+ * implemented. Once the controller is wired, all tests should pass green.
+ *
+ * Endpoints covered:
+ *   GET  /api/advisor/requests
+ *   GET  /api/advisor/requests/{requestId}
+ *   PATCH /api/advisor/requests/{requestId}/respond
+ *
+ * References: docs/process3/sequences/3.2_3.3_advisor_respond_p3.md
+ */
+@SpringBootTest
+@AutoConfigureMockMvc
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+class AdvisorControllerIntegrationTest {
+
+    @Autowired MockMvc mockMvc;
+    @Autowired ObjectMapper objectMapper;
+    @Autowired JWTService jwtService;
+
+    @Autowired StaffUserRepository staffUserRepository;
+    @Autowired StudentRepository studentRepository;
+    @Autowired SystemConfigRepository systemConfigRepository;
+    @Autowired ProjectGroupRepository projectGroupRepository;
+    @Autowired GroupMembershipRepository groupMembershipRepository;
+    @Autowired GroupInvitationRepository groupInvitationRepository;
+    @Autowired AdvisorRequestRepository advisorRequestRepository;
+
+    private static final String TERM_ID = "2026-SPRING-TEST";
+
+    // Shared test fixtures — re-created fresh in @BeforeEach
+    private StaffUser professor;
+    private StaffUser coordinator;
+    private Student student;
+    private ProjectGroup toolsBoundGroup;
+
+    private String professorToken;
+    private String coordinatorToken;
+    private String studentToken;
+
+    @BeforeEach
+    void setUp() {
+        // FK-safe teardown
+        advisorRequestRepository.deleteAll();
+        groupInvitationRepository.deleteAll();
+        groupMembershipRepository.deleteAll();
+        projectGroupRepository.deleteAll();
+        studentRepository.deleteAll();
+        staffUserRepository.deleteAll();
+        systemConfigRepository.deleteAll();
+
+        // System config
+        SystemConfig termConfig = new SystemConfig();
+        termConfig.setConfigKey("active_term_id");
+        termConfig.setConfigValue(TERM_ID);
+        systemConfigRepository.save(termConfig);
+
+        // Professor (default capacity = 5)
+        professor = staffUserRepository.save(newProfessor("prof@test.com", 5));
+        coordinator = staffUserRepository.save(newCoordinator("coord@test.com"));
+
+        // Student + group in TOOLS_BOUND state
+        student = studentRepository.save(newStudent("12345678901", "gh-user"));
+        toolsBoundGroup = projectGroupRepository.save(newGroup("Alpha Team", GroupStatus.TOOLS_BOUND));
+        groupMembershipRepository.save(newMembership(student, toolsBoundGroup, MemberRole.TEAM_LEADER));
+
+        // JWT tokens
+        professorToken  = jwtService.issueToken(professor);
+        coordinatorToken = jwtService.issueToken(coordinator);
+        studentToken    = jwtService.issueToken(student);
+    }
+
+    // =========================================================================
+    // GET /api/advisor/requests
+    // =========================================================================
+
+    /** Test 1 — returns the professor's PENDING requests */
+    @Test
+    @Order(1)
+    void listRequests_withPendingRequests_returns200WithList() throws Exception {
+        advisorRequestRepository.save(pendingRequest(toolsBoundGroup, professor));
+
+        mockMvc.perform(get("/api/advisor/requests")
+                .header("Authorization", "Bearer " + professorToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].requestId").exists())
+                .andExpect(jsonPath("$[0].groupId").exists())
+                .andExpect(jsonPath("$[0].groupName").value("Alpha Team"))
+                .andExpect(jsonPath("$[0].termId").value(TERM_ID))
+                .andExpect(jsonPath("$[0].memberCount").value(1))
+                .andExpect(jsonPath("$[0].sentAt").exists());
+    }
+
+    /** Test 2 — empty list (not 404) when no pending requests */
+    @Test
+    @Order(2)
+    void listRequests_noPendingRequests_returns200WithEmptyArray() throws Exception {
+        mockMvc.perform(get("/api/advisor/requests")
+                .header("Authorization", "Bearer " + professorToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$").isArray())
+                .andExpect(jsonPath("$").isEmpty());
+    }
+
+    /** Test 3 — no token → rejected */
+    @Test
+    @Order(3)
+    void listRequests_noToken_isRejected() throws Exception {
+        mockMvc.perform(get("/api/advisor/requests"))
+                .andExpect(status().is4xxClientError());
+    }
+
+    /** Test 4 — student token → 403 */
+    @Test
+    @Order(4)
+    void listRequests_studentToken_returns403() throws Exception {
+        mockMvc.perform(get("/api/advisor/requests")
+                .header("Authorization", "Bearer " + studentToken))
+                .andExpect(status().isForbidden());
+    }
+
+    /** Test 5 — coordinator token → 403 */
+    @Test
+    @Order(5)
+    void listRequests_coordinatorToken_returns403() throws Exception {
+        mockMvc.perform(get("/api/advisor/requests")
+                .header("Authorization", "Bearer " + coordinatorToken))
+                .andExpect(status().isForbidden());
+    }
+
+    // =========================================================================
+    // GET /api/advisor/requests/{requestId}
+    // =========================================================================
+
+    /** Test 6 — professor fetches their own request detail */
+    @Test
+    @Order(6)
+    void getRequestDetail_ownRequest_returns200WithDetail() throws Exception {
+        AdvisorRequest req = advisorRequestRepository.save(pendingRequest(toolsBoundGroup, professor));
+
+        mockMvc.perform(get("/api/advisor/requests/{id}", req.getId())
+                .header("Authorization", "Bearer " + professorToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.requestId").value(req.getId().toString()))
+                .andExpect(jsonPath("$.group.id").value(toolsBoundGroup.getId().toString()))
+                .andExpect(jsonPath("$.group.groupName").value("Alpha Team"))
+                .andExpect(jsonPath("$.group.termId").value(TERM_ID))
+                .andExpect(jsonPath("$.group.status").value("TOOLS_BOUND"))
+                .andExpect(jsonPath("$.group.members").isArray())
+                .andExpect(jsonPath("$.sentAt").exists());
+    }
+
+    /** Test 7 — professor fetches another professor's request → 403 */
+    @Test
+    @Order(7)
+    void getRequestDetail_otherProfessorsRequest_returns403() throws Exception {
+        StaffUser otherProf = staffUserRepository.save(newProfessor("other@test.com", 5));
+        AdvisorRequest req = advisorRequestRepository.save(pendingRequest(toolsBoundGroup, otherProf));
+
+        mockMvc.perform(get("/api/advisor/requests/{id}", req.getId())
+                .header("Authorization", "Bearer " + professorToken))
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.message").exists());
+    }
+
+    /** Test 8 — request does not exist → 404 */
+    @Test
+    @Order(8)
+    void getRequestDetail_nonExistentId_returns404() throws Exception {
+        mockMvc.perform(get("/api/advisor/requests/{id}", UUID.randomUUID())
+                .header("Authorization", "Bearer " + professorToken))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.message").exists());
+    }
+
+    /** Test 9 — no token → rejected */
+    @Test
+    @Order(9)
+    void getRequestDetail_noToken_isRejected() throws Exception {
+        mockMvc.perform(get("/api/advisor/requests/{id}", UUID.randomUUID()))
+                .andExpect(status().is4xxClientError());
+    }
+
+    // =========================================================================
+    // PATCH /api/advisor/requests/{requestId}/respond
+    // =========================================================================
+
+    /** Test 10 — accept: group becomes ADVISOR_ASSIGNED, request ACCEPTED */
+    @Test
+    @Order(10)
+    void respond_accept_returns200AndUpdatesDb() throws Exception {
+        AdvisorRequest req = advisorRequestRepository.save(pendingRequest(toolsBoundGroup, professor));
+
+        mockMvc.perform(patch("/api/advisor/requests/{id}/respond", req.getId())
+                .header("Authorization", "Bearer " + professorToken)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(respondBody(true)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.requestId").value(req.getId().toString()))
+                .andExpect(jsonPath("$.status").value("ACCEPTED"))
+                .andExpect(jsonPath("$.groupId").value(toolsBoundGroup.getId().toString()))
+                .andExpect(jsonPath("$.groupStatus").value("ADVISOR_ASSIGNED"));
+
+        // DB: group status and advisor must be updated
+        ProjectGroup updated = projectGroupRepository.findById(toolsBoundGroup.getId()).orElseThrow();
+        assertThat(updated.getStatus()).isEqualTo(GroupStatus.ADVISOR_ASSIGNED);
+        assertThat(updated.getAdvisor().getId()).isEqualTo(professor.getId());
+    }
+
+    /** Test 11 — reject: request REJECTED, group stays TOOLS_BOUND */
+    @Test
+    @Order(11)
+    void respond_reject_returns200AndGroupStatusUnchanged() throws Exception {
+        AdvisorRequest req = advisorRequestRepository.save(pendingRequest(toolsBoundGroup, professor));
+
+        mockMvc.perform(patch("/api/advisor/requests/{id}/respond", req.getId())
+                .header("Authorization", "Bearer " + professorToken)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(respondBody(false)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.requestId").value(req.getId().toString()))
+                .andExpect(jsonPath("$.status").value("REJECTED"));
+
+        // DB: group must remain TOOLS_BOUND, no advisor set
+        ProjectGroup unchanged = projectGroupRepository.findById(toolsBoundGroup.getId()).orElseThrow();
+        assertThat(unchanged.getStatus()).isEqualTo(GroupStatus.TOOLS_BOUND);
+        assertThat(unchanged.getAdvisor()).isNull();
+    }
+
+    /** Test 12 — non-existent request → 404 */
+    @Test
+    @Order(12)
+    void respond_nonExistentRequest_returns404() throws Exception {
+        mockMvc.perform(patch("/api/advisor/requests/{id}/respond", UUID.randomUUID())
+                .header("Authorization", "Bearer " + professorToken)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(respondBody(true)))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.message").exists());
+    }
+
+    /** Test 13 — professor tries to respond to another professor's request → 403 */
+    @Test
+    @Order(13)
+    void respond_otherProfessorsRequest_returns403() throws Exception {
+        StaffUser otherProf = staffUserRepository.save(newProfessor("other2@test.com", 5));
+        AdvisorRequest req = advisorRequestRepository.save(pendingRequest(toolsBoundGroup, otherProf));
+
+        mockMvc.perform(patch("/api/advisor/requests/{id}/respond", req.getId())
+                .header("Authorization", "Bearer " + professorToken)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(respondBody(true)))
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.message").exists());
+    }
+
+    /** Test 14 — request already REJECTED → 400 */
+    @Test
+    @Order(14)
+    void respond_alreadyRejectedRequest_returns400() throws Exception {
+        AdvisorRequest req = pendingRequest(toolsBoundGroup, professor);
+        req.setStatus(RequestStatus.REJECTED);
+        req.setRespondedAt(LocalDateTime.now(ZoneId.of("UTC")));
+        advisorRequestRepository.save(req);
+
+        mockMvc.perform(patch("/api/advisor/requests/{id}/respond", req.getId())
+                .header("Authorization", "Bearer " + professorToken)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(respondBody(true)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.message").exists());
+    }
+
+    /** Test 15 — request already ACCEPTED → 400 */
+    @Test
+    @Order(15)
+    void respond_alreadyAcceptedRequest_returns400() throws Exception {
+        AdvisorRequest req = pendingRequest(toolsBoundGroup, professor);
+        req.setStatus(RequestStatus.ACCEPTED);
+        req.setRespondedAt(LocalDateTime.now(ZoneId.of("UTC")));
+        advisorRequestRepository.save(req);
+
+        mockMvc.perform(patch("/api/advisor/requests/{id}/respond", req.getId())
+                .header("Authorization", "Bearer " + professorToken)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(respondBody(true)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.message").exists());
+    }
+
+    /** Test 16 — professor is at capacity → 400 */
+    @Test
+    @Order(16)
+    void respond_accept_professorAtCapacity_returns400() throws Exception {
+        // Set professor capacity to 1
+        professor.setAdvisorCapacity(1);
+        staffUserRepository.save(professor);
+
+        // Assign one group already (fills the capacity)
+        ProjectGroup occupiedGroup = projectGroupRepository.save(newGroup("Occupied Group", GroupStatus.ADVISOR_ASSIGNED));
+        occupiedGroup.setAdvisor(professor);
+        projectGroupRepository.save(occupiedGroup);
+
+        // New pending request on a different group
+        AdvisorRequest req = advisorRequestRepository.save(pendingRequest(toolsBoundGroup, professor));
+
+        mockMvc.perform(patch("/api/advisor/requests/{id}/respond", req.getId())
+                .header("Authorization", "Bearer " + professorToken)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(respondBody(true)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.message").exists());
+
+        // Group must remain TOOLS_BOUND
+        assertThat(projectGroupRepository.findById(toolsBoundGroup.getId()).orElseThrow().getStatus())
+                .isEqualTo(GroupStatus.TOOLS_BOUND);
+    }
+
+    /**
+     * Test 17 — accept: other PENDING requests for the same group become AUTO_REJECTED.
+     * Simulates two advisors receiving requests for the same group; first one to accept
+     * must auto-reject the other.
+     */
+    @Test
+    @Order(17)
+    void respond_accept_autoRejectsOtherPendingRequestsForSameGroup() throws Exception {
+        StaffUser secondProfessor = staffUserRepository.save(newProfessor("prof2@test.com", 5));
+
+        AdvisorRequest req1 = advisorRequestRepository.save(pendingRequest(toolsBoundGroup, professor));
+        AdvisorRequest req2 = advisorRequestRepository.save(pendingRequest(toolsBoundGroup, secondProfessor));
+
+        // Professor 1 accepts
+        mockMvc.perform(patch("/api/advisor/requests/{id}/respond", req1.getId())
+                .header("Authorization", "Bearer " + professorToken)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(respondBody(true)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value("ACCEPTED"));
+
+        // req2 must now be AUTO_REJECTED in the DB
+        AdvisorRequest req2Updated = advisorRequestRepository.findById(req2.getId()).orElseThrow();
+        assertThat(req2Updated.getStatus()).isEqualTo(RequestStatus.AUTO_REJECTED);
+
+        // No PENDING requests remain for the group
+        List<AdvisorRequest> remaining = advisorRequestRepository.findByGroupId(toolsBoundGroup.getId());
+        assertThat(remaining).noneMatch(r -> r.getStatus() == RequestStatus.PENDING);
+    }
+
+    /** Test 18 — reject: group status and other requests are completely unaffected */
+    @Test
+    @Order(18)
+    void respond_reject_doesNotAffectOtherRequestsOrGroupStatus() throws Exception {
+        StaffUser secondProfessor = staffUserRepository.save(newProfessor("prof3@test.com", 5));
+
+        AdvisorRequest req1 = advisorRequestRepository.save(pendingRequest(toolsBoundGroup, professor));
+        AdvisorRequest req2 = advisorRequestRepository.save(pendingRequest(toolsBoundGroup, secondProfessor));
+
+        // Professor 1 rejects
+        mockMvc.perform(patch("/api/advisor/requests/{id}/respond", req1.getId())
+                .header("Authorization", "Bearer " + professorToken)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(respondBody(false)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value("REJECTED"));
+
+        // req2 must still be PENDING
+        assertThat(advisorRequestRepository.findById(req2.getId()).orElseThrow().getStatus())
+                .isEqualTo(RequestStatus.PENDING);
+
+        // Group status must remain TOOLS_BOUND
+        assertThat(projectGroupRepository.findById(toolsBoundGroup.getId()).orElseThrow().getStatus())
+                .isEqualTo(GroupStatus.TOOLS_BOUND);
+    }
+
+    /** Test 19 — no token → rejected */
+    @Test
+    @Order(19)
+    void respond_noToken_isRejected() throws Exception {
+        AdvisorRequest req = advisorRequestRepository.save(pendingRequest(toolsBoundGroup, professor));
+
+        mockMvc.perform(patch("/api/advisor/requests/{id}/respond", req.getId())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(respondBody(true)))
+                .andExpect(status().is4xxClientError());
+    }
+
+    /** Test 20 — student token → 403 */
+    @Test
+    @Order(20)
+    void respond_studentToken_returns403() throws Exception {
+        AdvisorRequest req = advisorRequestRepository.save(pendingRequest(toolsBoundGroup, professor));
+
+        mockMvc.perform(patch("/api/advisor/requests/{id}/respond", req.getId())
+                .header("Authorization", "Bearer " + studentToken)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(respondBody(true)))
+                .andExpect(status().isForbidden());
+    }
+
+    // =========================================================================
+    // Helpers
+    // =========================================================================
+
+    private StaffUser newProfessor(String mail, int capacity) {
+        StaffUser u = new StaffUser();
+        u.setMail(mail);
+        u.setPasswordHash("$2a$10$dXJ3SW6G7P50lGmMkkmwe.20cQQubK3.HZWzG3YB1tlRy.fqvM/BG");
+        u.setRole(Role.Professor);
+        u.setAdvisorCapacity(capacity);
+        return u;
+    }
+
+    private StaffUser newCoordinator(String mail) {
+        StaffUser u = new StaffUser();
+        u.setMail(mail);
+        u.setPasswordHash("$2a$10$dXJ3SW6G7P50lGmMkkmwe.20cQQubK3.HZWzG3YB1tlRy.fqvM/BG");
+        u.setRole(Role.Coordinator);
+        return u;
+    }
+
+    private Student newStudent(String studentId, String githubUsername) {
+        Student s = new Student();
+        s.setStudentId(studentId);
+        s.setGithubUsername(githubUsername);
+        return s;
+    }
+
+    private ProjectGroup newGroup(String name, GroupStatus status) {
+        ProjectGroup g = new ProjectGroup();
+        g.setGroupName(name);
+        g.setTermId(TERM_ID);
+        g.setStatus(status);
+        g.setCreatedAt(LocalDateTime.now(ZoneId.of("UTC")));
+        return g;
+    }
+
+    private GroupMembership newMembership(Student s, ProjectGroup g, MemberRole role) {
+        GroupMembership m = new GroupMembership();
+        m.setStudent(s);
+        m.setGroup(g);
+        m.setRole(role);
+        m.setJoinedAt(LocalDateTime.now(ZoneId.of("UTC")));
+        return m;
+    }
+
+    private AdvisorRequest pendingRequest(ProjectGroup group, StaffUser advisor) {
+        AdvisorRequest r = new AdvisorRequest();
+        r.setGroup(group);
+        r.setAdvisor(advisor);
+        r.setStatus(RequestStatus.PENDING);
+        r.setSentAt(LocalDateTime.now(ZoneId.of("UTC")));
+        return r;
+    }
+
+    private String respondBody(boolean accept) throws Exception {
+        return objectMapper.writeValueAsString(Map.of("accept", accept));
+    }
+}

--- a/backend/src/test/java/com/senior/spm/AdvisorControllerIntegrationTest.java
+++ b/backend/src/test/java/com/senior/spm/AdvisorControllerIntegrationTest.java
@@ -28,6 +28,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.web.servlet.MockMvc;
 
@@ -59,6 +60,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @AutoConfigureMockMvc
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 @TestPropertySource(locations = "classpath:test.properties")
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
 class AdvisorControllerIntegrationTest {
 
     @Autowired MockMvc mockMvc;

--- a/backend/src/test/java/com/senior/spm/CoordinatorGroupOverrideIntegrationTest.java
+++ b/backend/src/test/java/com/senior/spm/CoordinatorGroupOverrideIntegrationTest.java
@@ -28,6 +28,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.web.servlet.MockMvc;
 
@@ -63,6 +64,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @AutoConfigureMockMvc
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 @TestPropertySource(locations = "classpath:test.properties")
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
 class CoordinatorGroupOverrideIntegrationTest {
 
     @Autowired MockMvc mockMvc;

--- a/backend/src/test/java/com/senior/spm/CoordinatorGroupOverrideIntegrationTest.java
+++ b/backend/src/test/java/com/senior/spm/CoordinatorGroupOverrideIntegrationTest.java
@@ -1,0 +1,426 @@
+package com.senior.spm;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.senior.spm.entity.GroupInvitation;
+import com.senior.spm.entity.GroupInvitation.InvitationStatus;
+import com.senior.spm.entity.GroupMembership;
+import com.senior.spm.entity.GroupMembership.MemberRole;
+import com.senior.spm.entity.ProjectGroup;
+import com.senior.spm.entity.ProjectGroup.GroupStatus;
+import com.senior.spm.entity.StaffUser;
+import com.senior.spm.entity.StaffUser.Role;
+import com.senior.spm.entity.Student;
+import com.senior.spm.entity.SystemConfig;
+import com.senior.spm.repository.AdvisorRequestRepository;
+import com.senior.spm.repository.GroupInvitationRepository;
+import com.senior.spm.repository.GroupMembershipRepository;
+import com.senior.spm.repository.ProjectGroupRepository;
+import com.senior.spm.repository.StaffUserRepository;
+import com.senior.spm.repository.StudentRepository;
+import com.senior.spm.repository.SystemConfigRepository;
+import com.senior.spm.service.JWTService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * Black-box integration tests for coordinator group override operations (DFD 2.6).
+ *
+ * All 15 tests pass green against the full Spring Boot context and H2 in-memory DB.
+ *
+ * Endpoints covered:
+ *   PATCH /api/coordinator/groups/{groupId}/members  (ADD / REMOVE)
+ *   PATCH /api/coordinator/groups/{groupId}/disband
+ *
+ * Acceptance criteria verified:
+ *   - Disband confirms DB cascading: memberships hard-deleted, outbound invitations AUTO_DENIED.
+ *   - Non-Coordinator roles (Professor, Admin) receive strict 403.
+ *   - DB query confirms AUTO_DENIED on all competing invitations after force-add.
+ *   - Force-add at capacity returns 400.
+ *
+ * References: Process 2 / DFD 2.6
+ */
+@SpringBootTest
+@AutoConfigureMockMvc
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+@TestPropertySource(locations = "classpath:test.properties")
+class CoordinatorGroupOverrideIntegrationTest {
+
+    @Autowired MockMvc mockMvc;
+    @Autowired ObjectMapper objectMapper;
+    @Autowired JWTService jwtService;
+
+    @Autowired StaffUserRepository staffUserRepository;
+    @Autowired StudentRepository studentRepository;
+    @Autowired SystemConfigRepository systemConfigRepository;
+    @Autowired ProjectGroupRepository projectGroupRepository;
+    @Autowired GroupMembershipRepository groupMembershipRepository;
+    @Autowired GroupInvitationRepository groupInvitationRepository;
+    @Autowired AdvisorRequestRepository advisorRequestRepository;
+
+    private static final String TERM_ID = "2026-SPRING-TEST";
+    private static final int MAX_TEAM_SIZE = 5;
+
+    private StaffUser coordinator;
+    private StaffUser professor;
+    private StaffUser admin;
+
+    private Student teamLeader;
+    private Student member;
+    private Student outsider; // free student — not in any group
+
+    private ProjectGroup group;
+
+    private String coordinatorToken;
+    private String professorToken;
+    private String adminToken;
+
+    @BeforeEach
+    void setUp() {
+        // FK-safe teardown
+        advisorRequestRepository.deleteAll();
+        groupInvitationRepository.deleteAll();
+        groupMembershipRepository.deleteAll();
+        projectGroupRepository.deleteAll();
+        studentRepository.deleteAll();
+        staffUserRepository.deleteAll();
+        systemConfigRepository.deleteAll();
+
+        // System config
+        systemConfigRepository.save(config("active_term_id", TERM_ID));
+        systemConfigRepository.save(config("max_team_size", String.valueOf(MAX_TEAM_SIZE)));
+
+        // Staff users
+        coordinator = staffUserRepository.save(newStaff("coord@test.com", Role.Coordinator));
+        professor   = staffUserRepository.save(newStaff("prof@test.com",  Role.Professor));
+        admin       = staffUserRepository.save(newStaff("admin@test.com", Role.Admin));
+
+        // Students
+        teamLeader = studentRepository.save(newStudent("12345678901", "gh-leader"));
+        member     = studentRepository.save(newStudent("12345678902", "gh-member"));
+        outsider   = studentRepository.save(newStudent("12345678903", "gh-outsider"));
+
+        // Group with two members (teamLeader + member)
+        group = projectGroupRepository.save(newGroup("Alpha Team", GroupStatus.FORMING));
+        groupMembershipRepository.save(newMembership(teamLeader, group, MemberRole.TEAM_LEADER));
+        groupMembershipRepository.save(newMembership(member, group, MemberRole.MEMBER));
+
+        // Tokens
+        coordinatorToken = jwtService.issueToken(coordinator);
+        professorToken   = jwtService.issueToken(professor);
+        adminToken       = jwtService.issueToken(admin);
+    }
+
+    // =========================================================================
+    // PATCH /api/coordinator/groups/{groupId}/members — ADD
+    // =========================================================================
+
+    /** Test 1 — successful force-add returns 200 and student is persisted in group */
+    @Test
+    @Order(1)
+    void forceAdd_validStudent_returns200AndMembershipCreated() throws Exception {
+        mockMvc.perform(patch("/api/coordinator/groups/{id}/members", group.getId())
+                .header("Authorization", "Bearer " + coordinatorToken)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(memberBody("ADD", outsider.getStudentId())))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value(group.getId().toString()))
+                .andExpect(jsonPath("$.groupName").value("Alpha Team"));
+
+        assertThat(groupMembershipRepository.countByGroupId(group.getId())).isEqualTo(3);
+    }
+
+    /**
+     * Test 2 — force-add auto-denies all PENDING invitations addressed to the added student.
+     * Direct DB query confirms no PENDING rows remain for that student.
+     */
+    @Test
+    @Order(2)
+    void forceAdd_autoDeniesAllPendingInvitationsForAddedStudent() throws Exception {
+        // outsider has two PENDING invitations from two other groups
+        ProjectGroup beta  = projectGroupRepository.save(newGroup("Beta Team",  GroupStatus.FORMING));
+        ProjectGroup gamma = projectGroupRepository.save(newGroup("Gamma Team", GroupStatus.FORMING));
+        groupInvitationRepository.save(pendingInvitation(beta,  outsider));
+        groupInvitationRepository.save(pendingInvitation(gamma, outsider));
+
+        mockMvc.perform(patch("/api/coordinator/groups/{id}/members", group.getId())
+                .header("Authorization", "Bearer " + coordinatorToken)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(memberBody("ADD", outsider.getStudentId())))
+                .andExpect(status().isOk());
+
+        // DB: every invitation targeting outsider must be AUTO_DENIED — none may remain PENDING
+        List<GroupInvitation> invitations = groupInvitationRepository.findByInviteeId(outsider.getId());
+        assertThat(invitations).isNotEmpty();
+        assertThat(invitations).allMatch(i -> i.getStatus() == InvitationStatus.AUTO_DENIED);
+    }
+
+    /**
+     * Test 3 — force-add returns 400 when group is at max capacity.
+     * Capacity = currentMembers (2) + pendingInvitations (3) = MAX_TEAM_SIZE (5).
+     */
+    @Test
+    @Order(3)
+    void forceAdd_groupAtMaxCapacity_returns400() throws Exception {
+        // currentMembers=2; need (MAX_TEAM_SIZE - 2) pending invitations to hit the cap
+        for (int i = 4; i < 4 + (MAX_TEAM_SIZE - 2); i++) {
+            Student filler = studentRepository.save(newStudent("1234567890" + i, "gh-filler" + i));
+            groupInvitationRepository.save(pendingInvitation(group, filler));
+        }
+
+        mockMvc.perform(patch("/api/coordinator/groups/{id}/members", group.getId())
+                .header("Authorization", "Bearer " + coordinatorToken)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(memberBody("ADD", outsider.getStudentId())))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.message").exists());
+    }
+
+    /** Test 4 — force-add a student already in a group returns 400 */
+    @Test
+    @Order(4)
+    void forceAdd_studentAlreadyInGroup_returns400() throws Exception {
+        mockMvc.perform(patch("/api/coordinator/groups/{id}/members", group.getId())
+                .header("Authorization", "Bearer " + coordinatorToken)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(memberBody("ADD", member.getStudentId())))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.message").exists());
+    }
+
+    // =========================================================================
+    // PATCH /api/coordinator/groups/{groupId}/members — REMOVE
+    // =========================================================================
+
+    /** Test 5 — successful force-remove of a regular MEMBER returns 200 */
+    @Test
+    @Order(5)
+    void forceRemove_regularMember_returns200AndMembershipDeleted() throws Exception {
+        mockMvc.perform(patch("/api/coordinator/groups/{id}/members", group.getId())
+                .header("Authorization", "Bearer " + coordinatorToken)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(memberBody("REMOVE", member.getStudentId())))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value(group.getId().toString()));
+
+        assertThat(groupMembershipRepository.countByGroupId(group.getId())).isEqualTo(1);
+    }
+
+    /**
+     * Test 6 — TEAM_LEADER removal is blocked with 400.
+     * Leadership must be transferred before the leader can be removed.
+     * DB confirms the TEAM_LEADER is still in the group.
+     */
+    @Test
+    @Order(6)
+    void forceRemove_teamLeader_returns400AndLeaderRemainsInGroup() throws Exception {
+        mockMvc.perform(patch("/api/coordinator/groups/{id}/members", group.getId())
+                .header("Authorization", "Bearer " + coordinatorToken)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(memberBody("REMOVE", teamLeader.getStudentId())))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.message").exists());
+
+        // DB: count unchanged — TEAM_LEADER was not removed
+        assertThat(groupMembershipRepository.countByGroupId(group.getId())).isEqualTo(2);
+    }
+
+    /** Test 7 — removing a student not in the group returns 404 */
+    @Test
+    @Order(7)
+    void forceRemove_studentNotInGroup_returns404() throws Exception {
+        mockMvc.perform(patch("/api/coordinator/groups/{id}/members", group.getId())
+                .header("Authorization", "Bearer " + coordinatorToken)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(memberBody("REMOVE", outsider.getStudentId())))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.message").exists());
+    }
+
+    // =========================================================================
+    // PATCH /api/coordinator/groups/{groupId}/disband
+    // =========================================================================
+
+    /**
+     * Test 8 — successful disband returns 200, sets group to DISBANDED, hard-deletes all
+     * memberships, and auto-denies all PENDING outbound invitations.
+     * DB assertions confirm full cascade.
+     */
+    @Test
+    @Order(8)
+    void disband_success_returns200AndCascadesInDb() throws Exception {
+        // One PENDING outbound invitation from the group
+        groupInvitationRepository.save(pendingInvitation(group, outsider));
+
+        mockMvc.perform(patch("/api/coordinator/groups/{id}/disband", group.getId())
+                .header("Authorization", "Bearer " + coordinatorToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value(group.getId().toString()))
+                .andExpect(jsonPath("$.status").value("DISBANDED"));
+
+        // DB: group status
+        ProjectGroup disbanded = projectGroupRepository.findById(group.getId()).orElseThrow();
+        assertThat(disbanded.getStatus()).isEqualTo(GroupStatus.DISBANDED);
+
+        // DB: memberships hard-deleted
+        assertThat(groupMembershipRepository.countByGroupId(group.getId())).isZero();
+
+        // DB: outbound invitations AUTO_DENIED
+        List<GroupInvitation> invitations = groupInvitationRepository.findByGroupId(group.getId());
+        assertThat(invitations).isNotEmpty();
+        assertThat(invitations).allMatch(i -> i.getStatus() == InvitationStatus.AUTO_DENIED);
+    }
+
+    /** Test 9 — disbanding an already-disbanded group returns 400 */
+    @Test
+    @Order(9)
+    void disband_alreadyDisbanded_returns400() throws Exception {
+        group.setStatus(GroupStatus.DISBANDED);
+        projectGroupRepository.save(group);
+
+        mockMvc.perform(patch("/api/coordinator/groups/{id}/disband", group.getId())
+                .header("Authorization", "Bearer " + coordinatorToken))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.message").exists());
+    }
+
+    /** Test 10 — disbanding a non-existent group returns 404 */
+    @Test
+    @Order(10)
+    void disband_nonExistentGroup_returns404() throws Exception {
+        mockMvc.perform(patch("/api/coordinator/groups/{id}/disband", UUID.randomUUID())
+                .header("Authorization", "Bearer " + coordinatorToken))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.message").exists());
+    }
+
+    // =========================================================================
+    // RBAC — strict 403 for non-Coordinator roles
+    // =========================================================================
+
+    /** Test 11 — Professor token on members endpoint → 403 */
+    @Test
+    @Order(11)
+    void memberManagement_professorToken_returns403() throws Exception {
+        mockMvc.perform(patch("/api/coordinator/groups/{id}/members", group.getId())
+                .header("Authorization", "Bearer " + professorToken)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(memberBody("ADD", outsider.getStudentId())))
+                .andExpect(status().isForbidden());
+    }
+
+    /** Test 12 — Admin token on members endpoint → 403 */
+    @Test
+    @Order(12)
+    void memberManagement_adminToken_returns403() throws Exception {
+        mockMvc.perform(patch("/api/coordinator/groups/{id}/members", group.getId())
+                .header("Authorization", "Bearer " + adminToken)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(memberBody("ADD", outsider.getStudentId())))
+                .andExpect(status().isForbidden());
+    }
+
+    /** Test 13 — No token on members endpoint → 4xx */
+    @Test
+    @Order(13)
+    void memberManagement_noToken_isRejected() throws Exception {
+        mockMvc.perform(patch("/api/coordinator/groups/{id}/members", group.getId())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(memberBody("ADD", outsider.getStudentId())))
+                .andExpect(status().is4xxClientError());
+    }
+
+    /** Test 14 — Professor token on disband endpoint → 403 */
+    @Test
+    @Order(14)
+    void disband_professorToken_returns403() throws Exception {
+        mockMvc.perform(patch("/api/coordinator/groups/{id}/disband", group.getId())
+                .header("Authorization", "Bearer " + professorToken))
+                .andExpect(status().isForbidden());
+    }
+
+    /** Test 15 — Admin token on disband endpoint → 403 */
+    @Test
+    @Order(15)
+    void disband_adminToken_returns403() throws Exception {
+        mockMvc.perform(patch("/api/coordinator/groups/{id}/disband", group.getId())
+                .header("Authorization", "Bearer " + adminToken))
+                .andExpect(status().isForbidden());
+    }
+
+    // =========================================================================
+    // Helpers
+    // =========================================================================
+
+    private SystemConfig config(String key, String value) {
+        SystemConfig c = new SystemConfig();
+        c.setConfigKey(key);
+        c.setConfigValue(value);
+        return c;
+    }
+
+    private StaffUser newStaff(String mail, Role role) {
+        StaffUser u = new StaffUser();
+        u.setMail(mail);
+        u.setPasswordHash("$2a$10$dXJ3SW6G7P50lGmMkkmwe.20cQQubK3.HZWzG3YB1tlRy.fqvM/BG");
+        u.setRole(role);
+        return u;
+    }
+
+    private Student newStudent(String studentId, String githubUsername) {
+        Student s = new Student();
+        s.setStudentId(studentId);
+        s.setGithubUsername(githubUsername);
+        return s;
+    }
+
+    private ProjectGroup newGroup(String name, GroupStatus status) {
+        ProjectGroup g = new ProjectGroup();
+        g.setGroupName(name);
+        g.setTermId(TERM_ID);
+        g.setStatus(status);
+        g.setCreatedAt(LocalDateTime.now(ZoneId.of("UTC")));
+        return g;
+    }
+
+    private GroupMembership newMembership(Student s, ProjectGroup g, MemberRole role) {
+        GroupMembership m = new GroupMembership();
+        m.setStudent(s);
+        m.setGroup(g);
+        m.setRole(role);
+        m.setJoinedAt(LocalDateTime.now(ZoneId.of("UTC")));
+        return m;
+    }
+
+    private GroupInvitation pendingInvitation(ProjectGroup g, Student invitee) {
+        GroupInvitation inv = new GroupInvitation();
+        inv.setGroup(g);
+        inv.setInvitee(invitee);
+        inv.setStatus(InvitationStatus.PENDING);
+        inv.setSentAt(LocalDateTime.now(ZoneId.of("UTC")));
+        return inv;
+    }
+
+    private String memberBody(String action, String studentId) throws Exception {
+        return objectMapper.writeValueAsString(Map.of("action", action, "studentId", studentId));
+    }
+}

--- a/backend/src/test/java/com/senior/spm/GroupCreationIntegrationTest.java
+++ b/backend/src/test/java/com/senior/spm/GroupCreationIntegrationTest.java
@@ -1,0 +1,298 @@
+package com.senior.spm;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.senior.spm.entity.GroupMembership;
+import com.senior.spm.entity.GroupMembership.MemberRole;
+import com.senior.spm.entity.ProjectGroup;
+import com.senior.spm.entity.ProjectGroup.GroupStatus;
+import com.senior.spm.entity.ScheduleWindow;
+import com.senior.spm.entity.ScheduleWindow.WindowType;
+import com.senior.spm.entity.Student;
+import com.senior.spm.entity.SystemConfig;
+import com.senior.spm.repository.AdvisorRequestRepository;
+import com.senior.spm.repository.GroupInvitationRepository;
+import com.senior.spm.repository.GroupMembershipRepository;
+import com.senior.spm.repository.ProjectGroupRepository;
+import com.senior.spm.repository.ScheduleWindowRepository;
+import com.senior.spm.repository.StudentRepository;
+import com.senior.spm.repository.SystemConfigRepository;
+import com.senior.spm.service.JWTService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * End-to-end integration tests for POST /api/groups (group creation).
+ *
+ * Covers: happy path DB integrity, all closed-window variants (no window, not yet open,
+ * expired), duplicate group name, student already in a group, and unauthenticated access.
+ *
+ * References: Process 2 – DFD 2.1 (Group Creation & Schedule Window Enforcement).
+ */
+@SpringBootTest
+@AutoConfigureMockMvc
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+@TestPropertySource(locations = "classpath:test.properties")
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+class GroupCreationIntegrationTest {
+
+    @Autowired MockMvc mockMvc;
+    @Autowired ObjectMapper objectMapper;
+    @Autowired JWTService jwtService;
+
+    @Autowired StudentRepository studentRepository;
+    @Autowired SystemConfigRepository systemConfigRepository;
+    @Autowired ScheduleWindowRepository scheduleWindowRepository;
+    @Autowired ProjectGroupRepository projectGroupRepository;
+    @Autowired GroupMembershipRepository groupMembershipRepository;
+    @Autowired GroupInvitationRepository groupInvitationRepository;
+    @Autowired AdvisorRequestRepository advisorRequestRepository;
+
+    private static final String TERM_ID = "2026-SPRING-TEST";
+
+    private Student testStudent;
+    private String studentToken;
+
+    @BeforeEach
+    void setUp() {
+        // Delete in FK-safe order so constraints don't block teardown between tests
+        advisorRequestRepository.deleteAll();
+        groupInvitationRepository.deleteAll();
+        groupMembershipRepository.deleteAll();
+        projectGroupRepository.deleteAll();
+        studentRepository.deleteAll();
+        scheduleWindowRepository.deleteAll();
+        systemConfigRepository.deleteAll();
+
+        // Seed the minimum system config that GroupService requires
+        SystemConfig termConfig = new SystemConfig();
+        termConfig.setConfigKey("active_term_id");
+        termConfig.setConfigValue(TERM_ID);
+        systemConfigRepository.save(termConfig);
+
+        // Persist a student and issue a JWT for them
+        testStudent = new Student();
+        testStudent.setStudentId("12345678901");
+        testStudent.setGithubUsername("test-gh-user");
+        testStudent = studentRepository.save(testStudent);
+
+        studentToken = jwtService.issueToken(testStudent);
+    }
+
+    // ─── Happy Path ───────────────────────────────────────────────────────────
+
+    /**
+     * AC: A student inside an active window gets 201 and both ProjectGroup and
+     * GroupMembership rows land in the DB with correct values.
+     */
+    @Test
+    @Order(1)
+    void createGroup_withinActiveWindow_returns201AndPersistsRecords() throws Exception {
+        openWindow();
+
+        mockMvc.perform(post("/api/groups")
+                .header("Authorization", "Bearer " + studentToken)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(body("Alpha Team")))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.groupName").value("Alpha Team"))
+                .andExpect(jsonPath("$.status").value("FORMING"))
+                .andExpect(jsonPath("$.termId").value(TERM_ID))
+                .andExpect(jsonPath("$.members[0].role").value("TEAM_LEADER"));
+
+        // Verify ProjectGroup record
+        List<ProjectGroup> groups = projectGroupRepository.findAll();
+        assertThat(groups).hasSize(1);
+        assertThat(groups.get(0).getGroupName()).isEqualTo("Alpha Team");
+        assertThat(groups.get(0).getStatus()).isEqualTo(GroupStatus.FORMING);
+        assertThat(groups.get(0).getTermId()).isEqualTo(TERM_ID);
+
+        // Verify GroupMembership record — creator must be TEAM_LEADER
+        List<GroupMembership> memberships = groupMembershipRepository.findAll();
+        assertThat(memberships).hasSize(1);
+        assertThat(memberships.get(0).getRole()).isEqualTo(MemberRole.TEAM_LEADER);
+        assertThat(memberships.get(0).getStudent().getId()).isEqualTo(testStudent.getId());
+        assertThat(memberships.get(0).getGroup().getId()).isEqualTo(groups.get(0).getId());
+    }
+
+    // ─── Closed-Window Scenarios (AC: must all produce 400) ──────────────────
+
+    /**
+     * No ScheduleWindow row exists for the current term → 400.
+     */
+    @Test
+    @Order(2)
+    void createGroup_noWindowExists_returns400() throws Exception {
+        mockMvc.perform(post("/api/groups")
+                .header("Authorization", "Bearer " + studentToken)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(body("Beta Team")))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.message").exists());
+
+        assertThat(projectGroupRepository.count()).isZero();
+    }
+
+    /**
+     * Window exists but opensAt is in the future → 400.
+     */
+    @Test
+    @Order(3)
+    void createGroup_windowNotYetOpen_returns400() throws Exception {
+        saveWindow(
+                LocalDateTime.now(ZoneId.of("UTC")).plusDays(1),
+                LocalDateTime.now(ZoneId.of("UTC")).plusDays(2));
+
+        mockMvc.perform(post("/api/groups")
+                .header("Authorization", "Bearer " + studentToken)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(body("Gamma Team")))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.message").exists());
+
+        assertThat(projectGroupRepository.count()).isZero();
+    }
+
+    /**
+     * Window existed but closesAt is in the past → 400.
+     */
+    @Test
+    @Order(4)
+    void createGroup_windowExpired_returns400() throws Exception {
+        saveWindow(
+                LocalDateTime.now(ZoneId.of("UTC")).minusDays(2),
+                LocalDateTime.now(ZoneId.of("UTC")).minusDays(1));
+
+        mockMvc.perform(post("/api/groups")
+                .header("Authorization", "Bearer " + studentToken)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(body("Delta Team")))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.message").exists());
+
+        assertThat(projectGroupRepository.count()).isZero();
+    }
+
+    // ─── Business-Rule Violations ─────────────────────────────────────────────
+
+    /**
+     * A group with the same name already exists in the same term → 409 Conflict.
+     * No second group row must appear in the DB.
+     */
+    @Test
+    @Order(5)
+    void createGroup_duplicateName_returns409() throws Exception {
+        openWindow();
+
+        // Pre-seed a group occupying the name
+        ProjectGroup existing = new ProjectGroup();
+        existing.setGroupName("Taken Name");
+        existing.setTermId(TERM_ID);
+        existing.setStatus(GroupStatus.FORMING);
+        existing.setCreatedAt(LocalDateTime.now(ZoneId.of("UTC")));
+        projectGroupRepository.save(existing);
+
+        mockMvc.perform(post("/api/groups")
+                .header("Authorization", "Bearer " + studentToken)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(body("Taken Name")))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.message").exists());
+
+        // Only the pre-seeded group must exist — no second row created
+        assertThat(projectGroupRepository.count()).isEqualTo(1);
+    }
+
+    /**
+     * Student is already a member of another group → 400.
+     * Existing group and membership must be unchanged.
+     */
+    @Test
+    @Order(6)
+    void createGroup_studentAlreadyGrouped_returns400() throws Exception {
+        openWindow();
+
+        // Put testStudent in an existing group
+        ProjectGroup existingGroup = new ProjectGroup();
+        existingGroup.setGroupName("Already Here");
+        existingGroup.setTermId(TERM_ID);
+        existingGroup.setStatus(GroupStatus.FORMING);
+        existingGroup.setCreatedAt(LocalDateTime.now(ZoneId.of("UTC")));
+        ProjectGroup saved = projectGroupRepository.save(existingGroup);
+
+        GroupMembership membership = new GroupMembership();
+        membership.setStudent(testStudent);
+        membership.setGroup(saved);
+        membership.setRole(MemberRole.TEAM_LEADER);
+        membership.setJoinedAt(LocalDateTime.now(ZoneId.of("UTC")));
+        groupMembershipRepository.save(membership);
+
+        mockMvc.perform(post("/api/groups")
+                .header("Authorization", "Bearer " + studentToken)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(body("Second Group")))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.message").exists());
+
+        assertThat(projectGroupRepository.count()).isEqualTo(1);
+        assertThat(groupMembershipRepository.count()).isEqualTo(1);
+    }
+
+    // ─── Authentication ───────────────────────────────────────────────────────
+
+    /**
+     * No Authorization header → endpoint is protected, must be rejected (4xx).
+     */
+    @Test
+    @Order(7)
+    void createGroup_noToken_isRejected() throws Exception {
+        openWindow();
+
+        mockMvc.perform(post("/api/groups")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(body("Unauthorized Team")))
+                .andExpect(status().is4xxClientError());
+
+        assertThat(projectGroupRepository.count()).isZero();
+    }
+
+    // ─── Helpers ─────────────────────────────────────────────────────────────
+
+    private void openWindow() {
+        saveWindow(
+                LocalDateTime.now(ZoneId.of("UTC")).minusHours(1),
+                LocalDateTime.now(ZoneId.of("UTC")).plusHours(1));
+    }
+
+    private void saveWindow(LocalDateTime opensAt, LocalDateTime closesAt) {
+        ScheduleWindow window = new ScheduleWindow();
+        window.setTermId(TERM_ID);
+        window.setType(WindowType.GROUP_CREATION);
+        window.setOpensAt(opensAt);
+        window.setClosesAt(closesAt);
+        scheduleWindowRepository.save(window);
+    }
+
+    private String body(String groupName) throws Exception {
+        return objectMapper.writeValueAsString(Map.of("groupName", groupName));
+    }
+}

--- a/backend/src/test/java/com/senior/spm/README2.md
+++ b/backend/src/test/java/com/senior/spm/README2.md
@@ -1,0 +1,133 @@
+# Integration Tests
+
+## CoordinatorControllerIntegrationTest
+
+Verifies the student upload functionality of the Coordinator setup flow at both API and database level.
+
+### Test Cases
+
+| # | Scenario | Expected |
+|---|----------|----------|
+| 1 | Valid student ID list | 201 Created + records persisted in DB |
+| 2 | Invalid ID format (< 11 digits) | 400 Bad Request |
+| 3 | Duplicate IDs in same request | 400 Bad Request + no records inserted |
+| 4 | Empty student list | 400 Bad Request |
+
+### Technical Notes
+
+* Uses `SpringBootTest`, `MockMvc`, and `WithMockUser(roles = "COORDINATOR")`.
+* `StudentRepository` is used for DB-level verification since the endpoint does not return the inserted count.
+* Database is cleaned before each test for isolation.
+
+---
+
+## AdvisorControllerIntegrationTest
+
+Black-box integration tests for the professor-facing advisor request endpoints (P3-API-02 & P3-API-03).
+All 20 tests pass green against the full Spring Boot context and H2 in-memory DB.
+
+### Endpoints Covered
+
+* `GET  /api/advisor/requests`
+* `GET  /api/advisor/requests/{requestId}`
+* `PATCH /api/advisor/requests/{requestId}/respond`
+
+### Test Cases
+
+#### GET /api/advisor/requests
+
+| Order | Scenario | Expected |
+|-------|----------|----------|
+| 1 | Professor has PENDING requests | 200 + array with requestId, groupId, groupName, termId, memberCount, sentAt |
+| 2 | Professor has no pending requests | 200 + empty array (not 404) |
+| 3 | No token | 4xx |
+| 4 | Student JWT | 403 |
+| 5 | Coordinator JWT | 403 |
+
+#### GET /api/advisor/requests/{requestId}
+
+| Order | Scenario | Expected |
+|-------|----------|----------|
+| 6 | Professor fetches own request | 200 + {requestId, group:{id, groupName, termId, status, members:[...]}, sentAt} |
+| 7 | Professor fetches another professor's request | 403 |
+| 8 | Request does not exist | 404 |
+| 9 | No token | 4xx |
+
+#### PATCH /api/advisor/requests/{requestId}/respond
+
+| Order | Scenario | Expected |
+|-------|----------|----------|
+| 10 | accept: true, professor under capacity | 200 + status: ACCEPTED + DB: group → ADVISOR_ASSIGNED, advisor set |
+| 11 | accept: false | 200 + status: REJECTED + DB: group stays TOOLS_BOUND, no advisor set |
+| 12 | Non-existent request | 404 |
+| 13 | Professor responds to another professor's request | 403 |
+| 14 | Request already REJECTED | 400 |
+| 15 | Request already ACCEPTED | 400 |
+| 16 | Professor at capacity (advisorCapacity=1, 1 group already assigned) | 400 + group stays TOOLS_BOUND |
+| 17 | accept: true, second PENDING request exists for same group | 200 ACCEPTED + DB: other request → AUTO_REJECTED |
+| 18 | accept: false, second PENDING request exists for same group | 200 REJECTED + DB: other request stays PENDING |
+| 19 | No token | 4xx |
+| 20 | Student JWT | 403 |
+
+### Technical Notes
+
+* Uses `SpringBootTest`, `MockMvc`, and real JWT tokens issued via `JWTService`.
+* Repositories are used directly for DB-level assertions on state transitions (group status, advisor assignment, cascade AUTO_REJECT).
+* Database is cleaned before each test via `@BeforeEach` to ensure full isolation.
+* Runs against H2 in-memory DB via `@TestPropertySource(locations = "classpath:test.properties")`.
+
+---
+
+## CoordinatorGroupOverrideIntegrationTest
+
+Black-box integration tests for coordinator group override operations (DFD 2.6).
+All 15 tests pass green against the full Spring Boot context and H2 in-memory DB.
+
+### Endpoints Covered
+
+* `PATCH /api/coordinator/groups/{groupId}/members` (ADD / REMOVE)
+* `PATCH /api/coordinator/groups/{groupId}/disband`
+
+### Test Cases
+
+#### PATCH /api/coordinator/groups/{groupId}/members — ADD
+
+| Order | Scenario | Expected |
+|-------|----------|----------|
+| 1 | Valid student force-added | 200 + DB: membership count +1 |
+| 2 | Force-add auto-denies competing invitations | 200 + DB: all PENDING invitations for that student → AUTO_DENIED |
+| 3 | Group at max capacity (members + pending invitations ≥ maxTeamSize) | 400 |
+| 4 | Student already in a group | 400 |
+
+#### PATCH /api/coordinator/groups/{groupId}/members — REMOVE
+
+| Order | Scenario | Expected |
+|-------|----------|----------|
+| 5 | Regular MEMBER force-removed | 200 + DB: membership count -1 |
+| 6 | TEAM_LEADER removal blocked | 400 + DB: count unchanged |
+| 7 | Student not in group | 404 |
+
+#### PATCH /api/coordinator/groups/{groupId}/disband
+
+| Order | Scenario | Expected |
+|-------|----------|----------|
+| 8 | Successful disband | 200 + DB: status=DISBANDED, memberships hard-deleted, outbound invitations AUTO_DENIED |
+| 9 | Already disbanded | 400 |
+| 10 | Non-existent group | 404 |
+
+#### RBAC — Non-Coordinator roles
+
+| Order | Scenario | Expected |
+|-------|----------|----------|
+| 11 | Professor token on members endpoint | 403 |
+| 12 | Admin token on members endpoint | 403 |
+| 13 | No token on members endpoint | 4xx |
+| 14 | Professor token on disband | 403 |
+| 15 | Admin token on disband | 403 |
+
+### Technical Notes
+
+* Uses `SpringBootTest`, `MockMvc`, and real JWT tokens issued via `JWTService`.
+* Repositories are used directly for DB-level assertions (membership counts, invitation statuses, group status).
+* Database is cleaned before each test via `@BeforeEach` to ensure full isolation.
+* Runs against H2 in-memory DB via `@TestPropertySource(locations = "classpath:test.properties")`.


### PR DESCRIPTION
## Issue #53 Summary 
# Integration Tests

## CoordinatorControllerIntegrationTest

Verifies the student upload functionality of the Coordinator setup flow at both API and database level.

### Test Cases

| # | Scenario | Expected |
|---|----------|----------|
| 1 | Valid student ID list | 201 Created + records persisted in DB |
| 2 | Invalid ID format (< 11 digits) | 400 Bad Request |
| 3 | Duplicate IDs in same request | 400 Bad Request + no records inserted |
| 4 | Empty student list | 400 Bad Request |

### Technical Notes

* Uses `SpringBootTest`, `MockMvc`, and `WithMockUser(roles = "COORDINATOR")`.
* `StudentRepository` is used for DB-level verification since the endpoint does not return the inserted count.
* Database is cleaned before each test for isolation.

---

## AdvisorControllerIntegrationTest

Black-box integration tests for the professor-facing advisor request endpoints (P3-API-02 & P3-API-03).
All 20 tests pass green against the full Spring Boot context and H2 in-memory DB.

### Endpoints Covered

* `GET  /api/advisor/requests`
* `GET  /api/advisor/requests/{requestId}`
* `PATCH /api/advisor/requests/{requestId}/respond`

### Test Cases

#### GET /api/advisor/requests

| Order | Scenario | Expected |
|-------|----------|----------|
| 1 | Professor has PENDING requests | 200 + array with requestId, groupId, groupName, termId, memberCount, sentAt |
| 2 | Professor has no pending requests | 200 + empty array (not 404) |
| 3 | No token | 4xx |
| 4 | Student JWT | 403 |
| 5 | Coordinator JWT | 403 |

#### GET /api/advisor/requests/{requestId}

| Order | Scenario | Expected |
|-------|----------|----------|
| 6 | Professor fetches own request | 200 + {requestId, group:{id, groupName, termId, status, members:[...]}, sentAt} |
| 7 | Professor fetches another professor's request | 403 |
| 8 | Request does not exist | 404 |
| 9 | No token | 4xx |

#### PATCH /api/advisor/requests/{requestId}/respond

| Order | Scenario | Expected |
|-------|----------|----------|
| 10 | accept: true, professor under capacity | 200 + status: ACCEPTED + DB: group → ADVISOR_ASSIGNED, advisor set |
| 11 | accept: false | 200 + status: REJECTED + DB: group stays TOOLS_BOUND, no advisor set |
| 12 | Non-existent request | 404 |
| 13 | Professor responds to another professor's request | 403 |
| 14 | Request already REJECTED | 400 |
| 15 | Request already ACCEPTED | 400 |
| 16 | Professor at capacity (advisorCapacity=1, 1 group already assigned) | 400 + group stays TOOLS_BOUND |
| 17 | accept: true, second PENDING request exists for same group | 200 ACCEPTED + DB: other request → AUTO_REJECTED |
| 18 | accept: false, second PENDING request exists for same group | 200 REJECTED + DB: other request stays PENDING |
| 19 | No token | 4xx |
| 20 | Student JWT | 403 |

### Technical Notes

* Uses `SpringBootTest`, `MockMvc`, and real JWT tokens issued via `JWTService`.
* Repositories are used directly for DB-level assertions on state transitions (group status, advisor assignment, cascade AUTO_REJECT).
* Database is cleaned before each test via `@BeforeEach` to ensure full isolation.
* Runs against H2 in-memory DB via `@TestPropertySource(locations = "classpath:test.properties")`.

## Issue #44  Summary

- Adds `GroupCreationIntegrationTest` covering the full POST `/api/groups` flow end-to-end against a real database
- Tests all closed-window variants (no window, not yet open, expired) and verifies each produces a 400
- Tests duplicate group name (409) and already-grouped student (400)
- Happy path directly queries the DB to assert both `ProjectGroup` and `GroupMembership` records exist with correct values (FORMING status, TEAM_LEADER role)

## Test Results

| Test | Scenario | Expected |
|---|---|---|
| `@Order(1)` | Active window | 201 + DB has 1 `ProjectGroup` + 1 `GroupMembership` (TEAM_LEADER) |
| `@Order(2)` | No window row | 400 + no DB rows |
| `@Order(3)` | Window not yet open | 400 + no DB rows |
| `@Order(4)` | Window expired | 400 + no DB rows |
| `@Order(5)` | Duplicate name | 409 + only pre-seeded group remains |
| `@Order(6)` | Student already in group | 400 + original membership unchanged |
| `@Order(7)` | No JWT token | 4xx + no DB rows |
 
resolves #44, #53