### PR TITLE
[QA] Tool Integration & Security — WireMock Tests

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -95,6 +95,12 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.wiremock</groupId>
+            <artifactId>wiremock-standalone</artifactId>
+            <version>3.9.2</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.springdoc</groupId>
             <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
             <version>2.8.6</version>

--- a/backend/src/main/java/com/senior/spm/service/GitHubValidationService.java
+++ b/backend/src/main/java/com/senior/spm/service/GitHubValidationService.java
@@ -1,5 +1,6 @@
 package com.senior.spm.service;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
@@ -26,12 +27,14 @@ import com.senior.spm.exception.GitHubValidationException;
 @Service
 public class GitHubValidationService {
 
-    private static final String GITHUB_API_BASE = "https://api.github.com";
-
     private final RestTemplate restTemplate;
+    private final String githubApiBase;
 
-    public GitHubValidationService(RestTemplate restTemplate) {
+    public GitHubValidationService(
+            RestTemplate restTemplate,
+            @Value("${github.api.base-url:https://api.github.com}") String githubApiBase) {
         this.restTemplate = restTemplate;
+        this.githubApiBase = githubApiBase;
     }
 
     /**
@@ -64,7 +67,7 @@ public class GitHubValidationService {
      * unreachable.
      */
     private void callStep1OrgExists(String githubOrgName, HttpEntity<?> entity) {
-        var url = GITHUB_API_BASE + "/orgs/" + githubOrgName;
+        var url = githubApiBase + "/orgs/" + githubOrgName;
         try {
             restTemplate.exchange(url, HttpMethod.GET, entity, Void.class);
 
@@ -94,7 +97,7 @@ public class GitHubValidationService {
      * GitHub returns 403 (not 401) when the PAT lacks 'repo' scope.
      */
     private void callStep2RepoScope(String githubOrgName, HttpEntity<?> entity) {
-        var url = GITHUB_API_BASE + "/orgs/" + githubOrgName + "/repos?per_page=1";
+        var url = githubApiBase + "/orgs/" + githubOrgName + "/repos?per_page=1";
         try {
             restTemplate.exchange(url, HttpMethod.GET, entity, Void.class);
 

--- a/backend/src/test/java/com/senior/spm/service/GitHubValidationServiceTest.java
+++ b/backend/src/test/java/com/senior/spm/service/GitHubValidationServiceTest.java
@@ -8,10 +8,10 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.HttpEntity;
@@ -31,8 +31,12 @@ class GitHubValidationServiceTest {
     @Mock
     private RestTemplate restTemplate;
 
-    @InjectMocks
     private GitHubValidationService service;
+
+    @BeforeEach
+    void setUp() {
+        service = new GitHubValidationService(restTemplate, "https://api.github.com");
+    }
 
     private static final String ORG_NAME = "my-org";
     private static final String PAT = "ghp_testtoken";

--- a/backend/src/test/java/com/senior/spm/service/GitHubValidationWireMockTest.java
+++ b/backend/src/test/java/com/senior/spm/service/GitHubValidationWireMockTest.java
@@ -1,0 +1,107 @@
+package com.senior.spm.service;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
+import static org.assertj.core.api.Assertions.assertThatNoException;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.web.client.RestTemplate;
+
+import com.github.tomakehurst.wiremock.junit5.WireMockExtension;
+import com.senior.spm.exception.ExternalToolValidationException;
+import com.senior.spm.exception.GitHubValidationException;
+
+/**
+ * WireMock integration tests for GitHubValidationService.
+ *
+ * Uses a real RestTemplate (with the 5s timeout from RestTemplateConfig)
+ * pointed at a local WireMock HTTP server. The service base URL is overridden
+ * via constructor so no production code hits real GitHub.
+ */
+@SpringBootTest
+@TestPropertySource(locations = "classpath:test.properties")
+class GitHubValidationWireMockTest {
+
+    @RegisterExtension
+    static WireMockExtension wireMock = WireMockExtension.newInstance()
+            .options(wireMockConfig().dynamicPort())
+            .build();
+
+    @Autowired
+    private RestTemplate restTemplate;
+
+    private GitHubValidationService service;
+
+    private static final String ORG = "test-org";
+    private static final String PAT = "ghp_test_token";
+
+    @BeforeEach
+    void setUp() {
+        service = new GitHubValidationService(restTemplate, wireMock.baseUrl());
+    }
+
+    @Test
+    @DisplayName("Both calls return 200 — validate succeeds without exception")
+    void validate_success_whenBothCallsReturn200() {
+        wireMock.stubFor(get(urlEqualTo("/orgs/" + ORG))
+                .willReturn(aResponse().withStatus(200)));
+        wireMock.stubFor(get(urlEqualTo("/orgs/" + ORG + "/repos?per_page=1"))
+                .willReturn(aResponse().withStatus(200)));
+
+        assertThatNoException().isThrownBy(() -> service.validate(ORG, PAT));
+    }
+
+    @Test
+    @DisplayName("Step 1 returns 401 — throws GitHubValidationException: PAT invalid or expired")
+    void validate_401_throwsInvalidPat() {
+        wireMock.stubFor(get(urlEqualTo("/orgs/" + ORG))
+                .willReturn(aResponse().withStatus(401)));
+
+        assertThatThrownBy(() -> service.validate(ORG, PAT))
+                .isInstanceOf(GitHubValidationException.class)
+                .hasMessageContaining("PAT is invalid or expired");
+    }
+
+    @Test
+    @DisplayName("Step 1 returns 404 — throws GitHubValidationException: org not found")
+    void validate_404_throwsOrgNotFound() {
+        wireMock.stubFor(get(urlEqualTo("/orgs/" + ORG))
+                .willReturn(aResponse().withStatus(404)));
+
+        assertThatThrownBy(() -> service.validate(ORG, PAT))
+                .isInstanceOf(GitHubValidationException.class)
+                .hasMessageContaining("Organization '" + ORG + "' not found");
+    }
+
+    @Test
+    @DisplayName("Step 1 passes (200), Step 2 returns 403 — throws GitHubValidationException: lacks repo scope")
+    void validate_step2_403_throwsLacksRepoScope() {
+        wireMock.stubFor(get(urlEqualTo("/orgs/" + ORG))
+                .willReturn(aResponse().withStatus(200)));
+        wireMock.stubFor(get(urlEqualTo("/orgs/" + ORG + "/repos?per_page=1"))
+                .willReturn(aResponse().withStatus(403)));
+
+        assertThatThrownBy(() -> service.validate(ORG, PAT))
+                .isInstanceOf(GitHubValidationException.class)
+                .hasMessageContaining("PAT lacks required 'repo' scope");
+    }
+
+    @Test
+    @DisplayName("GitHubValidationException is an ExternalToolValidationException (422-equivalent)")
+    void validate_throwsExternalToolValidationException_subtype() {
+        wireMock.stubFor(get(urlEqualTo("/orgs/" + ORG))
+                .willReturn(aResponse().withStatus(401)));
+
+        assertThatThrownBy(() -> service.validate(ORG, PAT))
+                .isInstanceOf(ExternalToolValidationException.class);
+    }
+}

--- a/backend/src/test/java/com/senior/spm/service/JiraValidationWireMockTest.java
+++ b/backend/src/test/java/com/senior/spm/service/JiraValidationWireMockTest.java
@@ -1,0 +1,106 @@
+package com.senior.spm.service;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
+import static org.assertj.core.api.Assertions.assertThatNoException;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.TestPropertySource;
+
+import com.github.tomakehurst.wiremock.junit5.WireMockExtension;
+import com.senior.spm.exception.ExternalToolValidationException;
+import com.senior.spm.exception.JiraValidationException;
+
+/**
+ * WireMock integration tests for JiraValidationService.
+ *
+ * JiraValidationService already accepts the base URL as a parameter to validate(),
+ * so no production code changes are needed — tests simply pass wireMock.baseUrl().
+ */
+@SpringBootTest
+@TestPropertySource(locations = "classpath:test.properties")
+class JiraValidationWireMockTest {
+
+    @RegisterExtension
+    static WireMockExtension wireMock = WireMockExtension.newInstance()
+            .options(wireMockConfig().dynamicPort())
+            .build();
+
+    @Autowired
+    private JiraValidationService service;
+
+    private static final String PROJECT_KEY = "SPM";
+    private static final String TOKEN = "test-jira-token";
+    private static final String PROJECT_PATH = "/rest/api/3/project/" + PROJECT_KEY;
+
+    @Test
+    @DisplayName("JIRA returns 200 — validate succeeds without exception")
+    void validate_success_whenJiraReturns200() {
+        wireMock.stubFor(get(urlEqualTo(PROJECT_PATH))
+                .willReturn(aResponse().withStatus(200)));
+
+        assertThatNoException().isThrownBy(
+                () -> service.validate(wireMock.baseUrl(), PROJECT_KEY, TOKEN));
+    }
+
+    @Test
+    @DisplayName("JIRA returns 401 — throws JiraValidationException: token invalid or expired")
+    void validate_401_throwsInvalidToken() {
+        wireMock.stubFor(get(urlEqualTo(PROJECT_PATH))
+                .willReturn(aResponse().withStatus(401)));
+
+        assertThatThrownBy(() -> service.validate(wireMock.baseUrl(), PROJECT_KEY, TOKEN))
+                .isInstanceOf(JiraValidationException.class)
+                .hasMessageContaining("API token is invalid or expired");
+    }
+
+    @Test
+    @DisplayName("JIRA returns 403 — throws JiraValidationException: token invalid or expired")
+    void validate_403_throwsInvalidToken() {
+        wireMock.stubFor(get(urlEqualTo(PROJECT_PATH))
+                .willReturn(aResponse().withStatus(403)));
+
+        assertThatThrownBy(() -> service.validate(wireMock.baseUrl(), PROJECT_KEY, TOKEN))
+                .isInstanceOf(JiraValidationException.class)
+                .hasMessageContaining("API token is invalid or expired");
+    }
+
+    @Test
+    @DisplayName("JIRA returns 404 — throws JiraValidationException: project key not found")
+    void validate_404_throwsProjectNotFound() {
+        wireMock.stubFor(get(urlEqualTo(PROJECT_PATH))
+                .willReturn(aResponse().withStatus(404)));
+
+        assertThatThrownBy(() -> service.validate(wireMock.baseUrl(), PROJECT_KEY, TOKEN))
+                .isInstanceOf(JiraValidationException.class)
+                .hasMessageContaining("Project key '" + PROJECT_KEY + "' not found");
+    }
+
+    @Test
+    @DisplayName("JIRA returns other 4xx — throws JiraValidationException: URL unreachable")
+    void validate_other4xx_throwsUnreachable() {
+        wireMock.stubFor(get(urlEqualTo(PROJECT_PATH))
+                .willReturn(aResponse().withStatus(400)));
+
+        assertThatThrownBy(() -> service.validate(wireMock.baseUrl(), PROJECT_KEY, TOKEN))
+                .isInstanceOf(JiraValidationException.class)
+                .hasMessageContaining("JIRA space URL is unreachable");
+    }
+
+    @Test
+    @DisplayName("JiraValidationException is an ExternalToolValidationException (422-equivalent)")
+    void validate_throwsExternalToolValidationException_subtype() {
+        wireMock.stubFor(get(urlEqualTo(PROJECT_PATH))
+                .willReturn(aResponse().withStatus(401)));
+
+        assertThatThrownBy(() -> service.validate(wireMock.baseUrl(), PROJECT_KEY, TOKEN))
+                .isInstanceOf(ExternalToolValidationException.class);
+    }
+}


### PR DESCRIPTION
Closes #51

## What
Adds WireMock integration tests for `GitHubValidationService` and `JiraValidationService`.
Also adds `wiremock-standalone 3.9.2` to `pom.xml` and a constructor overload on
`GitHubValidationService` to accept a configurable base URL (needed for WireMock injection).

## Tests added
**GitHub (`GitHubValidationWireMockTest`):**
- Both calls 200 → no exception
- Step 1 returns 401 → `GitHubValidationException`: PAT invalid or expired
- Step 1 returns 404 → `GitHubValidationException`: org not found
- Step 1 passes, Step 2 returns 403 → `GitHubValidationException`: lacks repo scope
- `GitHubValidationException` is a subtype of `ExternalToolValidationException`

**JIRA (`JiraValidationWireMockTest`):**
- 200 → no exception
- 401 → `JiraValidationException`: token invalid or expired
- 403 → `JiraValidationException`: token invalid or expired
- 404 → `JiraValidationException`: project key not found
- Other 4xx → `JiraValidationException`: URL unreachable
- `JiraValidationException` is a subtype of `ExternalToolValidationException`

## Approach
`WireMockExtension` starts a local HTTP server on a dynamic port.
`GitHubValidationService` is instantiated manually with `wireMock.baseUrl()` — no real GitHub calls.
`JiraValidationService` already accepted base URL as a method param — no production change needed there.

## Review Notes

During the sprint, I wrote unit tests covering each issue's scope as part of the
development review process. Those unit tests were embedded directly in the related
feature branches (e.g. `feature/issue-45-*`, `feature/issue-48-*`, `feature/issue-59-*`)
and were reviewed and approved by the developer responsible for each issue before merge.

This PR contains the dedicated QA-layer tests (integration / concurrency / WireMock)
that are separate from those in-branch unit tests and live in their own QA branches
as agreed during sprint planning.

The GitHubValidationService and JiraValidationService under test were reviewed and
approved by the developers on feature/issue-48 and feature/issue-49 before merging.
The constructor overload added to GitHubValidationService is test-only plumbing —
the default Spring bean wiring is unchanged.