### PR TITLE
Feature/issue 66 coordinator advisor sanitization

### DIFF
--- a/frontend/composables/useApiClient.ts
+++ b/frontend/composables/useApiClient.ts
@@ -79,6 +79,38 @@ export interface GithubLoginResponse {
   };
 }
 
+export interface CoordinatorGroupSummary {
+  id: string;
+  groupName: string;
+  termId?: string;
+  status: string;
+  memberCount: number;
+  jiraBound: boolean;
+  githubBound: boolean;
+}
+
+export interface CoordinatorAdvisor {
+  advisorId: string;
+  name: string;
+  mail: string;
+  currentGroupCount: number;
+  capacity: number;
+  atCapacity: boolean;
+}
+
+export interface AdvisorOverrideResponse {
+  groupId: string;
+  status: "ADVISOR_ASSIGNED" | "TOOLS_BOUND";
+  advisorId: string | null;
+}
+
+export interface SanitizationReport {
+  disbandedCount: number;
+  autoRejectedRequestCount?: number;
+  rejectedRequestCount?: number;
+  triggeredAt: string;
+}
+
 async function apiCall<T>(
   endpoint: string,
   method: "GET" | "POST" | "PUT" | "PATCH" | "DELETE" = "GET",
@@ -287,6 +319,60 @@ export function useApiClient() {
     return apiCall<GroupDetailResponse>("/groups/my", "GET", undefined, token);
   }
 
+  async function fetchCoordinatorGroups(token?: string): Promise<CoordinatorGroupSummary[]> {
+    return apiCall<CoordinatorGroupSummary[]>("/coordinator/groups", "GET", undefined, token);
+  }
+
+  async function fetchCoordinatorGroup(groupId: string, token?: string): Promise<GroupDetailResponse> {
+    return apiCall<GroupDetailResponse>(
+      `/coordinator/groups/${encodeURIComponent(groupId)}`,
+      "GET",
+      undefined,
+      token
+    );
+  }
+
+  async function fetchCoordinatorAdvisors(token?: string): Promise<CoordinatorAdvisor[]> {
+    return apiCall<CoordinatorAdvisor[]>("/coordinator/advisors", "GET", undefined, token);
+  }
+
+  async function assignCoordinatorAdvisor(
+    groupId: string,
+    advisorId: string,
+    token?: string
+  ): Promise<AdvisorOverrideResponse> {
+    return apiCall<AdvisorOverrideResponse>(
+      `/coordinator/groups/${encodeURIComponent(groupId)}/advisor`,
+      "PATCH",
+      { action: "ASSIGN", advisorId },
+      token
+    );
+  }
+
+  async function removeCoordinatorAdvisor(
+    groupId: string,
+    token?: string
+  ): Promise<AdvisorOverrideResponse> {
+    return apiCall<AdvisorOverrideResponse>(
+      `/coordinator/groups/${encodeURIComponent(groupId)}/advisor`,
+      "PATCH",
+      { action: "REMOVE" },
+      token
+    );
+  }
+
+  async function runCoordinatorSanitization(
+    force: boolean,
+    token?: string
+  ): Promise<SanitizationReport> {
+    return apiCall<SanitizationReport>(
+      "/coordinator/sanitize",
+      "POST",
+      force ? { force: true } : undefined,
+      token
+    );
+  }
+
   return {
     getAuthToken,
     loginFaculty,
@@ -309,5 +395,11 @@ export function useApiClient() {
     registerProfessor,
     createGroup,
     fetchMyGroup,
+    fetchCoordinatorGroups,
+    fetchCoordinatorGroup,
+    fetchCoordinatorAdvisors,
+    assignCoordinatorAdvisor,
+    removeCoordinatorAdvisor,
+    runCoordinatorSanitization,
   };
 }

--- a/frontend/pages/coordinator/dashboard.vue
+++ b/frontend/pages/coordinator/dashboard.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
-	import { LogOut, Play, FileText, ClipboardCheck, Send } from "lucide-vue-next";
+	import { AlertTriangle, LogOut, Play, FileText, ClipboardCheck, Send, ShieldX, X } from "lucide-vue-next";
 	import { useAuthStore } from "~/stores/auth";
+	import type { SanitizationReport } from "~/composables/useApiClient";
 
 	definePageMeta({
 		middleware: "auth",
@@ -9,10 +10,80 @@
 
 	const router = useRouter();
 	const authStore = useAuthStore();
+	const { getAuthToken, runCoordinatorSanitization } = useApiClient();
+
+	const sanitizationLoading = ref(false);
+	const sanitizationError = ref("");
+	const sanitizationReport = ref<SanitizationReport | null>(null);
+	const showReportModal = ref(false);
+	const showForceWarning = ref(false);
+
+	const autoRejectedCount = computed(() =>
+		sanitizationReport.value?.autoRejectedRequestCount ??
+		sanitizationReport.value?.rejectedRequestCount ??
+		0
+	);
+
+	const triggeredAtLabel = computed(() => {
+		if (!sanitizationReport.value?.triggeredAt) {
+			return "Unavailable";
+		}
+
+		return new Intl.DateTimeFormat("en-US", {
+			dateStyle: "medium",
+			timeStyle: "short",
+		}).format(new Date(sanitizationReport.value.triggeredAt));
+	});
 
 	function handleLogout() {
 		authStore.logout();
 		router.push("/auth/login");
+	}
+
+	function closeReportModal() {
+		showReportModal.value = false;
+	}
+
+	function isActiveWindowError(message = "") {
+		const normalized = message.toLowerCase();
+		return normalized.includes("window") && normalized.includes("active");
+	}
+
+	async function submitSanitization(force = false) {
+		sanitizationLoading.value = true;
+		sanitizationError.value = "";
+
+		try {
+			const token = getAuthToken();
+			if (!token) {
+				throw new Error("Authentication required. Please log in again.");
+			}
+
+			const report = await runCoordinatorSanitization(force, token);
+			sanitizationReport.value = report;
+			showForceWarning.value = false;
+			showReportModal.value = true;
+		} catch (error: unknown) {
+			const apiError = error as { message?: string };
+			const message = apiError.message || "Sanitization could not be started.";
+
+			if (!force && isActiveWindowError(message)) {
+				showForceWarning.value = true;
+				return;
+			}
+
+			sanitizationError.value = message;
+		} finally {
+			sanitizationLoading.value = false;
+		}
+	}
+
+	function handleRunSanitization() {
+		submitSanitization(false);
+	}
+
+	function confirmForcedSanitization() {
+		submitSanitization(true);
 	}
 </script>
 
@@ -93,7 +164,126 @@
             Review and finalize all settings.
           </p>
         </NuxtLink>
+
+        <button
+          type="button"
+          class="group rounded-2xl border border-red-200 bg-red-50 p-6 text-left shadow-sm transition-all hover:border-red-400 hover:shadow-md disabled:cursor-not-allowed disabled:opacity-70 dark:border-red-900 dark:bg-red-950/30 dark:hover:border-red-500"
+          :disabled="sanitizationLoading"
+          @click="handleRunSanitization"
+        >
+          <ShieldX class="h-8 w-8 text-red-600 dark:text-red-400" />
+          <h3 class="mt-3 font-semibold text-red-950 group-hover:text-red-700 dark:text-red-100 dark:group-hover:text-red-300">
+            Run Sanitization
+          </h3>
+          <p class="mt-1 text-sm text-red-800 dark:text-red-300">
+            Disband unadvised groups and auto-reject pending advisor requests.
+          </p>
+        </button>
       </div>
+
+      <section
+        v-if="sanitizationError"
+        class="rounded-2xl border border-red-300 bg-red-50 p-4 text-sm text-red-800 shadow-sm dark:border-red-800 dark:bg-red-950/40 dark:text-red-200"
+      >
+        {{ sanitizationError }}
+      </section>
+    </div>
+
+    <div
+      v-if="showForceWarning"
+      class="fixed inset-0 z-50 flex items-center justify-center bg-slate-950/70 p-4"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="force-sanitization-title"
+    >
+      <section class="w-full max-w-lg rounded-lg border border-red-300 bg-white p-6 shadow-xl dark:border-red-800 dark:bg-slate-900">
+        <div class="flex items-start gap-3">
+          <AlertTriangle class="mt-1 h-6 w-6 shrink-0 text-red-600 dark:text-red-400" />
+          <div>
+            <h2 id="force-sanitization-title" class="text-xl font-semibold text-red-950 dark:text-red-100">
+              Advisor window is still active
+            </h2>
+            <p class="mt-3 text-sm leading-6 text-red-900 dark:text-red-200">
+              Forced sanitization will disband every group without an advisor right now and auto-reject their pending advisor requests. This bypasses the active window.
+            </p>
+          </div>
+        </div>
+
+        <div class="mt-6 flex flex-col-reverse gap-3 sm:flex-row sm:justify-end">
+          <button
+            type="button"
+            class="rounded-lg border border-slate-300 bg-white px-4 py-2 text-sm font-medium text-slate-700 transition hover:bg-slate-50 dark:border-slate-600 dark:bg-slate-800 dark:text-slate-200 dark:hover:bg-slate-700"
+            :disabled="sanitizationLoading"
+            @click="showForceWarning = false"
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            class="rounded-lg bg-red-700 px-4 py-2 text-sm font-semibold text-white transition hover:bg-red-800 disabled:cursor-not-allowed disabled:opacity-70"
+            :disabled="sanitizationLoading"
+            @click="confirmForcedSanitization"
+          >
+            Force Sanitization
+          </button>
+        </div>
+      </section>
+    </div>
+
+    <div
+      v-if="showReportModal && sanitizationReport"
+      class="fixed inset-0 z-50 flex items-center justify-center bg-slate-950/70 p-4"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="sanitization-report-title"
+    >
+      <section class="w-full max-w-lg rounded-lg border border-slate-200 bg-white p-6 shadow-xl dark:border-slate-700 dark:bg-slate-900">
+        <div class="flex items-start justify-between gap-4">
+          <div>
+            <p class="text-xs font-semibold uppercase tracking-[0.2em] text-slate-500 dark:text-slate-400">
+              Sanitization Report
+            </p>
+            <h2 id="sanitization-report-title" class="mt-2 text-2xl font-semibold text-slate-950 dark:text-white">
+              Run complete
+            </h2>
+          </div>
+          <button
+            type="button"
+            class="rounded-lg p-2 text-slate-500 transition hover:bg-slate-100 hover:text-slate-800 dark:text-slate-400 dark:hover:bg-slate-800 dark:hover:text-slate-100"
+            aria-label="Close report"
+            @click="closeReportModal"
+          >
+            <X class="h-5 w-5" />
+          </button>
+        </div>
+
+        <dl class="mt-6 grid gap-4 sm:grid-cols-2">
+          <div class="rounded-lg border border-slate-200 p-4 dark:border-slate-700">
+            <dt class="text-sm text-slate-600 dark:text-slate-400">
+              Groups disbanded
+            </dt>
+            <dd class="mt-2 text-3xl font-semibold text-slate-950 dark:text-white">
+              {{ sanitizationReport.disbandedCount }}
+            </dd>
+          </div>
+          <div class="rounded-lg border border-slate-200 p-4 dark:border-slate-700">
+            <dt class="text-sm text-slate-600 dark:text-slate-400">
+              Requests auto-rejected
+            </dt>
+            <dd class="mt-2 text-3xl font-semibold text-slate-950 dark:text-white">
+              {{ autoRejectedCount }}
+            </dd>
+          </div>
+          <div class="rounded-lg border border-slate-200 p-4 dark:border-slate-700 sm:col-span-2">
+            <dt class="text-sm text-slate-600 dark:text-slate-400">
+              Triggered at
+            </dt>
+            <dd class="mt-2 text-sm font-medium text-slate-950 dark:text-white">
+              {{ triggeredAtLabel }}
+            </dd>
+          </div>
+        </dl>
+      </section>
     </div>
   </main>
 </template>

--- a/frontend/pages/coordinator/groups/[groupId].vue
+++ b/frontend/pages/coordinator/groups/[groupId].vue
@@ -1,0 +1,389 @@
+<script setup lang="ts">
+	import { AlertCircle, ArrowLeft, RefreshCw, UserCheck, UserMinus, Users } from "lucide-vue-next";
+	import type { CoordinatorAdvisor } from "~/composables/useApiClient";
+	import type { GroupDetailResponse } from "~/types/group";
+
+	definePageMeta({
+		middleware: "auth",
+		roles: ["Coordinator"],
+	});
+
+	const route = useRoute();
+	const {
+		getAuthToken,
+		fetchCoordinatorGroup,
+		fetchCoordinatorAdvisors,
+		assignCoordinatorAdvisor,
+		removeCoordinatorAdvisor,
+	} = useApiClient();
+
+	const groupId = computed(() => String(route.params.groupId || ""));
+	const group = ref<GroupDetailResponse | null>(null);
+	const advisors = ref<CoordinatorAdvisor[]>([]);
+	const selectedAdvisorId = ref("");
+	const loading = ref(true);
+	const advisorsLoading = ref(false);
+	const submitting = ref(false);
+	const errorMessage = ref("");
+	const advisorMessage = ref("");
+	const removeConfirmationArmed = ref(false);
+
+	const selectedAdvisor = computed(() =>
+		advisors.value.find((advisor) => advisor.advisorId === selectedAdvisorId.value) || null
+	);
+
+	const assignedAdvisor = computed(() => {
+		if (!group.value?.advisorId) {
+			return null;
+		}
+
+		return (
+			advisors.value.find((advisor) => advisor.advisorId === group.value?.advisorId) || {
+				advisorId: group.value.advisorId,
+				name: group.value.advisorName || "Assigned advisor",
+				mail: group.value.advisorMail || "",
+				currentGroupCount: 0,
+				capacity: 0,
+				atCapacity: false,
+			}
+		);
+	});
+
+	const createdAtLabel = computed(() => {
+		if (!group.value?.createdAt) {
+			return "Creation date unavailable";
+		}
+
+		return new Intl.DateTimeFormat("en-US", {
+			dateStyle: "medium",
+			timeStyle: "short",
+		}).format(new Date(group.value.createdAt));
+	});
+
+	async function loadGroup() {
+		errorMessage.value = "";
+
+		try {
+			const token = getAuthToken();
+			if (!token) {
+				throw new Error("Authentication required. Please log in again.");
+			}
+
+			group.value = await fetchCoordinatorGroup(groupId.value, token);
+			selectedAdvisorId.value = group.value.advisorId || selectedAdvisorId.value;
+		} catch (error: unknown) {
+			const apiError = error as { message?: string };
+			group.value = null;
+			errorMessage.value = apiError.message || "We couldn't load this group.";
+		}
+	}
+
+	async function loadAdvisors() {
+		advisorsLoading.value = true;
+		advisorMessage.value = "";
+
+		try {
+			const token = getAuthToken();
+			if (!token) {
+				throw new Error("Authentication required. Please log in again.");
+			}
+
+			advisors.value = await fetchCoordinatorAdvisors(token);
+		} catch (error: unknown) {
+			const apiError = error as { message?: string };
+			advisorMessage.value = apiError.message || "Advisors could not be loaded.";
+		} finally {
+			advisorsLoading.value = false;
+		}
+	}
+
+	async function refreshPage() {
+		loading.value = true;
+		await Promise.all([loadGroup(), loadAdvisors()]);
+		loading.value = false;
+	}
+
+	async function handleAssignAdvisor() {
+		if (!group.value || !selectedAdvisorId.value) {
+			return;
+		}
+
+		submitting.value = true;
+		advisorMessage.value = "";
+
+		try {
+			const token = getAuthToken();
+			if (!token) {
+				throw new Error("Authentication required. Please log in again.");
+			}
+
+			const response = await assignCoordinatorAdvisor(group.value.id, selectedAdvisorId.value, token);
+			const advisor = selectedAdvisor.value;
+
+			group.value = {
+				...group.value,
+				status: response.status,
+				advisorId: response.advisorId,
+				advisorName: advisor?.name || group.value.advisorName || null,
+				advisorMail: advisor?.mail || group.value.advisorMail || null,
+			};
+			removeConfirmationArmed.value = false;
+			advisorMessage.value = "Advisor assigned. Group status updated without a reload.";
+		} catch (error: unknown) {
+			const apiError = error as { message?: string };
+			advisorMessage.value = apiError.message || "Advisor assignment failed.";
+		} finally {
+			submitting.value = false;
+		}
+	}
+
+	async function handleRemoveAdvisor() {
+		if (!group.value) {
+			return;
+		}
+
+		if (!removeConfirmationArmed.value) {
+			removeConfirmationArmed.value = true;
+			advisorMessage.value = "Click Remove Advisor again to confirm removal.";
+			return;
+		}
+
+		submitting.value = true;
+		advisorMessage.value = "";
+
+		try {
+			const token = getAuthToken();
+			if (!token) {
+				throw new Error("Authentication required. Please log in again.");
+			}
+
+			const response = await removeCoordinatorAdvisor(group.value.id, token);
+			group.value = {
+				...group.value,
+				status: response.status,
+				advisorId: null,
+				advisorName: null,
+				advisorMail: null,
+			};
+			selectedAdvisorId.value = "";
+			removeConfirmationArmed.value = false;
+			advisorMessage.value = "Advisor removed. Group status returned to Tools Bound.";
+		} catch (error: unknown) {
+			const apiError = error as { message?: string };
+			advisorMessage.value = apiError.message || "Advisor removal failed.";
+		} finally {
+			submitting.value = false;
+		}
+	}
+
+	onMounted(refreshPage);
+</script>
+
+<template>
+  <main class="min-h-screen bg-gradient-to-br from-slate-50 via-white to-slate-100 p-4 transition-colors dark:from-slate-950 dark:via-slate-900 dark:to-slate-950 md:p-8">
+    <div class="mx-auto w-full max-w-5xl space-y-6">
+      <header class="rounded-2xl border border-slate-200 bg-white/90 p-6 shadow-sm backdrop-blur transition-colors dark:border-slate-700 dark:bg-slate-800/90 dark:shadow-lg">
+        <div class="flex flex-col gap-4 md:flex-row md:items-start md:justify-between">
+          <div>
+            <NuxtLink
+              to="/coordinator/dashboard"
+              class="inline-flex items-center gap-2 text-sm font-medium text-slate-600 transition hover:text-slate-950 dark:text-slate-400 dark:hover:text-white"
+            >
+              <ArrowLeft class="h-4 w-4" />
+              Coordinator Dashboard
+            </NuxtLink>
+            <h1 class="mt-4 text-2xl font-semibold tracking-tight text-slate-900 dark:text-white md:text-3xl">
+              {{ group?.groupName || "Group Detail" }}
+            </h1>
+            <p class="mt-2 text-sm text-slate-600 dark:text-slate-400">
+              Review group status and manage advisor assignment.
+            </p>
+          </div>
+
+          <button
+            type="button"
+            class="inline-flex items-center justify-center gap-2 self-start rounded-lg border border-slate-300 bg-white px-4 py-2 text-sm font-medium text-slate-700 transition hover:bg-slate-50 dark:border-slate-600 dark:bg-slate-700 dark:text-slate-200 dark:hover:bg-slate-600"
+            :disabled="loading"
+            @click="refreshPage"
+          >
+            <RefreshCw class="h-4 w-4" />
+            Refresh
+          </button>
+        </div>
+      </header>
+
+      <section
+        v-if="loading"
+        class="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm dark:border-slate-700 dark:bg-slate-800"
+      >
+        <div class="animate-pulse space-y-4">
+          <div class="h-6 w-48 rounded bg-slate-200 dark:bg-slate-700"></div>
+          <div class="h-4 w-full rounded bg-slate-200 dark:bg-slate-700"></div>
+          <div class="h-32 rounded-xl bg-slate-100 dark:bg-slate-900"></div>
+        </div>
+      </section>
+
+      <section
+        v-else-if="errorMessage"
+        class="rounded-2xl border border-red-300 bg-red-50 p-6 shadow-sm dark:border-red-800 dark:bg-red-950/40"
+      >
+        <div class="flex items-start gap-3">
+          <AlertCircle class="mt-0.5 h-5 w-5 shrink-0 text-red-600 dark:text-red-400" />
+          <div>
+            <h2 class="text-lg font-semibold text-red-900 dark:text-red-100">
+              Unable to load group
+            </h2>
+            <p class="mt-2 text-sm text-red-800 dark:text-red-300">
+              {{ errorMessage }}
+            </p>
+          </div>
+        </div>
+      </section>
+
+      <template v-else-if="group">
+        <section class="grid gap-6 lg:grid-cols-[1.2fr_1fr]">
+          <article class="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm transition-colors dark:border-slate-700 dark:bg-slate-800 dark:shadow-lg">
+            <div class="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+              <div>
+                <p class="text-xs font-semibold uppercase tracking-[0.2em] text-slate-500 dark:text-slate-400">
+                  Current Group
+                </p>
+                <h2 class="mt-2 text-2xl font-semibold text-slate-900 dark:text-white">
+                  {{ group.groupName }}
+                </h2>
+              </div>
+              <UiGroupStatusBadge :status="group.status" />
+            </div>
+
+            <dl class="mt-6 grid gap-4 rounded-xl bg-slate-50 p-4 dark:bg-slate-900/60 sm:grid-cols-2">
+              <div>
+                <dt class="text-xs font-medium uppercase tracking-wide text-slate-500 dark:text-slate-400">
+                  Term
+                </dt>
+                <dd class="mt-1 text-sm font-medium text-slate-900 dark:text-white">
+                  {{ group.termId || "Unavailable" }}
+                </dd>
+              </div>
+              <div>
+                <dt class="text-xs font-medium uppercase tracking-wide text-slate-500 dark:text-slate-400">
+                  Created
+                </dt>
+                <dd class="mt-1 text-sm font-medium text-slate-900 dark:text-white">
+                  {{ createdAtLabel }}
+                </dd>
+              </div>
+              <div>
+                <dt class="text-xs font-medium uppercase tracking-wide text-slate-500 dark:text-slate-400">
+                  Jira
+                </dt>
+                <dd class="mt-1 text-sm font-medium text-slate-900 dark:text-white">
+                  {{ group.jiraBound ? "Connected" : "Not connected" }}
+                </dd>
+              </div>
+              <div>
+                <dt class="text-xs font-medium uppercase tracking-wide text-slate-500 dark:text-slate-400">
+                  GitHub
+                </dt>
+                <dd class="mt-1 text-sm font-medium text-slate-900 dark:text-white">
+                  {{ group.githubBound ? "Connected" : "Not connected" }}
+                </dd>
+              </div>
+            </dl>
+          </article>
+
+          <article class="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm transition-colors dark:border-slate-700 dark:bg-slate-800 dark:shadow-lg">
+            <div class="flex items-start gap-3">
+              <UserCheck class="mt-0.5 h-5 w-5 shrink-0 text-slate-700 dark:text-slate-300" />
+              <div>
+                <h2 class="text-lg font-semibold text-slate-900 dark:text-white">
+                  Advisor Management
+                </h2>
+                <p class="mt-2 text-sm text-slate-600 dark:text-slate-400">
+                  Select any advisor, including advisors currently at capacity.
+                </p>
+              </div>
+            </div>
+
+            <div class="mt-5 rounded-lg border border-slate-200 bg-slate-50 p-4 dark:border-slate-700 dark:bg-slate-900/60">
+              <p class="text-xs font-medium uppercase tracking-wide text-slate-500 dark:text-slate-400">
+                Assigned Advisor
+              </p>
+              <p class="mt-2 text-sm font-semibold text-slate-950 dark:text-white">
+                {{ assignedAdvisor?.name || "No advisor assigned" }}
+              </p>
+              <p v-if="assignedAdvisor?.mail" class="mt-1 text-xs text-slate-600 dark:text-slate-400">
+                {{ assignedAdvisor.mail }}
+              </p>
+            </div>
+
+            <label class="mt-5 block text-sm font-medium text-slate-700 dark:text-slate-200" for="advisor-select">
+              Advisor
+            </label>
+            <select
+              id="advisor-select"
+              v-model="selectedAdvisorId"
+              class="mt-2 w-full rounded-lg border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 outline-none transition focus:border-blue-500 focus:ring-2 focus:ring-blue-200 disabled:cursor-not-allowed disabled:bg-slate-100 dark:border-slate-600 dark:bg-slate-900 dark:text-white dark:focus:border-blue-400 dark:focus:ring-blue-900"
+              :disabled="advisorsLoading || submitting"
+            >
+              <option value="">
+                {{ advisorsLoading ? "Loading advisors..." : "Select an advisor" }}
+              </option>
+              <option
+                v-for="advisor in advisors"
+                :key="advisor.advisorId"
+                :value="advisor.advisorId"
+              >
+                {{ advisor.name }} ({{ advisor.currentGroupCount }}/{{ advisor.capacity }}){{ advisor.atCapacity ? " - At capacity" : "" }}
+              </option>
+            </select>
+
+            <p
+              v-if="selectedAdvisor?.atCapacity"
+              class="mt-2 rounded-lg border border-amber-200 bg-amber-50 px-3 py-2 text-sm text-amber-900 dark:border-amber-800 dark:bg-amber-950/30 dark:text-amber-200"
+            >
+              This advisor is at capacity, but coordinator override can still assign them.
+            </p>
+
+            <div class="mt-5 flex flex-col gap-3 sm:flex-row">
+              <button
+                type="button"
+                class="inline-flex items-center justify-center rounded-lg bg-blue-600 px-4 py-2 text-sm font-medium text-white transition hover:bg-blue-700 disabled:cursor-not-allowed disabled:opacity-70 dark:bg-blue-700 dark:hover:bg-blue-600"
+                :disabled="!selectedAdvisorId || submitting"
+                @click="handleAssignAdvisor"
+              >
+                Assign Advisor
+              </button>
+              <button
+                type="button"
+                class="inline-flex items-center justify-center gap-2 rounded-lg border border-red-300 px-4 py-2 text-sm font-medium text-red-700 transition hover:bg-red-50 disabled:cursor-not-allowed disabled:opacity-70 dark:border-red-800 dark:text-red-300 dark:hover:bg-red-950/30"
+                :disabled="!group.advisorId || submitting"
+                @click="handleRemoveAdvisor"
+              >
+                <UserMinus class="h-4 w-4" />
+                {{ removeConfirmationArmed ? "Confirm Removal" : "Remove Advisor" }}
+              </button>
+            </div>
+
+            <p
+              v-if="advisorMessage"
+              class="mt-4 rounded-lg border border-slate-200 bg-slate-50 px-3 py-2 text-sm text-slate-700 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-200"
+            >
+              {{ advisorMessage }}
+            </p>
+          </article>
+        </section>
+
+        <section class="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm transition-colors dark:border-slate-700 dark:bg-slate-800 dark:shadow-lg">
+          <div class="mb-4 flex items-center gap-2">
+            <Users class="h-5 w-5 text-slate-700 dark:text-slate-300" />
+            <h2 class="text-lg font-semibold text-slate-900 dark:text-white">
+              Group Members
+            </h2>
+          </div>
+
+          <UiMemberList :members="group.members" />
+        </section>
+      </template>
+    </div>
+  </main>
+</template>

--- a/frontend/pages/coordinator/groups/[groupId].vue
+++ b/frontend/pages/coordinator/groups/[groupId].vue
@@ -32,16 +32,34 @@
 		advisors.value.find((advisor) => advisor.advisorId === selectedAdvisorId.value) || null
 	);
 
+	const hasAssignedAdvisor = computed(() =>
+		Boolean(group.value?.advisorId) || group.value?.status === "ADVISOR_ASSIGNED"
+	);
+
 	const assignedAdvisor = computed(() => {
-		if (!group.value?.advisorId) {
+		const currentGroup = group.value;
+		if (!currentGroup || (!currentGroup.advisorId && !hasAssignedAdvisor.value)) {
 			return null;
 		}
 
+		if (!currentGroup.advisorId) {
+			return {
+				advisorId: "",
+				name: currentGroup.advisorName || "Assigned advisor",
+				mail: currentGroup.advisorMail || "",
+				currentGroupCount: 0,
+				capacity: 0,
+				atCapacity: false,
+			};
+		}
+
 		return (
-			advisors.value.find((advisor) => advisor.advisorId === group.value?.advisorId) || {
-				advisorId: group.value.advisorId,
-				name: group.value.advisorName || "Assigned advisor",
-				mail: group.value.advisorMail || "",
+			advisors.value.find((advisor) => advisor.advisorId === currentGroup.advisorId) ||
+			selectedAdvisor.value ||
+			{
+				advisorId: currentGroup.advisorId,
+				name: currentGroup.advisorName || "Assigned advisor",
+				mail: currentGroup.advisorMail || "",
 				currentGroupCount: 0,
 				capacity: 0,
 				atCapacity: false,
@@ -70,7 +88,7 @@
 			}
 
 			group.value = await fetchCoordinatorGroup(groupId.value, token);
-			selectedAdvisorId.value = group.value.advisorId || selectedAdvisorId.value;
+			selectedAdvisorId.value = group.value.advisorId || "";
 		} catch (error: unknown) {
 			const apiError = error as { message?: string };
 			group.value = null;
@@ -124,8 +142,8 @@
 				...group.value,
 				status: response.status,
 				advisorId: response.advisorId,
-				advisorName: advisor?.name || group.value.advisorName || null,
-				advisorMail: advisor?.mail || group.value.advisorMail || null,
+				advisorName: advisor?.name || null,
+				advisorMail: advisor?.mail || null,
 			};
 			removeConfirmationArmed.value = false;
 			advisorMessage.value = "Advisor assigned. Group status updated without a reload.";
@@ -144,7 +162,7 @@
 
 		if (!removeConfirmationArmed.value) {
 			removeConfirmationArmed.value = true;
-			advisorMessage.value = "Click Remove Advisor again to confirm removal.";
+			advisorMessage.value = "Click Confirm Removal to remove the advisor from this group.";
 			return;
 		}
 
@@ -356,7 +374,7 @@
               <button
                 type="button"
                 class="inline-flex items-center justify-center gap-2 rounded-lg border border-red-300 px-4 py-2 text-sm font-medium text-red-700 transition hover:bg-red-50 disabled:cursor-not-allowed disabled:opacity-70 dark:border-red-800 dark:text-red-300 dark:hover:bg-red-950/30"
-                :disabled="!group.advisorId || submitting"
+                :disabled="!hasAssignedAdvisor || submitting"
                 @click="handleRemoveAdvisor"
               >
                 <UserMinus class="h-4 w-4" />

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,3 +1,6 @@
 {
-  "extends": "./.nuxt/tsconfig.json"
+  "extends": "./.nuxt/tsconfig.json",
+  "compilerOptions": {
+    "types": ["node"]
+  }
 }

--- a/frontend/types/group.ts
+++ b/frontend/types/group.ts
@@ -24,6 +24,9 @@ export interface GroupDetailResponse {
   groupName: string
   termId?: string
   status: GroupStatus
+  advisorId?: string | null
+  advisorName?: string | null
+  advisorMail?: string | null
   members: GroupMember[]
   createdAt?: string
   jiraSpaceUrl?: string


### PR DESCRIPTION
## Summary

Implements the frontend UI for Issue 66: Coordinator advisor management and manual sanitization.

This PR adds advisor management to the Coordinator group detail page and adds a manual sanitization trigger to the Coordinator dashboard.

## What Changed

- Added `/coordinator/groups/:groupId` page for Coordinator group detail.
- Added an **Advisor Management** panel to the group detail page.
- Fetches advisors from `GET /api/coordinator/advisors`.
- Shows each advisor's current group count and capacity.
- Marks advisors at capacity as `At capacity`.
- Keeps at-capacity advisors selectable because Coordinator override should bypass advisor capacity limits.
- Supports assigning an advisor with `PATCH /api/coordinator/groups/{groupId}/advisor`.
- Supports removing an advisor with `PATCH /api/coordinator/groups/{groupId}/advisor`.
- Added a confirmation step before removing an advisor.
- Updates the group status locally after assign/remove so the page does not need a full reload.
- Added a **Run Sanitization** button to the Coordinator dashboard.
- Sends `POST /api/coordinator/sanitize` for manual sanitization.
- Shows a severe warning modal before sending `{ "force": true }` when the advisor association window is still active.
- Displays the returned sanitization result in a modal.

## Advisor Management Flow

Advisor assignment request:

```json
{
  "action": "ASSIGN",
  "advisorId": "uuid"
}
```

Advisor removal request:

```json
{
  "action": "REMOVE"
}
```

Expected advisor override response:

```json
{
  "groupId": "uuid",
  "status": "ADVISOR_ASSIGNED | TOOLS_BOUND",
  "advisorId": "uuid | null"
}
```

The frontend uses this response to update the group status immediately without a full page reload.

## Sanitization Flow

Normal manual sanitization request:

```http
POST /api/coordinator/sanitize
```

If the backend reports that the advisor association window is still active, the frontend displays a severe warning modal.

After Coordinator confirmation, the frontend sends:

```json
{
  "force": true
}
```

Expected sanitization response:

```json
{
  "disbandedCount": 3,
  "autoRejectedRequestCount": 5,
  "triggeredAt": "ISO-8601"
}
```

The modal displays:

- Disbanded group count
- Auto-rejected advisor request count
- Trigger timestamp

## Backend Expectations

The frontend expects the following P3 endpoints to be available:

- `GET /api/coordinator/advisors`
- `PATCH /api/coordinator/groups/{groupId}/advisor`
- `POST /api/coordinator/sanitize`

The frontend also expects `GET /api/coordinator/groups/{groupId}` to include assigned advisor metadata when a group already has an advisor.

Expected additional fields in `GroupDetailResponse`:

```json
{
  "advisorId": "uuid | null",
  "advisorName": "string | null",
  "advisorMail": "string | null"
}
```

This is needed because `status: "ADVISOR_ASSIGNED"` only tells the frontend that the group has an advisor. It does not tell the frontend which advisor is assigned.

Without these fields, the page can still update correctly immediately after assign/remove, but it cannot reliably show the currently assigned advisor after direct navigation or page refresh.

## Acceptance Criteria Coverage

- Advisors at capacity are marked but not disabled.
- Coordinator can assign an advisor through override.
- Coordinator can remove an advisor after confirmation.
- UI reflects `ADVISOR_ASSIGNED` after assignment without full page reload.
- UI reflects `TOOLS_BOUND` after removal without full page reload.
- Coordinator dashboard has a manual sanitization trigger.
- Active advisor-window force run requires severe warning confirmation.
- Sanitization results are displayed clearly.

## Verification

Ran frontend checks successfully:

- `npm run lint`
- `npx nuxi typecheck`
- `npm run build`