### PR TITLE
[QA] Invitation Lifecycle Concurrency Test

### DIFF
--- a/backend/src/test/java/com/senior/spm/service/InvitationConcurrencyTest.java
+++ b/backend/src/test/java/com/senior/spm/service/InvitationConcurrencyTest.java
@@ -1,0 +1,199 @@
+package com.senior.spm.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.TestPropertySource;
+
+import com.senior.spm.entity.GroupInvitation;
+import com.senior.spm.entity.GroupInvitation.InvitationStatus;
+import com.senior.spm.entity.GroupMembership;
+import com.senior.spm.entity.GroupMembership.MemberRole;
+import com.senior.spm.entity.ProjectGroup;
+import com.senior.spm.entity.ProjectGroup.GroupStatus;
+import com.senior.spm.entity.Student;
+import com.senior.spm.entity.SystemConfig;
+import com.senior.spm.repository.GroupInvitationRepository;
+import com.senior.spm.repository.GroupMembershipRepository;
+import com.senior.spm.repository.ProjectGroupRepository;
+import com.senior.spm.repository.StudentRepository;
+import com.senior.spm.repository.SystemConfigRepository;
+
+/**
+ * Concurrency test for the invitation accept flow.
+ *
+ * Verifies that when two threads simultaneously attempt to accept different
+ * invitations for the same student, the DB-level unique constraint
+ * (uq_gm_student on student_id) guarantees exactly one GroupMembership row.
+ *
+ * NOTE: This class intentionally has NO @Transactional — each thread must run
+ * its own transaction boundary. Manual cleanup is done in @AfterEach.
+ */
+@SpringBootTest
+@TestPropertySource(locations = "classpath:test.properties")
+class InvitationConcurrencyTest {
+
+    @Autowired private InvitationService invitationService;
+    @Autowired private GroupInvitationRepository groupInvitationRepository;
+    @Autowired private GroupMembershipRepository groupMembershipRepository;
+    @Autowired private ProjectGroupRepository projectGroupRepository;
+    @Autowired private StudentRepository studentRepository;
+    @Autowired private SystemConfigRepository systemConfigRepository;
+
+    private static final String TERM_ID = "2026-SPRING";
+
+    private Student invitee;
+    private GroupInvitation invA;
+    private GroupInvitation invB;
+
+    @BeforeEach
+    void setUp() {
+        // Clean up first (child tables before parents)
+        groupInvitationRepository.deleteAll();
+        groupMembershipRepository.deleteAll();
+        projectGroupRepository.deleteAll();
+        studentRepository.deleteAll();
+        systemConfigRepository.deleteAll();
+
+        // Seed term config
+        seedConfig("active_term_id", TERM_ID);
+        seedConfig("max_team_size", "5");
+
+        // One student who will try to accept two invitations simultaneously
+        invitee = createStudent("23070099001", "invitee-concurrent");
+
+        // Two groups, each with a team leader
+        ProjectGroup groupA = createGroup("Concurrent Group A");
+        ProjectGroup groupB = createGroup("Concurrent Group B");
+        createLeader(groupA);
+        createLeader(groupB);
+
+        // Two pending invitations for the same student
+        invA = createPendingInvitation(groupA, invitee);
+        invB = createPendingInvitation(groupB, invitee);
+    }
+
+    @AfterEach
+    void cleanUp() {
+        groupInvitationRepository.deleteAll();
+        groupMembershipRepository.deleteAll();
+        projectGroupRepository.deleteAll();
+        studentRepository.deleteAll();
+        systemConfigRepository.deleteAll();
+    }
+
+    @Test
+    @DisplayName("Concurrent accept of two invitations for the same student creates exactly one membership row")
+    void concurrentAccept_onlyOneMembershipCreated() throws Exception {
+        UUID inviteeId = invitee.getId();
+        UUID invAId = invA.getId();
+        UUID invBId = invB.getId();
+
+        CountDownLatch gate = new CountDownLatch(1);
+        ExecutorService executor = Executors.newFixedThreadPool(2);
+
+        Future<Boolean> futureA = executor.submit(() -> {
+            try {
+                gate.await();
+                invitationService.respondToInvitation(invAId, inviteeId, true);
+                return true;
+            } catch (Exception e) {
+                return false;
+            }
+        });
+
+        Future<Boolean> futureB = executor.submit(() -> {
+            try {
+                gate.await();
+                invitationService.respondToInvitation(invBId, inviteeId, true);
+                return true;
+            } catch (Exception e) {
+                return false;
+            }
+        });
+
+        // Release both threads simultaneously
+        gate.countDown();
+
+        boolean resultA = futureA.get(10, TimeUnit.SECONDS);
+        boolean resultB = futureB.get(10, TimeUnit.SECONDS);
+
+        executor.shutdown();
+
+        // Exactly one must succeed and one must fail
+        assertThat(resultA ^ resultB)
+                .as("Exactly one of the two concurrent accepts must succeed")
+                .isTrue();
+
+        // The DB uq_gm_student constraint guarantees at most one membership row per student
+        List<GroupMembership> memberships = groupMembershipRepository.findAll()
+                .stream()
+                .filter(m -> m.getStudent().getId().equals(inviteeId))
+                .toList();
+
+        assertThat(memberships)
+                .as("Student must have exactly one GroupMembership row regardless of race outcome")
+                .hasSize(1);
+    }
+
+    // ── Seed helpers ─────────────────────────────────────────────────────────────
+
+    private void seedConfig(String key, String value) {
+        SystemConfig cfg = new SystemConfig();
+        cfg.setConfigKey(key);
+        cfg.setConfigValue(value);
+        systemConfigRepository.save(cfg);
+    }
+
+    private Student createStudent(String studentId, String github) {
+        Student s = new Student();
+        s.setStudentId(studentId);
+        s.setGithubUsername(github);
+        return studentRepository.save(s);
+    }
+
+    private ProjectGroup createGroup(String name) {
+        ProjectGroup g = new ProjectGroup();
+        g.setGroupName(name);
+        g.setStatus(GroupStatus.FORMING);
+        g.setTermId(TERM_ID);
+        g.setCreatedAt(LocalDateTime.now());
+        g.setVersion(0L);
+        return projectGroupRepository.save(g);
+    }
+
+    private void createLeader(ProjectGroup group) {
+        String idStr = String.format("%011d",
+                Math.abs(UUID.randomUUID().getMostSignificantBits()) % 100_000_000_000L);
+        Student leader = createStudent(idStr, "leader-" + UUID.randomUUID());
+        GroupMembership m = new GroupMembership();
+        m.setGroup(group);
+        m.setStudent(leader);
+        m.setRole(MemberRole.TEAM_LEADER);
+        m.setJoinedAt(LocalDateTime.now());
+        groupMembershipRepository.save(m);
+    }
+
+    private GroupInvitation createPendingInvitation(ProjectGroup group, Student student) {
+        GroupInvitation inv = new GroupInvitation();
+        inv.setGroup(group);
+        inv.setInvitee(student);
+        inv.setStatus(InvitationStatus.PENDING);
+        inv.setSentAt(LocalDateTime.now());
+        return groupInvitationRepository.save(inv);
+    }
+}

--- a/backend/src/test/java/com/senior/spm/service/InvitationConcurrencyTest.java
+++ b/backend/src/test/java/com/senior/spm/service/InvitationConcurrencyTest.java
@@ -3,6 +3,7 @@ package com.senior.spm.service;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.CountDownLatch;
@@ -106,40 +107,54 @@ class InvitationConcurrencyTest {
         CountDownLatch gate = new CountDownLatch(1);
         ExecutorService executor = Executors.newFixedThreadPool(2);
 
-        Future<Boolean> futureA = executor.submit(() -> {
+        Future<AcceptAttempt> futureA = executor.submit(() -> {
             try {
                 gate.await();
                 invitationService.respondToInvitation(invAId, inviteeId, true);
-                return true;
+                return AcceptAttempt.success();
             } catch (Exception e) {
-                return false;
+                return AcceptAttempt.failure(e);
             }
         });
 
-        Future<Boolean> futureB = executor.submit(() -> {
+        Future<AcceptAttempt> futureB = executor.submit(() -> {
             try {
                 gate.await();
                 invitationService.respondToInvitation(invBId, inviteeId, true);
-                return true;
+                return AcceptAttempt.success();
             } catch (Exception e) {
-                return false;
+                return AcceptAttempt.failure(e);
             }
         });
 
         // Release both threads simultaneously
         gate.countDown();
 
-        boolean resultA = futureA.get(10, TimeUnit.SECONDS);
-        boolean resultB = futureB.get(10, TimeUnit.SECONDS);
+        AcceptAttempt resultA = futureA.get(10, TimeUnit.SECONDS);
+        AcceptAttempt resultB = futureB.get(10, TimeUnit.SECONDS);
 
         executor.shutdown();
+        assertThat(executor.awaitTermination(5, TimeUnit.SECONDS))
+                .as("Executor should shut down cleanly after both accept attempts finish")
+                .isTrue();
 
         // Exactly one must succeed and one must fail
-        assertThat(resultA ^ resultB)
+        assertThat(resultA.succeeded() ^ resultB.succeeded())
                 .as("Exactly one of the two concurrent accepts must succeed")
                 .isTrue();
 
-        // The DB uq_gm_student constraint guarantees at most one membership row per student
+        List<Throwable> failures = new ArrayList<>();
+        if (!resultA.succeeded()) {
+            failures.add(resultA.failure());
+        }
+        if (!resultB.succeeded()) {
+            failures.add(resultB.failure());
+        }
+        assertThat(failures)
+                .as("The losing concurrent accept must fail instead of being silently ignored")
+                .hasSize(1)
+                .allSatisfy(error -> assertThat(error).isNotNull());
+
         List<GroupMembership> memberships = groupMembershipRepository.findAll()
                 .stream()
                 .filter(m -> m.getStudent().getId().equals(inviteeId))
@@ -148,9 +163,28 @@ class InvitationConcurrencyTest {
         assertThat(memberships)
                 .as("Student must have exactly one GroupMembership row regardless of race outcome")
                 .hasSize(1);
+
+        List<InvitationStatus> finalStatuses = groupInvitationRepository.findByInviteeId(inviteeId)
+                .stream()
+                .map(GroupInvitation::getStatus)
+                .toList();
+
+        assertThat(finalStatuses)
+                .as("Concurrent accept must leave one accepted invite and auto-deny the competing invite")
+                .containsExactlyInAnyOrder(InvitationStatus.ACCEPTED, InvitationStatus.AUTO_DENIED);
     }
 
     // ── Seed helpers ─────────────────────────────────────────────────────────────
+
+    private record AcceptAttempt(boolean succeeded, Throwable failure) {
+        static AcceptAttempt success() {
+            return new AcceptAttempt(true, null);
+        }
+
+        static AcceptAttempt failure(Throwable failure) {
+            return new AcceptAttempt(false, failure);
+        }
+    }
 
     private void seedConfig(String key, String value) {
         SystemConfig cfg = new SystemConfig();

--- a/backend/src/test/java/com/senior/spm/service/InvitationLifecycleQaIntegrationTest.java
+++ b/backend/src/test/java/com/senior/spm/service/InvitationLifecycleQaIntegrationTest.java
@@ -1,0 +1,248 @@
+package com.senior.spm.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+
+import com.senior.spm.entity.GroupInvitation;
+import com.senior.spm.entity.GroupInvitation.InvitationStatus;
+import com.senior.spm.entity.GroupMembership;
+import com.senior.spm.entity.GroupMembership.MemberRole;
+import com.senior.spm.entity.ProjectGroup;
+import com.senior.spm.entity.ProjectGroup.GroupStatus;
+import com.senior.spm.entity.Student;
+import com.senior.spm.entity.SystemConfig;
+import com.senior.spm.repository.GroupInvitationRepository;
+import com.senior.spm.repository.GroupMembershipRepository;
+import com.senior.spm.repository.ProjectGroupRepository;
+import com.senior.spm.repository.StudentRepository;
+import com.senior.spm.repository.SystemConfigRepository;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@TestPropertySource(locations = "classpath:test.properties")
+class InvitationLifecycleQaIntegrationTest {
+
+    private static final String TERM_ID = "2026-SPRING";
+
+    @Autowired private MockMvc mockMvc;
+    @Autowired private GroupInvitationRepository groupInvitationRepository;
+    @Autowired private GroupMembershipRepository groupMembershipRepository;
+    @Autowired private ProjectGroupRepository projectGroupRepository;
+    @Autowired private StudentRepository studentRepository;
+    @Autowired private SystemConfigRepository systemConfigRepository;
+
+    @BeforeEach
+    void setUp() {
+        cleanDatabase();
+        seedConfig("active_term_id", TERM_ID);
+        seedConfig("max_team_size", "5");
+    }
+
+    @AfterEach
+    void cleanUp() {
+        cleanDatabase();
+    }
+
+    @Test
+    @DisplayName("QA #47: Team leader can dispatch invitation; non-leader gets 403")
+    void sendInvitation_teamLeaderAuthorizationAndSuccessfulDispatch() throws Exception {
+        Student leader = createStudent("23070010001", "leader-auth");
+        Student member = createStudent("23070010002", "member-auth");
+        Student target = createStudent("23070010003", "target-auth");
+        ProjectGroup group = createGroup("QA Dispatch Group", GroupStatus.FORMING);
+        createMembership(group, leader, MemberRole.TEAM_LEADER);
+        createMembership(group, member, MemberRole.MEMBER);
+
+        mockMvc.perform(post("/api/groups/{groupId}/invitations", group.getId())
+                .with(authentication(studentAuth(member)))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"targetStudentId\":\"" + target.getStudentId() + "\"}"))
+            .andExpect(status().isForbidden());
+
+        mockMvc.perform(post("/api/groups/{groupId}/invitations", group.getId())
+                .with(authentication(studentAuth(leader)))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"targetStudentId\":\"" + target.getStudentId() + "\"}"))
+            .andExpect(status().isCreated())
+            .andExpect(jsonPath("$.targetStudentId").value(target.getStudentId()))
+            .andExpect(jsonPath("$.status").value("PENDING"));
+
+        List<GroupInvitation> invitations = groupInvitationRepository.findByInviteeId(target.getId());
+        assertThat(invitations).hasSize(1);
+        assertThat(invitations.get(0).getStatus()).isEqualTo(InvitationStatus.PENDING);
+    }
+
+    @Test
+    @DisplayName("QA #47: Accept creates membership and auto-denies competing invitations in DB")
+    void acceptInvitation_createsMembershipAndAutoDeniesCompetingInvitations() throws Exception {
+        Student invitee = createStudent("23070011001", "invitee-accept");
+        ProjectGroup groupA = createGroupWithLeader("QA Accept Group A", "23070011002");
+        ProjectGroup groupB = createGroupWithLeader("QA Accept Group B", "23070011003");
+        GroupInvitation acceptedInvitation = createPendingInvitation(groupA, invitee);
+        GroupInvitation competingInvitation = createPendingInvitation(groupB, invitee);
+
+        mockMvc.perform(patch("/api/invitations/{invitationId}/respond", acceptedInvitation.getId())
+                .with(authentication(studentAuth(invitee)))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"accept\":true}"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.id").value(groupA.getId().toString()));
+
+        GroupInvitation accepted = groupInvitationRepository.findById(acceptedInvitation.getId()).orElseThrow();
+        GroupInvitation autoDenied = groupInvitationRepository.findById(competingInvitation.getId()).orElseThrow();
+
+        assertThat(accepted.getStatus()).isEqualTo(InvitationStatus.ACCEPTED);
+        assertThat(autoDenied.getStatus()).isEqualTo(InvitationStatus.AUTO_DENIED);
+        assertThat(groupMembershipRepository.findByGroupIdAndStudentId(groupA.getId(), invitee.getId()))
+            .isPresent()
+            .get()
+            .extracting(GroupMembership::getRole)
+            .isEqualTo(MemberRole.MEMBER);
+    }
+
+    @Test
+    @DisplayName("QA #47: DISBANDED group invitation attempt returns 400")
+    void sendInvitation_disbandedGroup_returns400() throws Exception {
+        Student leader = createStudent("23070012001", "leader-disbanded");
+        Student target = createStudent("23070012002", "target-disbanded");
+        ProjectGroup group = createGroup("QA Disbanded Group", GroupStatus.DISBANDED);
+        createMembership(group, leader, MemberRole.TEAM_LEADER);
+
+        mockMvc.perform(post("/api/groups/{groupId}/invitations", group.getId())
+                .with(authentication(studentAuth(leader)))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"targetStudentId\":\"" + target.getStudentId() + "\"}"))
+            .andExpect(status().isBadRequest());
+
+        assertThat(groupInvitationRepository.findByInviteeId(target.getId())).isEmpty();
+    }
+
+    @Test
+    @DisplayName("QA #47: Accept on TOOLS_BOUND group returns 400 and leaves invitation pending")
+    void acceptInvitation_toolsBoundGroup_returns400() throws Exception {
+        Student invitee = createStudent("23070013001", "invitee-tools-bound");
+        ProjectGroup group = createGroupWithLeader("QA Tools Bound Group", "23070013002");
+        group.setStatus(GroupStatus.TOOLS_BOUND);
+        group = projectGroupRepository.save(group);
+        GroupInvitation invitation = createPendingInvitation(group, invitee);
+
+        mockMvc.perform(patch("/api/invitations/{invitationId}/respond", invitation.getId())
+                .with(authentication(studentAuth(invitee)))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"accept\":true}"))
+            .andExpect(status().isBadRequest());
+
+        assertThat(groupInvitationRepository.findById(invitation.getId()).orElseThrow().getStatus())
+            .isEqualTo(InvitationStatus.PENDING);
+        assertThat(groupMembershipRepository.findByGroupIdAndStudentId(group.getId(), invitee.getId()))
+            .isEmpty();
+    }
+
+    @Test
+    @DisplayName("QA #47: Over-capacity invitation attempt returns 400")
+    void sendInvitation_membersPlusPendingAtLimit_returns400() throws Exception {
+        Student leader = createStudent("23070014001", "leader-capacity");
+        Student pendingInvitee = createStudent("23070014002", "pending-capacity");
+        Student target = createStudent("23070014003", "target-capacity");
+        ProjectGroup group = createGroup("QA Capacity Group", GroupStatus.FORMING);
+        createMembership(group, leader, MemberRole.TEAM_LEADER);
+        createMembership(group, createStudent("23070014004", "member-capacity-1"), MemberRole.MEMBER);
+        createMembership(group, createStudent("23070014005", "member-capacity-2"), MemberRole.MEMBER);
+        createMembership(group, createStudent("23070014006", "member-capacity-3"), MemberRole.MEMBER);
+        createPendingInvitation(group, pendingInvitee);
+
+        mockMvc.perform(post("/api/groups/{groupId}/invitations", group.getId())
+                .with(authentication(studentAuth(leader)))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"targetStudentId\":\"" + target.getStudentId() + "\"}"))
+            .andExpect(status().isBadRequest());
+
+        assertThat(groupInvitationRepository.findByInviteeId(target.getId())).isEmpty();
+    }
+
+    private void cleanDatabase() {
+        groupInvitationRepository.deleteAll();
+        groupMembershipRepository.deleteAll();
+        projectGroupRepository.deleteAll();
+        studentRepository.deleteAll();
+        systemConfigRepository.deleteAll();
+    }
+
+    private void seedConfig(String key, String value) {
+        SystemConfig config = new SystemConfig();
+        config.setConfigKey(key);
+        config.setConfigValue(value);
+        systemConfigRepository.save(config);
+    }
+
+    private ProjectGroup createGroupWithLeader(String groupName, String leaderStudentId) {
+        ProjectGroup group = createGroup(groupName, GroupStatus.FORMING);
+        createMembership(group, createStudent(leaderStudentId, "leader-" + UUID.randomUUID()), MemberRole.TEAM_LEADER);
+        return group;
+    }
+
+    private ProjectGroup createGroup(String name, GroupStatus status) {
+        ProjectGroup group = new ProjectGroup();
+        group.setGroupName(name);
+        group.setStatus(status);
+        group.setTermId(TERM_ID);
+        group.setCreatedAt(LocalDateTime.now());
+        group.setVersion(0L);
+        return projectGroupRepository.save(group);
+    }
+
+    private Student createStudent(String studentId, String githubUsername) {
+        Student student = new Student();
+        student.setStudentId(studentId);
+        student.setGithubUsername(githubUsername);
+        return studentRepository.save(student);
+    }
+
+    private GroupMembership createMembership(ProjectGroup group, Student student, MemberRole role) {
+        GroupMembership membership = new GroupMembership();
+        membership.setGroup(group);
+        membership.setStudent(student);
+        membership.setRole(role);
+        membership.setJoinedAt(LocalDateTime.now());
+        return groupMembershipRepository.save(membership);
+    }
+
+    private GroupInvitation createPendingInvitation(ProjectGroup group, Student invitee) {
+        GroupInvitation invitation = new GroupInvitation();
+        invitation.setGroup(group);
+        invitation.setInvitee(invitee);
+        invitation.setStatus(InvitationStatus.PENDING);
+        invitation.setSentAt(LocalDateTime.now());
+        return groupInvitationRepository.save(invitation);
+    }
+
+    private Authentication studentAuth(Student student) {
+        return new UsernamePasswordAuthenticationToken(
+            student.getId().toString(),
+            null,
+            List.of(new SimpleGrantedAuthority("ROLE_STUDENT"))
+        );
+    }
+}


### PR DESCRIPTION
Closes #47

## What
Adds `InvitationConcurrencyTest` — a full-stack integration test that fires two
concurrent invitation accepts for the same student and verifies the DB unique
constraint (`uq_gm_student`) enforces exactly one membership row.

## Tests added
- Two threads simultaneously call `invitationService.respondToInvitation()`
  for two different invitations to the same student
- Asserts exactly one succeeds (XOR), the other throws
- Asserts exactly one `GroupMembership` row exists for the student in DB

## Approach
Uses `CountDownLatch` to release both threads at the same time.
No `@Transactional` on the test class — each thread runs its own transaction
boundary so the constraint fires correctly.
Full DB seeding/teardown in `@BeforeEach` / `@AfterEach`.

## Review Notes

During the sprint, I wrote unit tests covering each issue's scope as part of the
development review process. Those unit tests were embedded directly in the related
feature branches (e.g. `feature/issue-45-*`, `feature/issue-48-*`, `feature/issue-59-*`)
and were reviewed and approved by the developer responsible for each issue before merge.

This PR contains the dedicated QA-layer tests (integration / concurrency / WireMock)
that are separate from those in-branch unit tests and live in their own QA branches
as agreed during sprint planning.

The invitation service logic under test (InvitationService.respondToInvitation + bulk
AUTO_DENY) was reviewed and approved by the developer on feature/issue-45 before
merging into main via PR #119.