### PR TITLE
feat(#61): SanitizationService — Auto-Disband Scheduler

### DIFF
--- a/backend/src/main/java/com/senior/spm/controller/CoordinatorController.java
+++ b/backend/src/main/java/com/senior/spm/controller/CoordinatorController.java
@@ -272,7 +272,6 @@ public class CoordinatorController {
      * trigger to mark groups DISBANDED and hard-delete their memberships.
      * 
      * Requires force=true if ADVISOR_ASSOCIATION window is still open.
-     * Returns counts of affected groups and advisor requests.
      * 
      * REST Endpoint: {@code POST /api/coordinator/sanitize}
      * Auth: Coordinator (staff role)
@@ -282,8 +281,8 @@ public class CoordinatorController {
             @RequestBody(required = false) java.util.Map<String, Object> body) {
         try {
             boolean force = body != null && Boolean.TRUE.equals(body.get("force"));
-            SanitizationService.SanitizationReport report = sanitizationService.triggerManually(force);
-            return ResponseEntity.status(HttpStatus.OK).body(report);
+            sanitizationService.triggerManually(force);
+            return ResponseEntity.status(HttpStatus.OK).body(java.util.Map.of("message", "Sanitization completed successfully"));
         } catch (com.senior.spm.exception.BusinessRuleException e) {
             return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(new ErrorMessage(e.getMessage()));
         } catch (Exception e) {

--- a/backend/src/main/java/com/senior/spm/controller/CoordinatorController.java
+++ b/backend/src/main/java/com/senior/spm/controller/CoordinatorController.java
@@ -29,6 +29,7 @@ import com.senior.spm.exception.AlreadyExistsException;
 import com.senior.spm.exception.NotFoundException;
 import com.senior.spm.service.DeliverableService;
 import com.senior.spm.service.GroupService;
+import com.senior.spm.service.SanitizationService;
 import com.senior.spm.service.SprintService;
 import com.senior.spm.service.StudentService;
 import com.senior.spm.service.SystemStateService;
@@ -44,17 +45,20 @@ public class CoordinatorController {
     private final StudentService studentService;
     private final SystemStateService systemStateService;
     private final GroupService groupService;
+    private final SanitizationService sanitizationService;
 
     public CoordinatorController(SprintService sprintService,
             DeliverableService deliverableService,
             StudentService studentService,
             SystemStateService systemStateService,
-            GroupService groupService) {
+            GroupService groupService,
+            SanitizationService sanitizationService) {
         this.sprintService = sprintService;
         this.deliverableService = deliverableService;
         this.studentService = studentService;
         this.systemStateService = systemStateService;
         this.groupService = groupService;
+        this.sanitizationService = sanitizationService;
     }
 
     @PostMapping("/sprints")
@@ -260,6 +264,31 @@ public class CoordinatorController {
             return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(new ErrorMessage(e.getMessage()));
         } catch (Exception e) {
             return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
+        }
+    }
+
+    /**
+     * Automatic sanitization — disband all unadvised groups (without advisors)
+     * trigger to mark groups DISBANDED and hard-delete their memberships.
+     * 
+     * Requires force=true if ADVISOR_ASSOCIATION window is still open.
+     * Returns counts of affected groups and advisor requests.
+     * 
+     * REST Endpoint: {@code POST /api/coordinator/sanitize}
+     * Auth: Coordinator (staff role)
+     */
+    @PostMapping("/sanitize")
+    public ResponseEntity<?> sanitizeUnadvisedGroups(
+            @RequestBody(required = false) java.util.Map<String, Object> body) {
+        try {
+            boolean force = body != null && Boolean.TRUE.equals(body.get("force"));
+            SanitizationService.SanitizationReport report = sanitizationService.triggerManually(force);
+            return ResponseEntity.status(HttpStatus.OK).body(report);
+        } catch (com.senior.spm.exception.BusinessRuleException e) {
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(new ErrorMessage(e.getMessage()));
+        } catch (Exception e) {
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                .body(new ErrorMessage("Sanitization failed: " + e.getMessage()));
         }
     }
 }

--- a/backend/src/main/java/com/senior/spm/controller/CoordinatorController.java
+++ b/backend/src/main/java/com/senior/spm/controller/CoordinatorController.java
@@ -29,7 +29,6 @@ import com.senior.spm.exception.AlreadyExistsException;
 import com.senior.spm.exception.NotFoundException;
 import com.senior.spm.service.DeliverableService;
 import com.senior.spm.service.GroupService;
-import com.senior.spm.service.SanitizationService;
 import com.senior.spm.service.SprintService;
 import com.senior.spm.service.StudentService;
 import com.senior.spm.service.SystemStateService;
@@ -45,20 +44,17 @@ public class CoordinatorController {
     private final StudentService studentService;
     private final SystemStateService systemStateService;
     private final GroupService groupService;
-    private final SanitizationService sanitizationService;
 
     public CoordinatorController(SprintService sprintService,
             DeliverableService deliverableService,
             StudentService studentService,
             SystemStateService systemStateService,
-            GroupService groupService,
-            SanitizationService sanitizationService) {
+            GroupService groupService) {
         this.sprintService = sprintService;
         this.deliverableService = deliverableService;
         this.studentService = studentService;
         this.systemStateService = systemStateService;
         this.groupService = groupService;
-        this.sanitizationService = sanitizationService;
     }
 
     @PostMapping("/sprints")
@@ -267,27 +263,4 @@ public class CoordinatorController {
         }
     }
 
-    /**
-     * Automatic sanitization — disband all unadvised groups (without advisors)
-     * trigger to mark groups DISBANDED and hard-delete their memberships.
-     * 
-     * Requires force=true if ADVISOR_ASSOCIATION window is still open.
-     * 
-     * REST Endpoint: {@code POST /api/coordinator/sanitize}
-     * Auth: Coordinator (staff role)
-     */
-    @PostMapping("/sanitize")
-    public ResponseEntity<?> sanitizeUnadvisedGroups(
-            @RequestBody(required = false) java.util.Map<String, Object> body) {
-        try {
-            boolean force = body != null && Boolean.TRUE.equals(body.get("force"));
-            sanitizationService.triggerManually(force);
-            return ResponseEntity.status(HttpStatus.OK).body(java.util.Map.of("message", "Sanitization completed successfully"));
-        } catch (com.senior.spm.exception.BusinessRuleException e) {
-            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(new ErrorMessage(e.getMessage()));
-        } catch (Exception e) {
-            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
-                .body(new ErrorMessage("Sanitization failed: " + e.getMessage()));
-        }
-    }
 }

--- a/backend/src/main/java/com/senior/spm/repository/AdvisorRequestRepository.java
+++ b/backend/src/main/java/com/senior/spm/repository/AdvisorRequestRepository.java
@@ -33,5 +33,5 @@ public interface AdvisorRequestRepository extends JpaRepository<AdvisorRequest, 
 
     @Modifying
     @Query("UPDATE AdvisorRequest ar SET ar.status = :status WHERE ar.status = 'PENDING' AND ar.group.id = :groupId")
-    void bulkUpdateStatusByGroupId(@org.springframework.data.repository.query.Param("status") RequestStatus status, @org.springframework.data.repository.query.Param("groupId") UUID groupId);
+    long bulkUpdateStatusByGroupId(@org.springframework.data.repository.query.Param("status") RequestStatus status, @org.springframework.data.repository.query.Param("groupId") UUID groupId);
 }

--- a/backend/src/main/java/com/senior/spm/repository/ProjectGroupRepository.java
+++ b/backend/src/main/java/com/senior/spm/repository/ProjectGroupRepository.java
@@ -24,4 +24,6 @@ public interface ProjectGroupRepository extends JpaRepository<ProjectGroup, UUID
     long countByAdvisorIdAndTermIdAndStatusNot(UUID advisorId, String termId, GroupStatus status);
 
     List<ProjectGroup> findByTermIdAndStatusNotAndAdvisorIsNull(String termId, GroupStatus status);
+
+    List<ProjectGroup> findByTermIdAndStatusInAndAdvisorIsNull(String termId, List<GroupStatus> statuses);
 }

--- a/backend/src/main/java/com/senior/spm/repository/ScheduleWindowRepository.java
+++ b/backend/src/main/java/com/senior/spm/repository/ScheduleWindowRepository.java
@@ -17,4 +17,6 @@ public interface ScheduleWindowRepository extends JpaRepository<ScheduleWindow, 
     Optional<ScheduleWindow> findByTermIdAndType(String termId, WindowType type);
 
     List<ScheduleWindow> findByTypeAndClosesAtLessThan(WindowType type, LocalDateTime dateTime);
+
+    List<ScheduleWindow> findByTypeAndClosesAtBetween(WindowType type, LocalDateTime afterTime, LocalDateTime beforeTime);
 }

--- a/backend/src/main/java/com/senior/spm/service/SanitizationService.java
+++ b/backend/src/main/java/com/senior/spm/service/SanitizationService.java
@@ -13,7 +13,6 @@ import com.senior.spm.entity.ProjectGroup;
 import com.senior.spm.entity.ProjectGroup.GroupStatus;
 import com.senior.spm.entity.ScheduleWindow;
 import com.senior.spm.entity.ScheduleWindow.WindowType;
-import com.senior.spm.exception.BusinessRuleException;
 import com.senior.spm.repository.AdvisorRequestRepository;
 import com.senior.spm.repository.GroupMembershipRepository;
 import com.senior.spm.repository.ProjectGroupRepository;
@@ -37,7 +36,6 @@ public class SanitizationService {
     private final ProjectGroupRepository projectGroupRepository;
     private final GroupMembershipRepository groupMembershipRepository;
     private final AdvisorRequestRepository advisorRequestRepository;
-    private final TermConfigService termConfigService;
 
     /**
      * Scheduled job that runs every 5 minutes to check for closed ADVISOR_ASSOCIATION windows
@@ -58,32 +56,6 @@ public class SanitizationService {
                 // Continue to next window even if one fails
             }
         }
-    }
-
-    /**
-     * Manual trigger for coordinators to sanitize (disband unadvised groups).
-     * Requires force=true if the ADVISOR_ASSOCIATION window is still open.
-     * 
-     * @param force if true, bypasses window check and sanitizes immediately
-     */
-    public void triggerManually(boolean force) {
-        String termId = termConfigService.getActiveTermId();
-        
-        // Check if window is still open
-        ScheduleWindow window = scheduleWindowRepository
-            .findByTermIdAndType(termId, WindowType.ADVISOR_ASSOCIATION)
-            .orElse(null);
-
-        LocalDateTime now = LocalDateTime.now(ZoneId.of("UTC"));
-        boolean windowIsActive = window != null && window.getClosesAt().isAfter(now);
-
-        if (windowIsActive && !force) {
-            throw new BusinessRuleException(
-                "Advisor association window is still active — cannot sanitize early without confirmation"
-            );
-        }
-
-        runSanitization(termId, force);
     }
 
     /**

--- a/backend/src/main/java/com/senior/spm/service/SanitizationService.java
+++ b/backend/src/main/java/com/senior/spm/service/SanitizationService.java
@@ -4,11 +4,15 @@ import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.util.List;
 
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Lazy;
 import org.springframework.dao.OptimisticLockingFailureException;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.senior.spm.entity.AdvisorRequest.RequestStatus;
 import com.senior.spm.entity.ProjectGroup;
 import com.senior.spm.entity.ProjectGroup.GroupStatus;
 import com.senior.spm.entity.ScheduleWindow;
@@ -19,84 +23,128 @@ import com.senior.spm.repository.ProjectGroupRepository;
 import com.senior.spm.repository.ScheduleWindowRepository;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
 /**
  * SanitizationService handles the automatic disbanding of unadvised groups
  * once the ADVISOR_ASSOCIATION window closes.
- * 
- * Scheduled job runs periodically to detect newly closed windows.
- * Manual trigger available for coordinators to force sanitization.
- * Gracefully handles OptimisticLockException — skips groups modified concurrently.
+ *
+ * <p>Scheduled job runs periodically to detect newly closed windows.
+ * Manual trigger (force=true) available for coordinators via a future endpoint.
+ *
+ * <p>Transaction design:
+ * <ul>
+ *   <li>{@code runSanitizationIfWindowClosed} — no transaction; calls self-proxy to
+ *       ensure Spring AOP is active on {@code runSanitization}.</li>
+ *   <li>{@code runSanitization} — read-only transaction for group fetch; delegates
+ *       per-group writes to {@code disbandGroup} through self-proxy.</li>
+ *   <li>{@code disbandGroup} — {@code REQUIRES_NEW} transaction; one commit per group.
+ *       {@code OptimisticLockingFailureException} rolls back only this group's
+ *       transaction and is caught by the caller, allowing the loop to continue.</li>
+ * </ul>
  */
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class SanitizationService {
 
     private final ScheduleWindowRepository scheduleWindowRepository;
-    private final ProjectGroupRepository projectGroupRepository;
+    private final ProjectGroupRepository   projectGroupRepository;
     private final GroupMembershipRepository groupMembershipRepository;
     private final AdvisorRequestRepository advisorRequestRepository;
 
     /**
-     * Scheduled job that runs every 5 minutes to check for closed ADVISOR_ASSOCIATION windows
-     * and automatically disband unadvised groups.
+     * Self-proxy reference — injected lazily to avoid circular dependency.
+     * Required so that internal calls to {@code runSanitization} and
+     * {@code disbandGroup} pass through the Spring AOP proxy, activating
+     * the {@code @Transactional} annotations on those methods.
      */
-    @Scheduled(fixedRate = 300000) // 5 minutes
+    @Autowired
+    @Lazy
+    private SanitizationService self;
+
+    // ── scheduled entry point ────────────────────────────────────────────────
+
+    /**
+     * Runs every 5 minutes. Finds all closed ADVISOR_ASSOCIATION windows and
+     * triggers sanitization per term. Logs and continues on per-term failure.
+     */
+    @Scheduled(fixedRate = 300_000)
     public void runSanitizationIfWindowClosed() {
         LocalDateTime now = LocalDateTime.now(ZoneId.of("UTC"));
-        
-        // Find all ADVISOR_ASSOCIATION windows that have closed
+
         List<ScheduleWindow> closedWindows = scheduleWindowRepository
             .findByTypeAndClosesAtLessThan(WindowType.ADVISOR_ASSOCIATION, now);
 
         for (ScheduleWindow window : closedWindows) {
             try {
-                runSanitization(window.getTermId(), false);
+                // Call through self-proxy so @Transactional on runSanitization is applied
+                self.runSanitization(window.getTermId(), false);
             } catch (Exception e) {
-                // Continue to next window even if one fails
+                log.error("Sanitization failed for term {}: {}", window.getTermId(), e.getMessage(), e);
             }
         }
     }
 
+    // ── per-term logic ───────────────────────────────────────────────────────
+
     /**
-     * Core sanitization logic:
-     * 1. Find all groups without an advisor (unadvised)
-     * 2. Mark them DISBANDED
-     * 3. Hard-delete their memberships (frees students)
-     * 4. Auto-reject pending advisor requests
-     * 
-     * Gracefully skips groups that throw OptimisticLockException
-     * (indicates concurrent modification by advisor accept).
-     * 
+     * Queries all unadvised groups for {@code termId} and disbands each one in its
+     * own transaction. Groups that raise an {@code OptimisticLockingFailureException}
+     * (concurrent advisor acceptance) are skipped and will be re-evaluated on the
+     * next scheduler tick.
+     *
      * @param termId the term to sanitize
-     * @param force flag (for audit purposes)
+     * @param force  when {@code true}, logs a warning for audit purposes (coordinator trigger)
      */
-    @Transactional
+    @Transactional(readOnly = true)
     public void runSanitization(String termId, boolean force) {
-        // Find all unadvised groups (status FORMING, TOOLS_PENDING, TOOLS_BOUND with no advisor assigned)
+        if (force) {
+            log.warn("Forced sanitization triggered for term {}", termId);
+        }
+
         List<ProjectGroup> unadvisedGroups = projectGroupRepository
-            .findByTermIdAndStatusInAndAdvisorIsNull(termId, 
-                java.util.List.of(GroupStatus.FORMING, GroupStatus.TOOLS_PENDING, GroupStatus.TOOLS_BOUND));
+            .findByTermIdAndStatusInAndAdvisorIsNull(termId,
+                List.of(GroupStatus.FORMING, GroupStatus.TOOLS_PENDING, GroupStatus.TOOLS_BOUND));
 
         for (ProjectGroup group : unadvisedGroups) {
             try {
-                // Mark group as DISBANDED
-                group.setStatus(GroupStatus.DISBANDED);
-                projectGroupRepository.save(group);
-
-                // Hard-delete all memberships (frees students to rejoin next term)
-                groupMembershipRepository.deleteByGroupId(group.getId());
-
-                // Auto-reject all PENDING advisor requests for this group
-                advisorRequestRepository.bulkUpdateStatusByGroupId(
-                    com.senior.spm.entity.AdvisorRequest.RequestStatus.AUTO_REJECTED,
-                    group.getId()
-                );
-
+                // Call through self-proxy so REQUIRES_NEW starts a fresh transaction per group
+                self.disbandGroup(group);
             } catch (OptimisticLockingFailureException e) {
-                // Group was concurrently modified (likely by advisor accept).
-                // Skip this group and continue — it will be re-queried on next run.
+                // Concurrent advisor acceptance modified this group between our read and
+                // this write. The group's own transaction was already rolled back by
+                // REQUIRES_NEW. Skip — next tick will re-query and decide correctly.
+                log.warn("Skipping group {} (term {}) — concurrent OL conflict; will retry on next tick",
+                    group.getId(), termId);
             }
         }
+    }
+
+    // ── per-group atomic unit ────────────────────────────────────────────────
+
+    /**
+     * Disbands a single group atomically (P3.6):
+     * <ol>
+     *   <li>Mark group DISBANDED and persist.</li>
+     *   <li>Hard-delete all {@code GroupMembership} rows (frees students).</li>
+     *   <li>Bulk-update all {@code PENDING} {@code AdvisorRequest} rows → {@code AUTO_REJECTED}.</li>
+     * </ol>
+     *
+     * <p>Uses {@code REQUIRES_NEW} so this group's transaction is independent of any
+     * outer transaction. An {@code OptimisticLockingFailureException} rolls back only
+     * this group without poisoning the outer session.
+     */
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void disbandGroup(ProjectGroup group) {
+        group.setStatus(GroupStatus.DISBANDED);
+        projectGroupRepository.save(group);
+
+        groupMembershipRepository.deleteByGroupId(group.getId());
+
+        advisorRequestRepository.bulkUpdateStatusByGroupId(
+            RequestStatus.AUTO_REJECTED,
+            group.getId()
+        );
     }
 }

--- a/backend/src/main/java/com/senior/spm/service/SanitizationService.java
+++ b/backend/src/main/java/com/senior/spm/service/SanitizationService.java
@@ -3,7 +3,6 @@ package com.senior.spm.service;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.util.List;
-import java.util.UUID;
 
 import org.springframework.dao.OptimisticLockingFailureException;
 import org.springframework.scheduling.annotation.Scheduled;
@@ -21,7 +20,6 @@ import com.senior.spm.repository.ProjectGroupRepository;
 import com.senior.spm.repository.ScheduleWindowRepository;
 
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 
 /**
  * SanitizationService handles the automatic disbanding of unadvised groups
@@ -33,7 +31,6 @@ import lombok.extern.slf4j.Slf4j;
  */
 @Service
 @RequiredArgsConstructor
-@Slf4j
 public class SanitizationService {
 
     private final ScheduleWindowRepository scheduleWindowRepository;
@@ -42,44 +39,25 @@ public class SanitizationService {
     private final AdvisorRequestRepository advisorRequestRepository;
     private final TermConfigService termConfigService;
 
-    // Tracks last run time to detect newly closed windows
-    private LocalDateTime lastScheduledRun = LocalDateTime.now(ZoneId.of("UTC"));
-
     /**
-     * Scheduled job that runs every 5 minutes to check for newly closed ADVISOR_ASSOCIATION windows.
-     * Automatically triggers sanitization for any affected terms without manual intervention.
+     * Scheduled job that runs every 5 minutes to check for closed ADVISOR_ASSOCIATION windows
+     * and automatically disband unadvised groups.
      */
     @Scheduled(fixedRate = 300000) // 5 minutes
     public void runSanitizationIfWindowClosed() {
         LocalDateTime now = LocalDateTime.now(ZoneId.of("UTC"));
         
-        // Find windows that closed since last run
-        List<ScheduleWindow> recentlyClosedWindows = scheduleWindowRepository
-            .findByTypeAndClosesAtBetween(
-                WindowType.ADVISOR_ASSOCIATION,
-                lastScheduledRun,
-                now
-            );
+        // Find all ADVISOR_ASSOCIATION windows that have closed
+        List<ScheduleWindow> closedWindows = scheduleWindowRepository
+            .findByTypeAndClosesAtLessThan(WindowType.ADVISOR_ASSOCIATION, now);
 
-        if (recentlyClosedWindows.isEmpty()) {
-            log.debug("No newly closed ADVISOR_ASSOCIATION windows detected");
-            lastScheduledRun = now;
-            return;
-        }
-
-        log.info("Detected {} newly closed ADVISOR_ASSOCIATION window(s)", recentlyClosedWindows.size());
-
-        for (ScheduleWindow window : recentlyClosedWindows) {
+        for (ScheduleWindow window : closedWindows) {
             try {
-                log.info("Running automatic sanitization for term: {}", window.getTermId());
                 runSanitization(window.getTermId(), false);
             } catch (Exception e) {
-                log.error("Error during automatic sanitization for term {}", window.getTermId(), e);
                 // Continue to next window even if one fails
             }
         }
-
-        lastScheduledRun = now;
     }
 
     /**
@@ -87,9 +65,8 @@ public class SanitizationService {
      * Requires force=true if the ADVISOR_ASSOCIATION window is still open.
      * 
      * @param force if true, bypasses window check and sanitizes immediately
-     * @return SanitizationReport with counts of affected groups/requests
      */
-    public SanitizationReport triggerManually(boolean force) {
+    public void triggerManually(boolean force) {
         String termId = termConfigService.getActiveTermId();
         
         // Check if window is still open
@@ -106,8 +83,7 @@ public class SanitizationService {
             );
         }
 
-        log.info("Manual sanitization triggered for term: {} (force={})", termId, force);
-        return runSanitization(termId, force);
+        runSanitization(termId, force);
     }
 
     /**
@@ -121,86 +97,34 @@ public class SanitizationService {
      * (indicates concurrent modification by advisor accept).
      * 
      * @param termId the term to sanitize
-     * @param force flag (for audit purposes, currently unused)
-     * @return report of actions taken
+     * @param force flag (for audit purposes)
      */
     @Transactional
-    public SanitizationReport runSanitization(String termId, boolean force) {
-        SanitizationReport report = new SanitizationReport();
-        report.setTriggeredAt(LocalDateTime.now(ZoneId.of("UTC")));
-
+    public void runSanitization(String termId, boolean force) {
         // Find all unadvised groups (status FORMING, TOOLS_PENDING, TOOLS_BOUND with no advisor assigned)
         List<ProjectGroup> unadvisedGroups = projectGroupRepository
             .findByTermIdAndStatusInAndAdvisorIsNull(termId, 
                 java.util.List.of(GroupStatus.FORMING, GroupStatus.TOOLS_PENDING, GroupStatus.TOOLS_BOUND));
-
-        log.info("Found {} unadvised groups in term {}", unadvisedGroups.size(), termId);
 
         for (ProjectGroup group : unadvisedGroups) {
             try {
                 // Mark group as DISBANDED
                 group.setStatus(GroupStatus.DISBANDED);
                 projectGroupRepository.save(group);
-                log.debug("Disbanded group: {}", group.getId());
 
                 // Hard-delete all memberships (frees students to rejoin next term)
-                long membershipsDeleted = groupMembershipRepository.countByGroupId(group.getId());
                 groupMembershipRepository.deleteByGroupId(group.getId());
-                report.addDeletedMemberships(membershipsDeleted);
-                log.debug("Deleted {} memberships for group: {}", membershipsDeleted, group.getId());
 
                 // Auto-reject all PENDING advisor requests for this group
-                long requestsUpdated = advisorRequestRepository.bulkUpdateStatusByGroupId(
+                advisorRequestRepository.bulkUpdateStatusByGroupId(
                     com.senior.spm.entity.AdvisorRequest.RequestStatus.AUTO_REJECTED,
                     group.getId()
                 );
-                report.addRejectedRequests(requestsUpdated);
-                log.debug("Auto-rejected pending advisor requests for group: {}", group.getId());
-
-                report.incrementDisbandedCount();
 
             } catch (OptimisticLockingFailureException e) {
                 // Group was concurrently modified (likely by advisor accept).
                 // Skip this group and continue — it will be re-queried on next run.
-                log.warn("Skipping group {} due to concurrent modification (optimizer lock). "
-                    + "Will retry on next scheduler tick.", group.getId());
             }
         }
-
-        log.info("Sanitization complete for term {}: {} groups disbanded, "
-            + "{} memberships deleted, {} requests auto-rejected",
-            termId, report.getDisbandedCount(), report.getDeletedMemberships(),
-            report.getAutoRejectedRequests());
-
-        return report;
-    }
-
-    /**
-     * DTO for sanitization result
-     */
-    public static class SanitizationReport {
-        private int disbandedCount = 0;
-        private long deletedMemberships = 0;
-        private long autoRejectedRequests = 0;
-        private LocalDateTime triggeredAt;
-
-        public void incrementDisbandedCount() {
-            this.disbandedCount++;
-        }
-
-        public void addDeletedMemberships(long count) {
-            this.deletedMemberships += count;
-        }
-
-        public void addRejectedRequests(long count) {
-            this.autoRejectedRequests += count;
-        }
-
-        // Getters
-        public int getDisbandedCount() { return disbandedCount; }
-        public long getDeletedMemberships() { return deletedMemberships; }
-        public long getAutoRejectedRequests() { return autoRejectedRequests; }
-        public LocalDateTime getTriggeredAt() { return triggeredAt; }
-        public void setTriggeredAt(LocalDateTime triggeredAt) { this.triggeredAt = triggeredAt; }
     }
 }

--- a/backend/src/main/java/com/senior/spm/service/SanitizationService.java
+++ b/backend/src/main/java/com/senior/spm/service/SanitizationService.java
@@ -1,0 +1,206 @@
+package com.senior.spm.service;
+
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.List;
+import java.util.UUID;
+
+import org.springframework.dao.OptimisticLockingFailureException;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.senior.spm.entity.ProjectGroup;
+import com.senior.spm.entity.ProjectGroup.GroupStatus;
+import com.senior.spm.entity.ScheduleWindow;
+import com.senior.spm.entity.ScheduleWindow.WindowType;
+import com.senior.spm.exception.BusinessRuleException;
+import com.senior.spm.repository.AdvisorRequestRepository;
+import com.senior.spm.repository.GroupMembershipRepository;
+import com.senior.spm.repository.ProjectGroupRepository;
+import com.senior.spm.repository.ScheduleWindowRepository;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * SanitizationService handles the automatic disbanding of unadvised groups
+ * once the ADVISOR_ASSOCIATION window closes.
+ * 
+ * Scheduled job runs periodically to detect newly closed windows.
+ * Manual trigger available for coordinators to force sanitization.
+ * Gracefully handles OptimisticLockException — skips groups modified concurrently.
+ */
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class SanitizationService {
+
+    private final ScheduleWindowRepository scheduleWindowRepository;
+    private final ProjectGroupRepository projectGroupRepository;
+    private final GroupMembershipRepository groupMembershipRepository;
+    private final AdvisorRequestRepository advisorRequestRepository;
+    private final TermConfigService termConfigService;
+
+    // Tracks last run time to detect newly closed windows
+    private LocalDateTime lastScheduledRun = LocalDateTime.now(ZoneId.of("UTC"));
+
+    /**
+     * Scheduled job that runs every 5 minutes to check for newly closed ADVISOR_ASSOCIATION windows.
+     * Automatically triggers sanitization for any affected terms without manual intervention.
+     */
+    @Scheduled(fixedRate = 300000) // 5 minutes
+    public void runSanitizationIfWindowClosed() {
+        LocalDateTime now = LocalDateTime.now(ZoneId.of("UTC"));
+        
+        // Find windows that closed since last run
+        List<ScheduleWindow> recentlyClosedWindows = scheduleWindowRepository
+            .findByTypeAndClosesAtBetween(
+                WindowType.ADVISOR_ASSOCIATION,
+                lastScheduledRun,
+                now
+            );
+
+        if (recentlyClosedWindows.isEmpty()) {
+            log.debug("No newly closed ADVISOR_ASSOCIATION windows detected");
+            lastScheduledRun = now;
+            return;
+        }
+
+        log.info("Detected {} newly closed ADVISOR_ASSOCIATION window(s)", recentlyClosedWindows.size());
+
+        for (ScheduleWindow window : recentlyClosedWindows) {
+            try {
+                log.info("Running automatic sanitization for term: {}", window.getTermId());
+                runSanitization(window.getTermId(), false);
+            } catch (Exception e) {
+                log.error("Error during automatic sanitization for term {}", window.getTermId(), e);
+                // Continue to next window even if one fails
+            }
+        }
+
+        lastScheduledRun = now;
+    }
+
+    /**
+     * Manual trigger for coordinators to sanitize (disband unadvised groups).
+     * Requires force=true if the ADVISOR_ASSOCIATION window is still open.
+     * 
+     * @param force if true, bypasses window check and sanitizes immediately
+     * @return SanitizationReport with counts of affected groups/requests
+     */
+    public SanitizationReport triggerManually(boolean force) {
+        String termId = termConfigService.getActiveTermId();
+        
+        // Check if window is still open
+        ScheduleWindow window = scheduleWindowRepository
+            .findByTermIdAndType(termId, WindowType.ADVISOR_ASSOCIATION)
+            .orElse(null);
+
+        LocalDateTime now = LocalDateTime.now(ZoneId.of("UTC"));
+        boolean windowIsActive = window != null && window.getClosesAt().isAfter(now);
+
+        if (windowIsActive && !force) {
+            throw new BusinessRuleException(
+                "Advisor association window is still active — cannot sanitize early without confirmation"
+            );
+        }
+
+        log.info("Manual sanitization triggered for term: {} (force={})", termId, force);
+        return runSanitization(termId, force);
+    }
+
+    /**
+     * Core sanitization logic:
+     * 1. Find all groups without an advisor (unadvised)
+     * 2. Mark them DISBANDED
+     * 3. Hard-delete their memberships (frees students)
+     * 4. Auto-reject pending advisor requests
+     * 
+     * Gracefully skips groups that throw OptimisticLockException
+     * (indicates concurrent modification by advisor accept).
+     * 
+     * @param termId the term to sanitize
+     * @param force flag (for audit purposes, currently unused)
+     * @return report of actions taken
+     */
+    @Transactional
+    public SanitizationReport runSanitization(String termId, boolean force) {
+        SanitizationReport report = new SanitizationReport();
+        report.setTriggeredAt(LocalDateTime.now(ZoneId.of("UTC")));
+
+        // Find all unadvised groups (status FORMING, TOOLS_PENDING, TOOLS_BOUND with no advisor assigned)
+        List<ProjectGroup> unadvisedGroups = projectGroupRepository
+            .findByTermIdAndStatusInAndAdvisorIsNull(termId, 
+                java.util.List.of(GroupStatus.FORMING, GroupStatus.TOOLS_PENDING, GroupStatus.TOOLS_BOUND));
+
+        log.info("Found {} unadvised groups in term {}", unadvisedGroups.size(), termId);
+
+        for (ProjectGroup group : unadvisedGroups) {
+            try {
+                // Mark group as DISBANDED
+                group.setStatus(GroupStatus.DISBANDED);
+                projectGroupRepository.save(group);
+                log.debug("Disbanded group: {}", group.getId());
+
+                // Hard-delete all memberships (frees students to rejoin next term)
+                long membershipsDeleted = groupMembershipRepository.countByGroupId(group.getId());
+                groupMembershipRepository.deleteByGroupId(group.getId());
+                report.addDeletedMemberships(membershipsDeleted);
+                log.debug("Deleted {} memberships for group: {}", membershipsDeleted, group.getId());
+
+                // Auto-reject all PENDING advisor requests for this group
+                long requestsUpdated = advisorRequestRepository.bulkUpdateStatusByGroupId(
+                    com.senior.spm.entity.AdvisorRequest.RequestStatus.AUTO_REJECTED,
+                    group.getId()
+                );
+                report.addRejectedRequests(requestsUpdated);
+                log.debug("Auto-rejected pending advisor requests for group: {}", group.getId());
+
+                report.incrementDisbandedCount();
+
+            } catch (OptimisticLockingFailureException e) {
+                // Group was concurrently modified (likely by advisor accept).
+                // Skip this group and continue — it will be re-queried on next run.
+                log.warn("Skipping group {} due to concurrent modification (optimizer lock). "
+                    + "Will retry on next scheduler tick.", group.getId());
+            }
+        }
+
+        log.info("Sanitization complete for term {}: {} groups disbanded, "
+            + "{} memberships deleted, {} requests auto-rejected",
+            termId, report.getDisbandedCount(), report.getDeletedMemberships(),
+            report.getAutoRejectedRequests());
+
+        return report;
+    }
+
+    /**
+     * DTO for sanitization result
+     */
+    public static class SanitizationReport {
+        private int disbandedCount = 0;
+        private long deletedMemberships = 0;
+        private long autoRejectedRequests = 0;
+        private LocalDateTime triggeredAt;
+
+        public void incrementDisbandedCount() {
+            this.disbandedCount++;
+        }
+
+        public void addDeletedMemberships(long count) {
+            this.deletedMemberships += count;
+        }
+
+        public void addRejectedRequests(long count) {
+            this.autoRejectedRequests += count;
+        }
+
+        // Getters
+        public int getDisbandedCount() { return disbandedCount; }
+        public long getDeletedMemberships() { return deletedMemberships; }
+        public long getAutoRejectedRequests() { return autoRejectedRequests; }
+        public LocalDateTime getTriggeredAt() { return triggeredAt; }
+        public void setTriggeredAt(LocalDateTime triggeredAt) { this.triggeredAt = triggeredAt; }
+    }
+}

--- a/backend/src/test/java/com/senior/spm/service/SanitizationServiceTest.java
+++ b/backend/src/test/java/com/senior/spm/service/SanitizationServiceTest.java
@@ -1,0 +1,517 @@
+package com.senior.spm.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.Collections;
+import java.util.List;
+import java.util.UUID;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InOrder;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.dao.OptimisticLockingFailureException;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import com.senior.spm.entity.AdvisorRequest.RequestStatus;
+import com.senior.spm.entity.ProjectGroup;
+import com.senior.spm.entity.ProjectGroup.GroupStatus;
+import com.senior.spm.entity.ScheduleWindow;
+import com.senior.spm.entity.ScheduleWindow.WindowType;
+import com.senior.spm.repository.AdvisorRequestRepository;
+import com.senior.spm.repository.GroupMembershipRepository;
+import com.senior.spm.repository.ProjectGroupRepository;
+import com.senior.spm.repository.ScheduleWindowRepository;
+
+/**
+ * SanitizationServiceTest — verifies correct behavior of SanitizationService.
+ *
+ * <p>Tests are grouped by topic. Bug-regression tests (Bug1–Bug5 suites) document
+ * what was broken in PR #121 and prove the current implementation is correct.
+ * "Happy path" tests verify the core contract directly.
+ *
+ * <p>Self-proxy design note: {@code SanitizationService.self} is set to the real
+ * service instance via {@code ReflectionTestUtils} in {@code setUp()}, mirroring
+ * what Spring's {@code @Lazy @Autowired} does at runtime.
+ */
+@ExtendWith(MockitoExtension.class)
+class SanitizationServiceTest {
+
+    @Mock private ScheduleWindowRepository  scheduleWindowRepo;
+    @Mock private ProjectGroupRepository    projectGroupRepo;
+    @Mock private GroupMembershipRepository groupMembershipRepo;
+    @Mock private AdvisorRequestRepository  advisorRequestRepo;
+
+    @InjectMocks
+    private SanitizationService sanitizationService;
+
+    // ── shared fixtures ───────────────────────────────────────────────────────
+
+    private static final String TERM_2024 = "2024-FALL";
+    private static final String TERM_2025 = "2025-SPRING";
+
+    private ProjectGroup group1, group2, group3;
+    private ScheduleWindow window2024, window2025;
+
+    @BeforeEach
+    void setUp() {
+        group1 = makeGroup("Alpha", TERM_2024, GroupStatus.FORMING);
+        group2 = makeGroup("Beta",  TERM_2024, GroupStatus.TOOLS_PENDING);
+        group3 = makeGroup("Gamma", TERM_2024, GroupStatus.TOOLS_BOUND);
+
+        window2024 = makeWindow(TERM_2024, LocalDateTime.now().minusDays(1));
+        window2025 = makeWindow(TERM_2025, LocalDateTime.now().minusDays(2));
+
+        // Wire the self-proxy field the same way Spring would at runtime.
+        // Without this, scheduler calls to self.runSanitization() / self.disbandGroup()
+        // would throw NullPointerException.
+        ReflectionTestUtils.setField(sanitizationService, "self", sanitizationService);
+    }
+
+    // ═════════════════════════════════════════════════════════════════════════
+    // BUG 1 regression — Self-invocation / atomicity
+    // Fix: scheduler calls self.runSanitization() through self-proxy
+    // ═════════════════════════════════════════════════════════════════════════
+
+    @Nested
+    @DisplayName("Bug1 regression — atomicity: deleteByGroupId or bulkUpdate failure propagates out of disbandGroup")
+    class Bug1_Regression_Atomicity {
+
+        /**
+         * With {@code REQUIRES_NEW} on {@code disbandGroup}, any RuntimeException thrown
+         * by {@code deleteByGroupId} propagates out of the per-group transaction boundary.
+         * In production Hibernate, the REQUIRES_NEW transaction is rolled back before the
+         * exception surfaces — so {@code save(group)} is also rolled back.
+         *
+         * <p>In mock context there is no real transaction, so we verify the call sequence:
+         * save was called, delete threw, bulkUpdate was never reached, and the scheduler
+         * absorbed the exception (now with a log.error).
+         */
+        @Test
+        @DisplayName("deleteByGroupId failure: save emitted, bulkUpdate skipped, scheduler absorbs — REQUIRES_NEW rolls back save in production")
+        void deleteFailure_saveEmitted_bulkUpdateNeverCalled_schedulerAbsorbs() {
+            when(scheduleWindowRepo.findByTypeAndClosesAtLessThan(eq(WindowType.ADVISOR_ASSOCIATION), any()))
+                .thenReturn(List.of(window2024));
+            when(projectGroupRepo.findByTermIdAndStatusInAndAdvisorIsNull(eq(TERM_2024), any()))
+                .thenReturn(List.of(group1));
+            when(projectGroupRepo.save(group1)).thenReturn(group1);
+            doThrow(new RuntimeException("simulated DB error on membership delete"))
+                .when(groupMembershipRepo).deleteByGroupId(group1.getId());
+
+            assertThatCode(() -> sanitizationService.runSanitizationIfWindowClosed())
+                .doesNotThrowAnyException();
+
+            verify(projectGroupRepo).save(group1);
+            verify(groupMembershipRepo).deleteByGroupId(group1.getId());
+            verify(advisorRequestRepo, never()).bulkUpdateStatusByGroupId(any(), any());
+        }
+
+        /**
+         * Calling {@code runSanitization} directly (as a future coordinator controller would,
+         * through Spring proxy) must propagate a RuntimeException from {@code disbandGroup}
+         * so the transaction manager can roll back REQUIRES_NEW.
+         */
+        @Test
+        @DisplayName("Direct call: RuntimeException from disbandGroup propagates — transaction manager can roll back")
+        void directCall_runtimeExceptionPropagates() {
+            when(projectGroupRepo.findByTermIdAndStatusInAndAdvisorIsNull(eq(TERM_2024), any()))
+                .thenReturn(List.of(group1));
+            when(projectGroupRepo.save(group1)).thenReturn(group1);
+            doThrow(new RuntimeException("simulated constraint violation"))
+                .when(groupMembershipRepo).deleteByGroupId(group1.getId());
+
+            assertThatThrownBy(() -> sanitizationService.runSanitization(TERM_2024, false))
+                .isInstanceOf(RuntimeException.class)
+                .hasMessageContaining("simulated constraint violation");
+
+            verify(projectGroupRepo).save(group1);
+            verify(advisorRequestRepo, never()).bulkUpdateStatusByGroupId(any(), any());
+        }
+
+        /**
+         * P3.6 atomicity: all three ops (save / deleteByGroupId / bulkUpdate) run in one
+         * REQUIRES_NEW transaction. If bulkUpdate fails, save and delete are also rolled back.
+         * In mock context: bulkUpdate is called and throws; scheduler absorbs the error.
+         */
+        @Test
+        @DisplayName("bulkUpdateStatus failure: scheduler absorbs; REQUIRES_NEW rolls back all three ops in production")
+        void bulkUpdateFailure_schedulerAbsorbs_requiresNewRollsBackAllInProduction() {
+            when(scheduleWindowRepo.findByTypeAndClosesAtLessThan(eq(WindowType.ADVISOR_ASSOCIATION), any()))
+                .thenReturn(List.of(window2024));
+            when(projectGroupRepo.findByTermIdAndStatusInAndAdvisorIsNull(eq(TERM_2024), any()))
+                .thenReturn(List.of(group1));
+            when(projectGroupRepo.save(group1)).thenReturn(group1);
+            doThrow(new RuntimeException("bulk update failed"))
+                .when(advisorRequestRepo).bulkUpdateStatusByGroupId(any(), any());
+
+            assertThatCode(() -> sanitizationService.runSanitizationIfWindowClosed())
+                .doesNotThrowAnyException();
+
+            verify(projectGroupRepo).save(group1);
+            verify(groupMembershipRepo).deleteByGroupId(group1.getId());
+            verify(advisorRequestRepo).bulkUpdateStatusByGroupId(
+                eq(RequestStatus.AUTO_REJECTED), eq(group1.getId()));
+        }
+    }
+
+    // ═════════════════════════════════════════════════════════════════════════
+    // BUG 2 regression — REQUIRES_NEW isolates per-group transactions
+    // Fix: disbandGroup has Propagation.REQUIRES_NEW
+    // ═════════════════════════════════════════════════════════════════════════
+
+    @Nested
+    @DisplayName("Bug2 regression — OL isolation: REQUIRES_NEW ensures only the conflicting group is skipped")
+    class Bug2_Regression_OLIsolation {
+
+        /**
+         * OL on group2: group2's REQUIRES_NEW transaction rolls back.
+         * group1 and group3 each have their own committed transactions (REQUIRES_NEW).
+         * In mock context this is demonstrated via call verification.
+         */
+        @Test
+        @DisplayName("OL on group2: group1 and group3 fully processed; group2 memberships and requests untouched")
+        void olOnGroup2_group1And3FullyProcessed_group2Skipped() {
+            when(projectGroupRepo.findByTermIdAndStatusInAndAdvisorIsNull(eq(TERM_2024), any()))
+                .thenReturn(List.of(group1, group2, group3));
+            when(projectGroupRepo.save(group1)).thenReturn(group1);
+            when(projectGroupRepo.save(group2))
+                .thenThrow(new OptimisticLockingFailureException("version conflict on group2"));
+            when(projectGroupRepo.save(group3)).thenReturn(group3);
+
+            assertThatCode(() -> sanitizationService.runSanitization(TERM_2024, false))
+                .doesNotThrowAnyException();
+
+            // group1 fully processed
+            verify(groupMembershipRepo).deleteByGroupId(group1.getId());
+            verify(advisorRequestRepo).bulkUpdateStatusByGroupId(
+                eq(RequestStatus.AUTO_REJECTED), eq(group1.getId()));
+
+            // group2 skipped after OL
+            verify(groupMembershipRepo, never()).deleteByGroupId(group2.getId());
+            verify(advisorRequestRepo, never()).bulkUpdateStatusByGroupId(any(), eq(group2.getId()));
+
+            // group3 fully processed
+            verify(groupMembershipRepo).deleteByGroupId(group3.getId());
+            verify(advisorRequestRepo).bulkUpdateStatusByGroupId(
+                eq(RequestStatus.AUTO_REJECTED), eq(group3.getId()));
+        }
+
+        /**
+         * Verifies the REQUIRES_NEW design via a spy on the service itself.
+         * OL on group2 is caught; disbandGroup is called for group1 and group3.
+         * In production, each completed disbandGroup call committed its own transaction.
+         */
+        @Test
+        @DisplayName("REQUIRES_NEW design: disbandGroup called per group; OL on group2 caught; group1 and group3 dispatched")
+        void requiresNew_disbandGroupCalledPerGroup_olOnGroup2Caught() {
+            SanitizationService spyService = spy(sanitizationService);
+            ReflectionTestUtils.setField(spyService, "self", spyService);
+
+            when(projectGroupRepo.findByTermIdAndStatusInAndAdvisorIsNull(eq(TERM_2024), any()))
+                .thenReturn(List.of(group1, group2, group3));
+            doNothing().when(spyService).disbandGroup(group1);
+            doThrow(new OptimisticLockingFailureException("OL on group2"))
+                .when(spyService).disbandGroup(group2);
+            doNothing().when(spyService).disbandGroup(group3);
+
+            assertThatCode(() -> spyService.runSanitization(TERM_2024, false))
+                .doesNotThrowAnyException();
+
+            verify(spyService).disbandGroup(group1);
+            verify(spyService).disbandGroup(group2);  // called but threw OL — was caught
+            verify(spyService).disbandGroup(group3);  // still dispatched after group2 OL
+        }
+
+        /**
+         * OL on first group: remaining groups are still dispatched.
+         * In production, each has its own REQUIRES_NEW transaction.
+         */
+        @Test
+        @DisplayName("OL on first group: group2 and group3 still dispatched and committed independently")
+        void olOnFirstGroup_remainingGroupsStillProcessed() {
+            when(projectGroupRepo.findByTermIdAndStatusInAndAdvisorIsNull(eq(TERM_2024), any()))
+                .thenReturn(List.of(group1, group2, group3));
+            when(projectGroupRepo.save(group1))
+                .thenThrow(new OptimisticLockingFailureException("conflict on group1"));
+            when(projectGroupRepo.save(group2)).thenReturn(group2);
+            when(projectGroupRepo.save(group3)).thenReturn(group3);
+
+            assertThatCode(() -> sanitizationService.runSanitization(TERM_2024, false))
+                .doesNotThrowAnyException();
+
+            verify(groupMembershipRepo, never()).deleteByGroupId(group1.getId());
+            verify(groupMembershipRepo).deleteByGroupId(group2.getId());
+            verify(groupMembershipRepo).deleteByGroupId(group3.getId());
+        }
+    }
+
+    // ═════════════════════════════════════════════════════════════════════════
+    // BUG 3 regression — scheduler no longer swallows silently
+    // Fix: catch (Exception e) now calls log.error(...)
+    // ═════════════════════════════════════════════════════════════════════════
+
+    @Nested
+    @DisplayName("Bug3 regression — scheduler continues on per-term failure (log.error is called)")
+    class Bug3_Regression_ExceptionHandling {
+
+        @Test
+        @DisplayName("Exception from runSanitization does not halt the scheduler loop")
+        void exceptionFromRunSanitization_doesNotHaltScheduler() {
+            when(scheduleWindowRepo.findByTypeAndClosesAtLessThan(eq(WindowType.ADVISOR_ASSOCIATION), any()))
+                .thenReturn(List.of(window2024));
+            when(projectGroupRepo.findByTermIdAndStatusInAndAdvisorIsNull(eq(TERM_2024), any()))
+                .thenThrow(new RuntimeException("catastrophic DB failure"));
+
+            assertThatCode(() -> sanitizationService.runSanitizationIfWindowClosed())
+                .doesNotThrowAnyException();
+        }
+
+        @Test
+        @DisplayName("Failure on window2024 does not stop window2025 processing")
+        void failureOnFirstWindow_secondWindowStillProcessed() {
+            when(scheduleWindowRepo.findByTypeAndClosesAtLessThan(eq(WindowType.ADVISOR_ASSOCIATION), any()))
+                .thenReturn(List.of(window2024, window2025));
+            when(projectGroupRepo.findByTermIdAndStatusInAndAdvisorIsNull(eq(TERM_2024), any()))
+                .thenThrow(new RuntimeException("term 2024 error"));
+            when(projectGroupRepo.findByTermIdAndStatusInAndAdvisorIsNull(eq(TERM_2025), any()))
+                .thenReturn(Collections.emptyList());
+
+            assertThatCode(() -> sanitizationService.runSanitizationIfWindowClosed())
+                .doesNotThrowAnyException();
+
+            verify(projectGroupRepo).findByTermIdAndStatusInAndAdvisorIsNull(eq(TERM_2025), any());
+        }
+    }
+
+    // ═════════════════════════════════════════════════════════════════════════
+    // BUG 4 regression — force=true logs a warning, force=false does not
+    // Fix: if (force) log.warn(...)
+    // ═════════════════════════════════════════════════════════════════════════
+
+    @Nested
+    @DisplayName("Bug4 regression — force parameter: same repo behavior regardless of flag")
+    class Bug4_Regression_ForceParameter {
+
+        @Test
+        @DisplayName("force=true and force=false make identical repository calls")
+        void forceTrueAndForceFalse_identicalRepoCalls() {
+            when(projectGroupRepo.findByTermIdAndStatusInAndAdvisorIsNull(eq(TERM_2024), any()))
+                .thenReturn(List.of(group1));
+            when(projectGroupRepo.save(any())).thenReturn(group1);
+
+            sanitizationService.runSanitization(TERM_2024, false);
+
+            org.mockito.Mockito.reset(projectGroupRepo, groupMembershipRepo, advisorRequestRepo);
+            when(projectGroupRepo.findByTermIdAndStatusInAndAdvisorIsNull(eq(TERM_2024), any()))
+                .thenReturn(List.of(group1));
+            when(projectGroupRepo.save(any())).thenReturn(group1);
+
+            sanitizationService.runSanitization(TERM_2024, true);
+
+            verify(projectGroupRepo, times(1)).findByTermIdAndStatusInAndAdvisorIsNull(any(), any());
+            verify(projectGroupRepo, times(1)).save(group1);
+            verify(groupMembershipRepo, times(1)).deleteByGroupId(group1.getId());
+            verify(advisorRequestRepo, times(1)).bulkUpdateStatusByGroupId(any(), any());
+        }
+    }
+
+    // ═════════════════════════════════════════════════════════════════════════
+    // BUG 5 — Historical re-scan (behavior unchanged by design; idempotent)
+    // ═════════════════════════════════════════════════════════════════════════
+
+    @Nested
+    @DisplayName("Bug5 — Historical re-scan: idempotent by design (already-disbanded groups excluded by status filter)")
+    class Bug5_HistoricalRescanning {
+
+        @Test
+        @DisplayName("All historical closed windows queried on every tick — idempotent because disbanded groups are excluded from query")
+        void allHistoricalWindowsQueried_idempotentBecauseDisbandedGroupsExcluded() {
+            ScheduleWindow oldWindow1 = makeWindow("2023-FALL",   LocalDateTime.now().minusYears(1));
+            ScheduleWindow oldWindow2 = makeWindow("2023-SPRING", LocalDateTime.now().minusYears(2));
+
+            when(scheduleWindowRepo.findByTypeAndClosesAtLessThan(eq(WindowType.ADVISOR_ASSOCIATION), any()))
+                .thenReturn(List.of(window2024, window2025, oldWindow1, oldWindow2));
+            when(projectGroupRepo.findByTermIdAndStatusInAndAdvisorIsNull(any(), any()))
+                .thenReturn(Collections.emptyList());
+
+            assertThatCode(() -> sanitizationService.runSanitizationIfWindowClosed())
+                .doesNotThrowAnyException();
+
+            // All 4 windows processed — old terms return empty (nothing to do)
+            verify(projectGroupRepo, times(4))
+                .findByTermIdAndStatusInAndAdvisorIsNull(any(), any());
+        }
+
+        @Test
+        @DisplayName("No closed windows: no group queries issued")
+        void noClosedWindows_noGroupQueriesIssued() {
+            when(scheduleWindowRepo.findByTypeAndClosesAtLessThan(any(), any()))
+                .thenReturn(Collections.emptyList());
+
+            sanitizationService.runSanitizationIfWindowClosed();
+
+            verifyNoInteractions(projectGroupRepo, groupMembershipRepo, advisorRequestRepo);
+        }
+    }
+
+    // ═════════════════════════════════════════════════════════════════════════
+    // HAPPY PATH — core contract verification
+    // ═════════════════════════════════════════════════════════════════════════
+
+    @Nested
+    @DisplayName("Happy path — core contract")
+    class HappyPath {
+
+        @Test
+        @DisplayName("disbandGroup: three-step sequence in correct order (save → deleteMemberships → rejectRequests)")
+        void disbandGroup_threeStepSequenceInCorrectOrder() {
+            when(projectGroupRepo.save(group1)).thenReturn(group1);
+
+            sanitizationService.disbandGroup(group1);
+
+            InOrder order = inOrder(projectGroupRepo, groupMembershipRepo, advisorRequestRepo);
+            order.verify(projectGroupRepo).save(group1);
+            order.verify(groupMembershipRepo).deleteByGroupId(group1.getId());
+            order.verify(advisorRequestRepo).bulkUpdateStatusByGroupId(
+                eq(RequestStatus.AUTO_REJECTED), eq(group1.getId()));
+        }
+
+        @Test
+        @DisplayName("disbandGroup: group status set to DISBANDED before save()")
+        void disbandGroup_statusSetToDisbandedBeforeSave() {
+            when(projectGroupRepo.save(any())).thenAnswer(inv -> {
+                ProjectGroup saved = inv.getArgument(0);
+                assertThat(saved.getStatus()).isEqualTo(GroupStatus.DISBANDED);
+                return saved;
+            });
+
+            sanitizationService.disbandGroup(group1);
+        }
+
+        @Test
+        @DisplayName("runSanitization: queries FORMING + TOOLS_PENDING + TOOLS_BOUND statuses only")
+        void runSanitization_queriesCorrectStatuses() {
+            org.mockito.ArgumentCaptor<List<GroupStatus>> statusCaptor =
+                org.mockito.ArgumentCaptor.forClass(List.class);
+            when(projectGroupRepo.findByTermIdAndStatusInAndAdvisorIsNull(
+                    eq(TERM_2024), statusCaptor.capture()))
+                .thenReturn(Collections.emptyList());
+
+            sanitizationService.runSanitization(TERM_2024, false);
+
+            assertThat(statusCaptor.getValue())
+                .containsExactlyInAnyOrder(
+                    GroupStatus.FORMING,
+                    GroupStatus.TOOLS_PENDING,
+                    GroupStatus.TOOLS_BOUND);
+        }
+
+        @Test
+        @DisplayName("runSanitization: no groups found → no save/delete/update called")
+        void runSanitization_noGroupsFound_noWritesIssued() {
+            when(projectGroupRepo.findByTermIdAndStatusInAndAdvisorIsNull(eq(TERM_2024), any()))
+                .thenReturn(Collections.emptyList());
+
+            sanitizationService.runSanitization(TERM_2024, false);
+
+            verify(projectGroupRepo, never()).save(any());
+            verifyNoInteractions(groupMembershipRepo, advisorRequestRepo);
+        }
+
+        @Test
+        @DisplayName("runSanitization: multiple groups each receive all three operations")
+        void runSanitization_multipleGroups_eachReceiveAllThreeOps() {
+            when(projectGroupRepo.findByTermIdAndStatusInAndAdvisorIsNull(eq(TERM_2024), any()))
+                .thenReturn(List.of(group1, group2, group3));
+            when(projectGroupRepo.save(any())).thenAnswer(inv -> inv.getArgument(0));
+
+            sanitizationService.runSanitization(TERM_2024, false);
+
+            verify(projectGroupRepo, times(3)).save(any());
+            List.of(group1, group2, group3).forEach(g -> {
+                verify(groupMembershipRepo).deleteByGroupId(g.getId());
+                verify(advisorRequestRepo).bulkUpdateStatusByGroupId(
+                    eq(RequestStatus.AUTO_REJECTED), eq(g.getId()));
+            });
+        }
+
+        @Test
+        @DisplayName("Scheduler dispatches runSanitization for each closed window with correct termId")
+        void scheduler_dispatchesForEachClosedWindow_correctTermId() {
+            when(scheduleWindowRepo.findByTypeAndClosesAtLessThan(eq(WindowType.ADVISOR_ASSOCIATION), any()))
+                .thenReturn(List.of(window2024, window2025));
+            when(projectGroupRepo.findByTermIdAndStatusInAndAdvisorIsNull(any(), any()))
+                .thenReturn(Collections.emptyList());
+
+            sanitizationService.runSanitizationIfWindowClosed();
+
+            verify(projectGroupRepo).findByTermIdAndStatusInAndAdvisorIsNull(eq(TERM_2024), any());
+            verify(projectGroupRepo).findByTermIdAndStatusInAndAdvisorIsNull(eq(TERM_2025), any());
+        }
+
+        @Test
+        @DisplayName("Scheduler only queries ADVISOR_ASSOCIATION type windows")
+        void scheduler_onlyQueriesAdvisorAssociationWindows() {
+            when(scheduleWindowRepo.findByTypeAndClosesAtLessThan(
+                    eq(WindowType.ADVISOR_ASSOCIATION), any()))
+                .thenReturn(Collections.emptyList());
+
+            sanitizationService.runSanitizationIfWindowClosed();
+
+            verify(scheduleWindowRepo).findByTypeAndClosesAtLessThan(
+                eq(WindowType.ADVISOR_ASSOCIATION), any());
+            verifyNoInteractions(projectGroupRepo, groupMembershipRepo, advisorRequestRepo);
+        }
+    }
+
+    // ── helpers ───────────────────────────────────────────────────────────────
+
+    private static ProjectGroup makeGroup(String name, String termId, GroupStatus status) {
+        ProjectGroup g = new ProjectGroup();
+        g.setGroupName(name);
+        g.setTermId(termId);
+        g.setStatus(status);
+        g.setCreatedAt(LocalDateTime.now());
+        try {
+            java.lang.reflect.Field idField = ProjectGroup.class.getDeclaredField("id");
+            idField.setAccessible(true);
+            idField.set(g, UUID.randomUUID());
+
+            java.lang.reflect.Field versionField = ProjectGroup.class.getDeclaredField("version");
+            versionField.setAccessible(true);
+            versionField.set(g, 0L);
+        } catch (Exception ex) {
+            throw new RuntimeException(ex);
+        }
+        return g;
+    }
+
+    private static ScheduleWindow makeWindow(String termId, LocalDateTime closesAt) {
+        ScheduleWindow w = new ScheduleWindow();
+        w.setTermId(termId);
+        w.setType(WindowType.ADVISOR_ASSOCIATION);
+        w.setOpensAt(closesAt.minusDays(14));
+        w.setClosesAt(closesAt);
+        return w;
+    }
+}


### PR DESCRIPTION
Implements `SanitizationService` for automatic disbanding of unadvised groups after `ADVISOR_ASSOCIATION` window closes.

## Changes
- **`SanitizationService.java`**: Core service with:
  - `@Scheduled` job (5min interval) detecting closed `ADVISOR_ASSOCIATION` windows
  - `runSanitization(termId, force)`: queries groups without `advisorId` (`FORMING`, `TOOLS_PENDING`, `TOOLS_BOUND`) → marks `DISBANDED`
  - Hard-deletes `GroupMembership` rows for disbanded groups
  - Bulk updates `PENDING` advisor requests → `AUTO_REJECTED`
  - Graceful `OptimisticLockingFailureException` handling per-group (skip & continue)
- **`CoordinatorController.java`**: Removed premature sanitize endpoint (belongs to Controllers & DTOs issue)

## Acceptance Criteria
- [x] Groups lacking `advisorId` transition to `DISBANDED` upon window close
- [x] `OptimisticLockException` triggered by `@Version` correctly skips the group — does not halt the entire job
- [x] Manual trigger endpoint deferred to Controllers & DTOs issue

Resolved #61 