### PR TITLE
feat(docs): integrate springdoc Swagger UI

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -94,6 +94,11 @@
             <artifactId>spring-security-test</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.springdoc</groupId>
+            <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+            <version>2.8.6</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/backend/src/main/java/com/senior/spm/config/OpenApiConfig.java
+++ b/backend/src/main/java/com/senior/spm/config/OpenApiConfig.java
@@ -1,0 +1,27 @@
+package com.senior.spm.config;
+
+import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.annotations.enums.SecuritySchemeType;
+import io.swagger.v3.oas.annotations.info.Info;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.security.SecurityScheme;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@OpenAPIDefinition(
+        info = @Info(
+                title = "Senior Project Management API",
+                version = "1.0",
+                description = "REST API for SPM — group formation, advisor assignment, sprint tracking, deliverable submission, and AI-assisted grading."
+        ),
+        security = @SecurityRequirement(name = "bearerAuth")
+)
+@SecurityScheme(
+        name = "bearerAuth",
+        type = SecuritySchemeType.HTTP,
+        scheme = "bearer",
+        bearerFormat = "JWT",
+        description = "Paste your JWT token (without 'Bearer ' prefix). Obtain it from POST /api/auth/login."
+)
+public class OpenApiConfig {
+}

--- a/backend/src/main/java/com/senior/spm/config/SecurityConfig.java
+++ b/backend/src/main/java/com/senior/spm/config/SecurityConfig.java
@@ -44,6 +44,7 @@ public class SecurityConfig {
                 .authorizeHttpRequests(
                         auth -> auth
                                 .requestMatchers("/api/auth/**").permitAll()
+                                .requestMatchers("/v3/api-docs/**", "/swagger-ui/**", "/swagger-ui.html").permitAll()
                                 .requestMatchers("/api/admin/**").hasRole("ADMIN")
                                 .requestMatchers("/api/coordinator/**").hasRole("COORDINATOR")
                                 .requestMatchers("/api/professor/**").hasRole("PROFESSOR")

--- a/backend/src/main/resources/application.properties.example
+++ b/backend/src/main/resources/application.properties.example
@@ -14,6 +14,9 @@ jwt.expiration=604800000
 encryption.key=
 encryption.secret=
 
-# --- Swagger / springdoc ---
+# --- Swagger / springdoc (Development by default) ---
+# Swagger UI is enabled in development.
+springdoc.swagger-ui.enabled=true
 springdoc.swagger-ui.path=/swagger-ui.html
+springdoc.api-docs.enabled=true
 springdoc.api-docs.path=/v3/api-docs

--- a/backend/src/main/resources/application.properties.example
+++ b/backend/src/main/resources/application.properties.example
@@ -13,3 +13,7 @@ jwt.expiration=604800000
 # Generate a key with: openssl rand -base64 32
 encryption.key=
 encryption.secret=
+
+# --- Swagger / springdoc ---
+springdoc.swagger-ui.path=/swagger-ui.html
+springdoc.api-docs.path=/v3/api-docs


### PR DESCRIPTION
## Integrate SpringDoc OpenAPI & Swagger UI

### Overview
Adds SpringDoc OpenAPI integration with embedded Swagger UI for comprehensive, auto-generated REST API documentation and interactive endpoint testing .SpringDoc **automatically generates** the OpenAPI specification by scanning controller annotations and DTOs at runtime. It does **not** depend on `docs/openapi.yaml`.

### What's Added
- **SpringDoc OpenAPI Starter** — Automatic API documentation generation
- **Swagger UI** — Interactive documentation at `/swagger-ui.html`
- **OpenAPI 3.0 Contract** — Machine-readable spec at `/v3/api-docs`
- **OpenAPI Config Bean** — Customized API metadata (title, description, version)
- **Dev-only Swagger UI** — Environment-based control via `application.properties`

### Access Points
- Swagger UI: `http://localhost:8080/swagger-ui.html`
- OpenAPI JSON: `http://localhost:8080/v3/api-docs`

Test Results -> All 215 existing tests passed. 