### PR TITLE
fix: restore missing braces in useApiClient.ts

### DIFF
--- a/frontend/composables/useApiClient.ts
+++ b/frontend/composables/useApiClient.ts
@@ -109,6 +109,8 @@ export interface SanitizationReport {
   autoRejectedRequestCount?: number;
   rejectedRequestCount?: number;
   triggeredAt: string;
+}
+
 export interface BindJiraRequest {
   jiraSpaceUrl: string;
   jiraProjectKey: string;
@@ -364,6 +366,10 @@ export function useApiClient() {
       `/coordinator/groups/${encodeURIComponent(groupId)}/advisor`,
       "PATCH",
       { action: "ASSIGN", advisorId },
+      token
+    );
+  }
+
   async function bindJiraTool(
     groupId: string,
     payload: BindJiraRequest,
@@ -397,6 +403,10 @@ export function useApiClient() {
       "/coordinator/sanitize",
       "POST",
       force ? { force: true } : undefined,
+      token
+    );
+  }
+
   async function bindGithubTool(
     groupId: string,
     payload: BindGithubRequest,


### PR DESCRIPTION
Restores 3 closing tokens dropped in botched merge conflict resolution (839c7c9). Fixes parse errors in SanitizationReport interface, assignCoordinatorAdvisor(), and runCoordinatorSanitization().