### PR TITLE
feat: add group status badge and member list components

### DIFF
--- a/frontend/components/ui/GroupStatusBadge.vue
+++ b/frontend/components/ui/GroupStatusBadge.vue
@@ -1,0 +1,70 @@
+<script setup lang="ts">
+import { computed } from "vue"
+import type { GroupStatus } from "@/types/group"
+
+const props = defineProps<{
+  status: GroupStatus | string
+}>()
+
+const statusConfig = computed(() => {
+  switch (props.status) {
+    case "FORMING":
+      return {
+        label: "Forming",
+        classes:
+          "bg-yellow-100 text-yellow-800 border-yellow-200 dark:bg-yellow-900/30 dark:text-yellow-300 dark:border-yellow-800",
+      }
+    case "UNADVISED":
+      return {
+        label: "Unadvised",
+        classes:
+          "bg-red-100 text-red-800 border-red-200 dark:bg-red-900/30 dark:text-red-300 dark:border-red-800",
+      }
+    case "ADVISOR_PENDING":
+      return {
+        label: "Advisor Pending",
+        classes:
+          "bg-orange-100 text-orange-800 border-orange-200 dark:bg-orange-900/30 dark:text-orange-300 dark:border-orange-800",
+      }
+    case "ADVISED":
+      return {
+        label: "Advised",
+        classes:
+          "bg-blue-100 text-blue-800 border-blue-200 dark:bg-blue-900/30 dark:text-blue-300 dark:border-blue-800",
+      }
+    case "TOOLS_BOUND":
+      return {
+        label: "Tools Bound",
+        classes:
+          "bg-green-100 text-green-800 border-green-200 dark:bg-green-900/30 dark:text-green-300 dark:border-green-800",
+      }
+    case "COMMITTEE_ASSIGNED":
+      return {
+        label: "Committee Assigned",
+        classes:
+          "bg-purple-100 text-purple-800 border-purple-200 dark:bg-purple-900/30 dark:text-purple-300 dark:border-purple-800",
+      }
+    case "DISBANDED":
+      return {
+        label: "Disbanded",
+        classes:
+          "bg-gray-100 text-gray-800 border-gray-200 dark:bg-gray-800 dark:text-gray-300 dark:border-gray-700",
+      }
+    default:
+      return {
+        label: props.status || "Unknown",
+        classes:
+          "bg-gray-100 text-gray-800 border-gray-200 dark:bg-gray-800 dark:text-gray-300 dark:border-gray-700",
+      }
+  }
+})
+</script>
+
+<template>
+  <span
+    class="inline-flex items-center rounded-full border px-2.5 py-1 text-xs font-medium whitespace-nowrap"
+    :class="statusConfig.classes"
+  >
+    {{ statusConfig.label }}
+  </span>
+</template>

--- a/frontend/components/ui/GroupStatusBadge.vue
+++ b/frontend/components/ui/GroupStatusBadge.vue
@@ -14,35 +14,24 @@ const statusConfig = computed(() => {
         classes:
           "bg-yellow-100 text-yellow-800 border-yellow-200 dark:bg-yellow-900/30 dark:text-yellow-300 dark:border-yellow-800",
       }
+    case "TOOLS_PENDING":
     case "UNADVISED":
       return {
-        label: "Unadvised",
+        label: "Tools Pending",
         classes:
-          "bg-red-100 text-red-800 border-red-200 dark:bg-red-900/30 dark:text-red-300 dark:border-red-800",
+          "bg-amber-100 text-amber-800 border-amber-200 dark:bg-amber-900/30 dark:text-amber-300 dark:border-amber-800",
       }
+    case "ADVISOR_ASSIGNED":
     case "ADVISOR_PENDING":
-      return {
-        label: "Advisor Pending",
-        classes:
-          "bg-orange-100 text-orange-800 border-orange-200 dark:bg-orange-900/30 dark:text-orange-300 dark:border-orange-800",
-      }
     case "ADVISED":
-      return {
-        label: "Advised",
-        classes:
-          "bg-blue-100 text-blue-800 border-blue-200 dark:bg-blue-900/30 dark:text-blue-300 dark:border-blue-800",
-      }
     case "TOOLS_BOUND":
-      return {
-        label: "Tools Bound",
-        classes:
-          "bg-green-100 text-green-800 border-green-200 dark:bg-green-900/30 dark:text-green-300 dark:border-green-800",
-      }
     case "COMMITTEE_ASSIGNED":
       return {
-        label: "Committee Assigned",
+        label: props.status === "TOOLS_BOUND" ? "Tools Bound" : "Advisor Assigned",
         classes:
-          "bg-purple-100 text-purple-800 border-purple-200 dark:bg-purple-900/30 dark:text-purple-300 dark:border-purple-800",
+          props.status === "TOOLS_BOUND"
+            ? "bg-green-100 text-green-800 border-green-200 dark:bg-green-900/30 dark:text-green-300 dark:border-green-800"
+            : "bg-blue-100 text-blue-800 border-blue-200 dark:bg-blue-900/30 dark:text-blue-300 dark:border-blue-800",
       }
     case "DISBANDED":
       return {

--- a/frontend/components/ui/GroupStatusBadge.vue
+++ b/frontend/components/ui/GroupStatusBadge.vue
@@ -15,23 +15,22 @@ const statusConfig = computed(() => {
           "bg-yellow-100 text-yellow-800 border-yellow-200 dark:bg-yellow-900/30 dark:text-yellow-300 dark:border-yellow-800",
       }
     case "TOOLS_PENDING":
-    case "UNADVISED":
       return {
         label: "Tools Pending",
         classes:
           "bg-amber-100 text-amber-800 border-amber-200 dark:bg-amber-900/30 dark:text-amber-300 dark:border-amber-800",
       }
     case "ADVISOR_ASSIGNED":
-    case "ADVISOR_PENDING":
-    case "ADVISED":
-    case "TOOLS_BOUND":
-    case "COMMITTEE_ASSIGNED":
       return {
-        label: props.status === "TOOLS_BOUND" ? "Tools Bound" : "Advisor Assigned",
+        label: "Advisor Assigned",
         classes:
-          props.status === "TOOLS_BOUND"
-            ? "bg-green-100 text-green-800 border-green-200 dark:bg-green-900/30 dark:text-green-300 dark:border-green-800"
-            : "bg-blue-100 text-blue-800 border-blue-200 dark:bg-blue-900/30 dark:text-blue-300 dark:border-blue-800",
+          "bg-blue-100 text-blue-800 border-blue-200 dark:bg-blue-900/30 dark:text-blue-300 dark:border-blue-800",
+      }
+    case "TOOLS_BOUND":
+      return {
+        label: "Tools Bound",
+        classes:
+          "bg-green-100 text-green-800 border-green-200 dark:bg-green-900/30 dark:text-green-300 dark:border-green-800",
       }
     case "DISBANDED":
       return {

--- a/frontend/components/ui/MemberList.vue
+++ b/frontend/components/ui/MemberList.vue
@@ -1,0 +1,89 @@
+<script setup lang="ts">
+import type { GroupMember } from "@/types/group"
+
+const props = withDefaults(
+  defineProps<{
+    members: GroupMember[]
+    removable?: boolean
+  }>(),
+  {
+    removable: false,
+  }
+)
+
+const emit = defineEmits<{
+  (e: "remove", member: GroupMember): void
+}>()
+
+function handleRemove(member: GroupMember) {
+  emit("remove", member)
+}
+</script>
+
+<template>
+  <div class="rounded-xl border border-gray-200 bg-white dark:border-gray-800 dark:bg-gray-900">
+    <div class="border-b border-gray-200 px-4 py-3 dark:border-gray-800">
+      <h3 class="text-sm font-semibold text-gray-900 dark:text-gray-100">
+        Members
+      </h3>
+    </div>
+
+    <div v-if="!members || members.length === 0" class="px-4 py-6 text-sm text-gray-500 dark:text-gray-400">
+      No members have been added yet.
+    </div>
+
+    <ul v-else class="divide-y divide-gray-200 dark:divide-gray-800">
+      <li
+        v-for="member in members"
+        :key="member.id"
+        class="flex items-center justify-between px-4 py-3"
+      >
+        <div class="flex items-center gap-3">
+          <span
+            v-if="member.role === 'TEAM_LEADER'"
+            class="inline-flex h-8 w-8 items-center justify-center rounded-full bg-indigo-100 text-indigo-700 dark:bg-indigo-900/40 dark:text-indigo-300"
+            title="Team Leader"
+            aria-label="Team Leader"
+          >
+            ★
+          </span>
+
+          <span
+            v-else
+            class="inline-flex h-8 w-8 items-center justify-center rounded-full bg-gray-100 text-gray-600 dark:bg-gray-800 dark:text-gray-300"
+            aria-hidden="true"
+          >
+            👤
+          </span>
+
+          <div>
+            <p class="text-sm font-medium text-gray-900 dark:text-gray-100">
+              {{ member.fullName }}
+            </p>
+            <p class="text-xs text-gray-500 dark:text-gray-400">
+              {{ member.studentId ?? "No student ID" }}
+            </p>
+          </div>
+        </div>
+
+        <div class="flex items-center gap-2">
+          <span
+            v-if="member.role === 'TEAM_LEADER'"
+            class="rounded-full bg-indigo-50 px-2 py-1 text-xs font-medium text-indigo-700 dark:bg-indigo-900/30 dark:text-indigo-300"
+          >
+            Team Leader
+          </span>
+
+          <button
+            v-if="removable && member.role !== 'TEAM_LEADER'"
+            type="button"
+            class="rounded-lg border border-red-200 px-3 py-1.5 text-xs font-medium text-red-600 transition hover:bg-red-50 dark:border-red-800 dark:text-red-300 dark:hover:bg-red-900/20"
+            @click="handleRemove(member)"
+          >
+            Remove
+          </button>
+        </div>
+      </li>
+    </ul>
+  </div>
+</template>

--- a/frontend/components/ui/MemberList.vue
+++ b/frontend/components/ui/MemberList.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { computed } from "vue"
 import type { GroupMember } from "@/types/group"
 
 const props = withDefaults(
@@ -18,6 +19,15 @@ const emit = defineEmits<{
 function handleRemove(member: GroupMember) {
   emit("remove", member)
 }
+
+const normalizedMembers = computed(() =>
+  props.members.map((member, index) => ({
+    ...member,
+    key: member.id ?? member.studentId ?? `${member.role}-${index}`,
+    displayName: member.fullName?.trim() || (member.studentId ? `Student ${member.studentId}` : "Unnamed member"),
+    secondaryText: member.studentId ?? "Student ID unavailable",
+  }))
+)
 </script>
 
 <template>
@@ -28,14 +38,17 @@ function handleRemove(member: GroupMember) {
       </h3>
     </div>
 
-    <div v-if="!members || members.length === 0" class="px-4 py-6 text-sm text-gray-500 dark:text-gray-400">
+    <div
+      v-if="!members || members.length === 0"
+      class="px-4 py-6 text-sm text-gray-500 dark:text-gray-400"
+    >
       No members have been added yet.
     </div>
 
     <ul v-else class="divide-y divide-gray-200 dark:divide-gray-800">
       <li
-        v-for="member in members"
-        :key="member.id"
+        v-for="member in normalizedMembers"
+        :key="member.key"
         class="flex items-center justify-between px-4 py-3"
       >
         <div class="flex items-center gap-3">
@@ -58,10 +71,10 @@ function handleRemove(member: GroupMember) {
 
           <div>
             <p class="text-sm font-medium text-gray-900 dark:text-gray-100">
-              {{ member.fullName }}
+              {{ member.displayName }}
             </p>
             <p class="text-xs text-gray-500 dark:text-gray-400">
-              {{ member.studentId ?? "No student ID" }}
+              {{ member.secondaryText }}
             </p>
           </div>
         </div>

--- a/frontend/types/group.ts
+++ b/frontend/types/group.ts
@@ -1,5 +1,8 @@
 export type GroupStatus =
   | "FORMING"
+  | "TOOLS_PENDING"
+  | "ADVISOR_ASSIGNED"
+  // Legacy aliases kept to avoid breaking in-progress frontend usage.
   | "UNADVISED"
   | "ADVISOR_PENDING"
   | "ADVISED"
@@ -10,15 +13,23 @@ export type GroupStatus =
 export type GroupMemberRole = "TEAM_LEADER" | "MEMBER"
 
 export interface GroupMember {
-  id: string
+  id?: string
   studentId?: string
-  fullName: string
+  fullName?: string
+  joinedAt?: string
   role: GroupMemberRole
 }
 
 export interface GroupDetailResponse {
   id: string
   groupName: string
+  termId?: string
   status: GroupStatus
   members: GroupMember[]
+  createdAt?: string
+  jiraSpaceUrl?: string
+  jiraProjectKey?: string
+  jiraBound?: boolean
+  githubOrgName?: string
+  githubBound?: boolean
 }

--- a/frontend/types/group.ts
+++ b/frontend/types/group.ts
@@ -1,0 +1,24 @@
+export type GroupStatus =
+  | "FORMING"
+  | "UNADVISED"
+  | "ADVISOR_PENDING"
+  | "ADVISED"
+  | "TOOLS_BOUND"
+  | "COMMITTEE_ASSIGNED"
+  | "DISBANDED"
+
+export type GroupMemberRole = "TEAM_LEADER" | "MEMBER"
+
+export interface GroupMember {
+  id: string
+  studentId?: string
+  fullName: string
+  role: GroupMemberRole
+}
+
+export interface GroupDetailResponse {
+  id: string
+  groupName: string
+  status: GroupStatus
+  members: GroupMember[]
+}

--- a/frontend/types/group.ts
+++ b/frontend/types/group.ts
@@ -2,12 +2,7 @@ export type GroupStatus =
   | "FORMING"
   | "TOOLS_PENDING"
   | "ADVISOR_ASSIGNED"
-  // Legacy aliases kept to avoid breaking in-progress frontend usage.
-  | "UNADVISED"
-  | "ADVISOR_PENDING"
-  | "ADVISED"
   | "TOOLS_BOUND"
-  | "COMMITTEE_ASSIGNED"
   | "DISBANDED"
 
 export type GroupMemberRole = "TEAM_LEADER" | "MEMBER"


### PR DESCRIPTION
Part of #41

**Summary**

Implements reusable frontend UI components for Process 2 group-related views by introducing a standardized group status badge and member list rendering.

This PR covers the shared UI layer responsibilities defined in Issue #41 and establishes consistent visual representation for group status and member roles across student and coordinator interfaces.

**Changes**
There is no reedited file.

**New Files**

| File | Description |
|---|---|
| `components/ui/GroupStatusBadge.vue` | Reusable component that maps group status values to styled Tailwind badge variants |
| `components/ui/MemberList.vue` | Reusable component for rendering group members with role-based UI behavior |
| `types/group.ts` | Type definitions for group status, member roles, and group structure used by shared components |

**Modified Files**

N/A

**Behavior**

- Group statuses are displayed using consistent color-coded badges across the UI
- Current Process 2 and Process 3 shared lifecycle states are supported, including `FORMING`, `TOOLS_PENDING`, `TOOLS_BOUND`, `ADVISOR_ASSIGNED`, and `DISBANDED`
- `TEAM_LEADER` is visually distinguished with a dedicated icon and label
- Member list supports conditional rendering of remove actions for non-leader members
- Empty member lists are handled gracefully with a placeholder message
- Member list supports fallback rendering for API-style member data when `fullName` is unavailable
- Components are fully compatible with both light and dark themes
- Components are designed to be reusable across multiple group and coordinator views

**Validation**

- Verified components render correctly in a local Nuxt development environment
- Tested multiple group states including `FORMING`, `TOOLS_PENDING`, `TOOLS_BOUND`, `ADVISOR_ASSIGNED`, and `DISBANDED`
- Confirmed conditional UI behavior for leader vs member rows and remove button visibility
- Confirmed empty-state rendering for member lists
- Confirmed styling consistency in both light and dark mode
- Confirmed compatibility with API-style member payloads using fallback display values

**Acceptance Criteria**

- [x] Group status badges correctly map status values to visual styles
- [x] Status badges render properly in both light and dark mode
- [x] Member list correctly displays all members with role distinction
- [x] `TEAM_LEADER` is visually identifiable with a unique icon and label
- [x] Remove action is only available for non-leader members when enabled
- [x] Empty member arrays display a user-friendly placeholder

**Out of Scope (deferred)**

- API-driven data binding for group and member data in actual feature pages
- Additional role-based UI enhancements beyond current requirements

**Notes**

- Type definitions were aligned with the current Process 2/3 lifecycle documentation and the current backend `GroupDetailResponse` shape
- Components are placed under `components/ui` to align with existing frontend structure and reuse conventions