### PR TITLE
fix: JIRA bind endpoint returns 422 for valid API tokens (#133)

### DIFF
--- a/backend/src/main/java/com/senior/spm/controller/GroupController.java
+++ b/backend/src/main/java/com/senior/spm/controller/GroupController.java
@@ -157,7 +157,7 @@ public class GroupController {
      * <p>Auth: Student JWT — requester must be {@code TEAM_LEADER} of {@code groupId}.
      *
      * @param groupId UUID of the group to bind
-     * @param request {@link BindJiraRequest} containing {@code jiraSpaceUrl},
+     * @param request {@link BindJiraRequest} containing {@code jiraSpaceUrl}, {@code jiraEmail},
      *                {@code jiraProjectKey}, and {@code jiraApiToken} (all required)
      * @return 200 with {@link BindToolResponse} containing non-sensitive JIRA metadata
      *         and updated group status
@@ -177,6 +177,7 @@ public class GroupController {
         BindToolResponse response = groupService.bindJira(
             groupId,
             request.getJiraSpaceUrl(),
+            request.getJiraEmail(),
             request.getJiraProjectKey(),
             request.getJiraApiToken(),
             requesterUUID

--- a/backend/src/main/java/com/senior/spm/controller/request/BindJiraRequest.java
+++ b/backend/src/main/java/com/senior/spm/controller/request/BindJiraRequest.java
@@ -9,6 +9,9 @@ public class BindJiraRequest {
     @NotBlank(message = "JIRA space URL is required")
     private String jiraSpaceUrl;
 
+    @NotBlank(message = "JIRA email is required")
+    private String jiraEmail;
+
     @NotBlank(message = "JIRA project key is required")
     private String jiraProjectKey;
 

--- a/backend/src/main/java/com/senior/spm/controller/response/GroupDetailResponse.java
+++ b/backend/src/main/java/com/senior/spm/controller/response/GroupDetailResponse.java
@@ -15,6 +15,7 @@ public final class GroupDetailResponse implements InvitationActionResponse {
     private String status;
     private LocalDateTime createdAt;
     private String jiraSpaceUrl;
+    private String jiraEmail;
     private String jiraProjectKey;
     private Boolean jiraBound;
     private String githubOrgName;

--- a/backend/src/main/java/com/senior/spm/entity/ProjectGroup.java
+++ b/backend/src/main/java/com/senior/spm/entity/ProjectGroup.java
@@ -48,7 +48,7 @@ public class ProjectGroup {
     @Column(length = 500, nullable = true)
     private String jiraSpaceUrl;
 
-    @Column(length = 100, nullable = true)
+    @Column(length = 254, nullable = true)
     private String jiraEmail;
 
     @Column(length = 100, nullable = true)

--- a/backend/src/main/java/com/senior/spm/entity/ProjectGroup.java
+++ b/backend/src/main/java/com/senior/spm/entity/ProjectGroup.java
@@ -49,6 +49,9 @@ public class ProjectGroup {
     private String jiraSpaceUrl;
 
     @Column(length = 100, nullable = true)
+    private String jiraEmail;
+
+    @Column(length = 100, nullable = true)
     private String jiraProjectKey;
 
     @Column(length = 1024, nullable = true)

--- a/backend/src/main/java/com/senior/spm/service/GitHubValidationService.java
+++ b/backend/src/main/java/com/senior/spm/service/GitHubValidationService.java
@@ -43,6 +43,8 @@ public class GitHubValidationService {
      */
     public void validate(String githubOrgName, String githubPat) {
         var headers = new HttpHeaders();
+        // GitHub REST API requires a User-Agent header
+        headers.set(HttpHeaders.USER_AGENT, "SPM-Senior-App");
         // GitHub REST API v3 accepts a PAT as a Bearer token.
         headers.set(HttpHeaders.AUTHORIZATION, "Bearer " + githubPat);
         var entity = new HttpEntity<>(headers);

--- a/backend/src/main/java/com/senior/spm/service/GroupService.java
+++ b/backend/src/main/java/com/senior/spm/service/GroupService.java
@@ -148,6 +148,7 @@ public class GroupService {
      *
      * @param groupId        UUID of the group to bind
      * @param jiraSpaceUrl   the JIRA space base URL (e.g., {@code https://company.atlassian.net})
+     * @param jiraEmail      the Atlassian account email used for Basic Auth (required for Jira Cloud)
      * @param jiraProjectKey the JIRA project key (e.g., {@code SPM})
      * @param jiraApiToken   the plain-text JIRA API token — encrypted before storage
      * @param requesterUUID  internal UUID of the authenticated student
@@ -158,8 +159,8 @@ public class GroupService {
      * @throws JiraValidationException         if the JIRA live call fails (→ 422)
      */
     @Transactional
-    public BindToolResponse bindJira(UUID groupId, String jiraSpaceUrl, String jiraProjectKey,
-                                     String jiraApiToken, UUID requesterUUID) {
+    public BindToolResponse bindJira(UUID groupId, String jiraSpaceUrl, String jiraEmail,
+                                     String jiraProjectKey, String jiraApiToken, UUID requesterUUID) {
         // 1. Verify requester is TEAM_LEADER of this group
         GroupMembership membership = groupMembershipRepository
             .findByGroupIdAndStudentId(groupId, requesterUUID)
@@ -178,7 +179,7 @@ public class GroupService {
         }
 
         // 3. Live validation — nothing is stored until this call returns without throwing
-        jiraValidationService.validate(jiraSpaceUrl, jiraProjectKey, jiraApiToken);
+        jiraValidationService.validate(jiraSpaceUrl, jiraEmail, jiraProjectKey, jiraApiToken);
 
         // 4. Encrypt token before persistence (NFR-7: AES-256 at rest)
         String encryptedJiraToken = encryptionService.encrypt(jiraApiToken);
@@ -192,6 +193,7 @@ public class GroupService {
 
         // 6. Persist group with JIRA fields
         group.setJiraSpaceUrl(jiraSpaceUrl);
+        group.setJiraEmail(jiraEmail);
         group.setJiraProjectKey(jiraProjectKey);
         group.setEncryptedJiraToken(encryptedJiraToken);
         group.setStatus(newStatus);
@@ -294,6 +296,7 @@ public class GroupService {
         response.setStatus(group.getStatus().toString());
         response.setCreatedAt(group.getCreatedAt());
         response.setJiraSpaceUrl(group.getJiraSpaceUrl());
+        response.setJiraEmail(group.getJiraEmail());
         response.setJiraProjectKey(group.getJiraProjectKey());
         response.setJiraBound(group.getEncryptedJiraToken() != null);
         response.setGithubOrgName(group.getGithubOrgName());

--- a/backend/src/main/java/com/senior/spm/service/JiraValidationService.java
+++ b/backend/src/main/java/com/senior/spm/service/JiraValidationService.java
@@ -1,12 +1,15 @@
 package com.senior.spm.service;
 
 import java.util.Base64;
+import java.util.Map;
 import java.nio.charset.StandardCharsets;
 
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.ResourceAccessException;
@@ -15,11 +18,8 @@ import org.springframework.web.client.RestTemplate;
 import com.senior.spm.exception.JiraValidationException;
 
 /**
- * Validates JIRA credentials by making a single live HTTP call to the JIRA REST
- * API.
- * Called by GroupService.bindJira()
- * Nothing is persisted until this service returns without throwing.
- *
+ * Validates JIRA credentials by making a single live HTTP call to the JIRA REST API.
+ * Called by GroupService.bindJira() — nothing is persisted until this returns without throwing.
  */
 @Service
 public class JiraValidationService {
@@ -31,60 +31,61 @@ public class JiraValidationService {
     }
 
     /**
-     * Performs a single GET against:
-     * {jiraSpaceUrl}/rest/api/3/project/{jiraProjectKey}
+     * Validates JIRA credentials using Basic Auth (Jira Cloud) or Bearer token (Jira Server).
+     * Uses the project search endpoint which works reliably across all Jira Cloud project types
+     * (classic and next-gen/team-managed).
      *
+     * @param jiraEmail Atlassian account email — required for Jira Cloud Basic Auth.
+     *                  If null, falls back to Bearer token for Jira Server compatibility.
      * @throws JiraValidationException on any failure (401/403 → invalid token,
-     *                                 404 → project key not found,
-     *                                 timeout/network → unreachable)
+     *                                 project not found, timeout/network → unreachable)
      */
-    @Deprecated // FIXED BY EFE: Kept for backward compatibility if you don't have email. Jira Cloud will reject this.
-    public void validate(String jiraSpaceUrl, String jiraProjectKey, String jiraApiToken) {
-        validate(jiraSpaceUrl, null, jiraProjectKey, jiraApiToken);
-    }
-
-    /**
-     * EFE'S FIX: Jira Cloud REQUIRES an email for Basic Auth. Bearer tokens do not work.
-     * @param jiraEmail Required for Jira Cloud. If null, falls back to Bearer token (for Jira Server).
-     */
+    @SuppressWarnings("unchecked")
     public void validate(String jiraSpaceUrl, String jiraEmail, String jiraProjectKey, String jiraApiToken) {
-        var url = jiraSpaceUrl.strip().replaceAll("/+$", "") + "/rest/api/3/project/" + jiraProjectKey;
+        String baseUrl = jiraSpaceUrl.strip().replaceAll("/+$", "");
+        String trimmedKey = jiraProjectKey.strip().toUpperCase();
+
+        // Use the search endpoint — more reliable than /project/{key} for all Jira Cloud project types
+        String url = baseUrl + "/rest/api/3/project/search?keys=" + trimmedKey;
 
         var headers = new HttpHeaders();
-        
-        // EFE'S FIX: Use Basic Auth if email is provided, else fallback to Bearer.
+        headers.set(HttpHeaders.ACCEPT, MediaType.APPLICATION_JSON_VALUE);
+
+        // Jira Cloud requires Basic Auth (email:token). Bearer is kept for Jira Server.
         if (jiraEmail != null && !jiraEmail.isBlank()) {
-            String authString = jiraEmail + ":" + jiraApiToken;
+            String authString = jiraEmail.strip() + ":" + jiraApiToken;
             String base64Auth = Base64.getEncoder().encodeToString(authString.getBytes(StandardCharsets.UTF_8));
             headers.set(HttpHeaders.AUTHORIZATION, "Basic " + base64Auth);
         } else {
             headers.set(HttpHeaders.AUTHORIZATION, "Bearer " + jiraApiToken);
         }
-        
+
         var entity = new HttpEntity<>(headers);
 
         try {
-            restTemplate.exchange(url, HttpMethod.GET, entity, Void.class);
+            ResponseEntity<Map<String, Object>> response = restTemplate.exchange(
+                    url, HttpMethod.GET, entity, (Class<Map<String, Object>>) (Class<?>) Map.class);
+
+            Map<String, Object> body = response.getBody();
+            int total = body != null ? ((Number) body.getOrDefault("total", 0)).intValue() : 0;
+            if (total == 0) {
+                throw new JiraValidationException(
+                        "JIRA validation failed: Project key '" + trimmedKey + "' not found in this Jira workspace");
+            }
+
+        } catch (JiraValidationException ex) {
+            throw ex;
 
         } catch (HttpClientErrorException ex) {
             HttpStatus status = HttpStatus.resolve(ex.getStatusCode().value());
 
             if (status == HttpStatus.UNAUTHORIZED || status == HttpStatus.FORBIDDEN) {
-                // JIRA returns 401 for bad tokens and 403 for insufficient permissions.
                 throw new JiraValidationException("JIRA validation failed: API token is invalid or expired");
             }
 
-            if (status == HttpStatus.NOT_FOUND) {
-                // The project key does not exist in the given JIRA space.
-                throw new JiraValidationException(
-                        "JIRA validation failed: Project key '" + jiraProjectKey + "' not found");
-            }
-
-            // Any other 4xx — treat as unreachable / misconfigured URL.
             throw new JiraValidationException("JIRA validation failed: JIRA space URL is unreachable");
 
         } catch (ResourceAccessException ex) {
-            // Covers connection timeout, read timeout, DNS failure, etc.
             throw new JiraValidationException("JIRA validation failed: JIRA space URL is unreachable");
         }
     }

--- a/backend/src/main/java/com/senior/spm/service/JiraValidationService.java
+++ b/backend/src/main/java/com/senior/spm/service/JiraValidationService.java
@@ -1,5 +1,8 @@
 package com.senior.spm.service;
 
+import java.util.Base64;
+import java.nio.charset.StandardCharsets;
+
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
@@ -35,13 +38,29 @@ public class JiraValidationService {
      *                                 404 → project key not found,
      *                                 timeout/network → unreachable)
      */
+    @Deprecated // FIXED BY EFE: Kept for backward compatibility if you don't have email. Jira Cloud will reject this.
     public void validate(String jiraSpaceUrl, String jiraProjectKey, String jiraApiToken) {
+        validate(jiraSpaceUrl, null, jiraProjectKey, jiraApiToken);
+    }
+
+    /**
+     * EFE'S FIX: Jira Cloud REQUIRES an email for Basic Auth. Bearer tokens do not work.
+     * @param jiraEmail Required for Jira Cloud. If null, falls back to Bearer token (for Jira Server).
+     */
+    public void validate(String jiraSpaceUrl, String jiraEmail, String jiraProjectKey, String jiraApiToken) {
         var url = jiraSpaceUrl.strip().replaceAll("/+$", "") + "/rest/api/3/project/" + jiraProjectKey;
 
         var headers = new HttpHeaders();
-        // JIRA Cloud accepts a Bearer token; on-prem may need Basic – Bearer covers
-        // both cases here.
-        headers.set(HttpHeaders.AUTHORIZATION, "Bearer " + jiraApiToken);
+        
+        // EFE'S FIX: Use Basic Auth if email is provided, else fallback to Bearer.
+        if (jiraEmail != null && !jiraEmail.isBlank()) {
+            String authString = jiraEmail + ":" + jiraApiToken;
+            String base64Auth = Base64.getEncoder().encodeToString(authString.getBytes(StandardCharsets.UTF_8));
+            headers.set(HttpHeaders.AUTHORIZATION, "Basic " + base64Auth);
+        } else {
+            headers.set(HttpHeaders.AUTHORIZATION, "Bearer " + jiraApiToken);
+        }
+        
         var entity = new HttpEntity<>(headers);
 
         try {

--- a/backend/src/test/java/com/senior/spm/service/GroupServiceTest.java
+++ b/backend/src/test/java/com/senior/spm/service/GroupServiceTest.java
@@ -871,7 +871,7 @@ class GroupServiceTest {
         when(encryptionService.encrypt("raw-jira-token")).thenReturn("enc-jira-token");
         when(projectGroupRepository.save(any())).thenReturn(savedGroup);
 
-        groupService.bindJira(GROUP_ID, "https://co.atlassian.net", "SPM", "raw-jira-token", STUDENT_ID);
+        groupService.bindJira(GROUP_ID, "https://co.atlassian.net", "test@example.com", "SPM", "raw-jira-token", STUDENT_ID);
 
         ArgumentCaptor<ProjectGroup> captor = ArgumentCaptor.forClass(ProjectGroup.class);
         verify(projectGroupRepository).save(captor.capture());
@@ -893,7 +893,7 @@ class GroupServiceTest {
         when(encryptionService.encrypt(any())).thenReturn("enc-jira-token");
         when(projectGroupRepository.save(any())).thenReturn(savedGroup);
 
-        groupService.bindJira(GROUP_ID, "https://co.atlassian.net", "SPM", "raw-token", STUDENT_ID);
+        groupService.bindJira(GROUP_ID, "https://co.atlassian.net", "test@example.com", "SPM", "raw-token", STUDENT_ID);
 
         ArgumentCaptor<ProjectGroup> captor = ArgumentCaptor.forClass(ProjectGroup.class);
         verify(projectGroupRepository).save(captor.capture());
@@ -913,11 +913,11 @@ class GroupServiceTest {
         when(groupMembershipRepository.findByGroupIdAndStudentId(GROUP_ID, STUDENT_ID))
                 .thenReturn(Optional.of(member));
 
-        assertThatThrownBy(() -> groupService.bindJira(GROUP_ID, "url", "key", "token", STUDENT_ID))
+        assertThatThrownBy(() -> groupService.bindJira(GROUP_ID, "url", "test@example.com", "key", "token", STUDENT_ID))
                 .isInstanceOf(ForbiddenException.class)
                 .hasMessageContaining("Team Leader");
 
-        verify(jiraValidationService, never()).validate(any(), any(), any());
+        verify(jiraValidationService, never()).validate(any(), any(), any(), any());
         verify(projectGroupRepository, never()).save(any());
     }
 
@@ -927,10 +927,10 @@ class GroupServiceTest {
         when(groupMembershipRepository.findByGroupIdAndStudentId(GROUP_ID, STUDENT_ID))
                 .thenReturn(Optional.empty());
 
-        assertThatThrownBy(() -> groupService.bindJira(GROUP_ID, "url", "key", "token", STUDENT_ID))
+        assertThatThrownBy(() -> groupService.bindJira(GROUP_ID, "url", "test@example.com", "key", "token", STUDENT_ID))
                 .isInstanceOf(ForbiddenException.class);
 
-        verify(jiraValidationService, never()).validate(any(), any(), any());
+        verify(jiraValidationService, never()).validate(any(), any(), any(), any());
     }
 
     @Test
@@ -944,11 +944,11 @@ class GroupServiceTest {
                 .thenReturn(Optional.of(leader));
         when(projectGroupRepository.findById(GROUP_ID)).thenReturn(Optional.of(savedGroup));
 
-        assertThatThrownBy(() -> groupService.bindJira(GROUP_ID, "url", "key", "token", STUDENT_ID))
+        assertThatThrownBy(() -> groupService.bindJira(GROUP_ID, "url", "test@example.com", "key", "token", STUDENT_ID))
                 .isInstanceOf(BusinessRuleException.class)
                 .hasMessageContaining("disbanded");
 
-        verify(jiraValidationService, never()).validate(any(), any(), any());
+        verify(jiraValidationService, never()).validate(any(), any(), any(), any());
         verify(projectGroupRepository, never()).save(any());
     }
 
@@ -960,7 +960,7 @@ class GroupServiceTest {
                 .thenReturn(Optional.of(leader));
         when(projectGroupRepository.findById(GROUP_ID)).thenReturn(Optional.empty());
 
-        assertThatThrownBy(() -> groupService.bindJira(GROUP_ID, "url", "key", "token", STUDENT_ID))
+        assertThatThrownBy(() -> groupService.bindJira(GROUP_ID, "url", "test@example.com", "key", "token", STUDENT_ID))
                 .isInstanceOf(GroupNotFoundException.class);
 
         verify(projectGroupRepository, never()).save(any());
@@ -977,9 +977,9 @@ class GroupServiceTest {
                 .thenReturn(Optional.of(leader));
         when(projectGroupRepository.findById(GROUP_ID)).thenReturn(Optional.of(savedGroup));
         doThrow(new JiraValidationException("JIRA validation failed: API token is invalid or expired"))
-                .when(jiraValidationService).validate(any(), any(), any());
+                .when(jiraValidationService).validate(any(), any(), any(), any());
 
-        assertThatThrownBy(() -> groupService.bindJira(GROUP_ID, "url", "key", "bad-token", STUDENT_ID))
+        assertThatThrownBy(() -> groupService.bindJira(GROUP_ID, "url", "test@example.com", "key", "bad-token", STUDENT_ID))
                 .isInstanceOf(JiraValidationException.class);
 
         verify(encryptionService, never()).encrypt(any());
@@ -999,7 +999,7 @@ class GroupServiceTest {
         when(encryptionService.encrypt("raw-token")).thenReturn("enc-token");
         when(projectGroupRepository.save(any())).thenReturn(savedGroup);
 
-        groupService.bindJira(GROUP_ID, "url", "key", "raw-token", STUDENT_ID);
+        groupService.bindJira(GROUP_ID, "url", "test@example.com", "key", "raw-token", STUDENT_ID);
 
         ArgumentCaptor<ProjectGroup> captor = ArgumentCaptor.forClass(ProjectGroup.class);
         verify(projectGroupRepository).save(captor.capture());
@@ -1019,7 +1019,7 @@ class GroupServiceTest {
         when(encryptionService.encrypt(any())).thenReturn("enc-token");
         when(projectGroupRepository.save(any())).thenReturn(savedGroup);
 
-        BindToolResponse response = groupService.bindJira(GROUP_ID, "https://co.atlassian.net", "SPM", "raw-token", STUDENT_ID);
+        BindToolResponse response = groupService.bindJira(GROUP_ID, "https://co.atlassian.net", "test@example.com", "SPM", "raw-token", STUDENT_ID);
 
         // BindToolResponse has no field for the token — verify no field equals plaintext
         assertThat(response.getJiraSpaceUrl()).isNotEqualTo("raw-token");
@@ -1040,7 +1040,7 @@ class GroupServiceTest {
         when(encryptionService.encrypt("new-raw-token")).thenReturn("new-enc-token");
         when(projectGroupRepository.save(any())).thenReturn(savedGroup);
 
-        groupService.bindJira(GROUP_ID, "url", "key", "new-raw-token", STUDENT_ID);
+        groupService.bindJira(GROUP_ID, "url", "test@example.com", "key", "new-raw-token", STUDENT_ID);
 
         ArgumentCaptor<ProjectGroup> captor = ArgumentCaptor.forClass(ProjectGroup.class);
         verify(projectGroupRepository).save(captor.capture());

--- a/backend/src/test/java/com/senior/spm/service/JiraValidationServiceTest.java
+++ b/backend/src/test/java/com/senior/spm/service/JiraValidationServiceTest.java
@@ -1,11 +1,17 @@
 package com.senior.spm.service;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatNoException;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.List;
+import java.util.Map;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -14,6 +20,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -33,131 +40,213 @@ class JiraValidationServiceTest {
     @InjectMocks
     private JiraValidationService service;
 
-    private static final String JIRA_URL = "https://myteam.atlassian.net";
+    private static final String JIRA_URL   = "https://myteam.atlassian.net";
+    private static final String JIRA_EMAIL = "user@example.com";
     private static final String PROJECT_KEY = "SPM";
-    private static final String API_TOKEN = "test-api-token";
-    private static final String EXPECTED_URL = JIRA_URL + "/rest/api/3/project/" + PROJECT_KEY;
+    private static final String API_TOKEN  = "test-api-token";
 
-    // ── Happy path ───────────────────────────────────────────────────────────
+    // Service uses /rest/api/3/project/search?keys={KEY} (uppercased)
+    private static final String EXPECTED_URL = JIRA_URL + "/rest/api/3/project/search?keys=" + PROJECT_KEY;
 
-    @Test
-    void validate_success_whenJiraReturns200() {
-        when(restTemplate.exchange(eq(EXPECTED_URL), eq(HttpMethod.GET), any(HttpEntity.class), eq(Void.class)))
-                .thenReturn(new ResponseEntity<>(HttpStatus.OK));
-
-        assertThatNoException().isThrownBy(() -> service.validate(JIRA_URL, PROJECT_KEY, API_TOKEN));
+    /** Helper: build the ResponseEntity the search endpoint returns (raw Map matches Map.class token). */
+    @SuppressWarnings("rawtypes")
+    private static ResponseEntity<Map> searchResponse(int total) {
+        return ResponseEntity.ok(Map.of("total", total, "values", List.of()));
     }
 
-    // ── 401 / 403 — invalid token ─────────────────────────────────────────
+    // ── Happy path — Basic Auth (email provided) ──────────────────────────────
+
+    @Test
+    void validate_success_whenSearchReturnsProjects_withEmail() {
+        when(restTemplate.exchange(eq(EXPECTED_URL), eq(HttpMethod.GET), any(HttpEntity.class), eq(Map.class)))
+                .thenReturn(searchResponse(1));
+
+        assertThatNoException().isThrownBy(
+                () -> service.validate(JIRA_URL, JIRA_EMAIL, PROJECT_KEY, API_TOKEN));
+    }
+
+    // ── Happy path — Bearer fallback (null email) ─────────────────────────────
+
+    @Test
+    void validate_success_whenNullEmail_fallsBackToBearer() {
+        when(restTemplate.exchange(eq(EXPECTED_URL), eq(HttpMethod.GET), any(HttpEntity.class), eq(Map.class)))
+                .thenReturn(searchResponse(1));
+
+        assertThatNoException().isThrownBy(
+                () -> service.validate(JIRA_URL, null, PROJECT_KEY, API_TOKEN));
+    }
+
+    // ── Project not found — search returns total: 0 ───────────────────────────
+
+    @Test
+    void validate_throwsProjectNotFound_whenSearchReturnsTotal0() {
+        when(restTemplate.exchange(eq(EXPECTED_URL), eq(HttpMethod.GET), any(HttpEntity.class), eq(Map.class)))
+                .thenReturn(searchResponse(0));
+
+        assertThatThrownBy(() -> service.validate(JIRA_URL, JIRA_EMAIL, PROJECT_KEY, API_TOKEN))
+                .isInstanceOf(JiraValidationException.class)
+                .hasMessageContaining("Project key 'SPM' not found");
+    }
+
+    // ── 401 / 403 — invalid token ─────────────────────────────────────────────
 
     @Test
     void validate_throwsInvalidToken_whenJiraReturns401() {
-        when(restTemplate.exchange(eq(EXPECTED_URL), eq(HttpMethod.GET), any(HttpEntity.class), eq(Void.class)))
+        when(restTemplate.exchange(eq(EXPECTED_URL), eq(HttpMethod.GET), any(HttpEntity.class), eq(Map.class)))
                 .thenThrow(new HttpClientErrorException(HttpStatus.UNAUTHORIZED));
 
-        assertThatThrownBy(() -> service.validate(JIRA_URL, PROJECT_KEY, API_TOKEN))
+        assertThatThrownBy(() -> service.validate(JIRA_URL, JIRA_EMAIL, PROJECT_KEY, API_TOKEN))
                 .isInstanceOf(JiraValidationException.class)
                 .hasMessage("JIRA validation failed: API token is invalid or expired");
     }
 
     @Test
     void validate_throwsInvalidToken_whenJiraReturns403() {
-        when(restTemplate.exchange(eq(EXPECTED_URL), eq(HttpMethod.GET), any(HttpEntity.class), eq(Void.class)))
+        when(restTemplate.exchange(eq(EXPECTED_URL), eq(HttpMethod.GET), any(HttpEntity.class), eq(Map.class)))
                 .thenThrow(new HttpClientErrorException(HttpStatus.FORBIDDEN));
 
-        assertThatThrownBy(() -> service.validate(JIRA_URL, PROJECT_KEY, API_TOKEN))
+        assertThatThrownBy(() -> service.validate(JIRA_URL, JIRA_EMAIL, PROJECT_KEY, API_TOKEN))
                 .isInstanceOf(JiraValidationException.class)
                 .hasMessage("JIRA validation failed: API token is invalid or expired");
     }
 
-    // ── 404 — project key not found ──────────────────────────────────────
-
-    @Test
-    void validate_throwsProjectNotFound_whenJiraReturns404() {
-        when(restTemplate.exchange(eq(EXPECTED_URL), eq(HttpMethod.GET), any(HttpEntity.class), eq(Void.class)))
-                .thenThrow(new HttpClientErrorException(HttpStatus.NOT_FOUND));
-
-        assertThatThrownBy(() -> service.validate(JIRA_URL, PROJECT_KEY, API_TOKEN))
-                .isInstanceOf(JiraValidationException.class)
-                .hasMessage("JIRA validation failed: Project key 'SPM' not found");
-    }
-
-    // ── Other 4xx — unreachable / misconfigured URL ──────────────────────
+    // ── Other 4xx — unreachable / misconfigured URL ───────────────────────────
 
     @Test
     void validate_throwsUnreachable_whenJiraReturnsOther4xx() {
-        when(restTemplate.exchange(eq(EXPECTED_URL), eq(HttpMethod.GET), any(HttpEntity.class), eq(Void.class)))
+        when(restTemplate.exchange(eq(EXPECTED_URL), eq(HttpMethod.GET), any(HttpEntity.class), eq(Map.class)))
                 .thenThrow(new HttpClientErrorException(HttpStatus.BAD_REQUEST));
 
-        assertThatThrownBy(() -> service.validate(JIRA_URL, PROJECT_KEY, API_TOKEN))
+        assertThatThrownBy(() -> service.validate(JIRA_URL, JIRA_EMAIL, PROJECT_KEY, API_TOKEN))
                 .isInstanceOf(JiraValidationException.class)
                 .hasMessage("JIRA validation failed: JIRA space URL is unreachable");
     }
 
-    // ── Timeout / network failure ─────────────────────────────────────────
+    // ── Timeout / network failure ─────────────────────────────────────────────
 
     @Test
-    void validate_throwsUnreachable_whenTimeout() {
-        when(restTemplate.exchange(eq(EXPECTED_URL), eq(HttpMethod.GET), any(HttpEntity.class), eq(Void.class)))
+    void validate_throwsUnreachable_whenNetworkTimeout() {
+        when(restTemplate.exchange(eq(EXPECTED_URL), eq(HttpMethod.GET), any(HttpEntity.class), eq(Map.class)))
                 .thenThrow(new ResourceAccessException("Connection timed out"));
 
-        assertThatThrownBy(() -> service.validate(JIRA_URL, PROJECT_KEY, API_TOKEN))
+        assertThatThrownBy(() -> service.validate(JIRA_URL, JIRA_EMAIL, PROJECT_KEY, API_TOKEN))
                 .isInstanceOf(JiraValidationException.class)
                 .hasMessage("JIRA validation failed: JIRA space URL is unreachable");
     }
 
-    // ── URL normalisation ─────────────────────────────────────────────────
+    // ── URL normalisation ─────────────────────────────────────────────────────
 
     @Test
-    void validate_handlesTrailingSlash_inJiraUrl() {
-        // Trailing slash in jiraSpaceUrl must be stripped before appending the path.
-        // "https://myteam.atlassian.net/" → exchange must be called with
-        // "https://myteam.atlassian.net/rest/api/3/project/SPM" (single slash, not double).
-        String urlWithSlash = JIRA_URL + "/";
-        when(restTemplate.exchange(eq(EXPECTED_URL), eq(HttpMethod.GET), any(HttpEntity.class), eq(Void.class)))
-                .thenReturn(new ResponseEntity<>(HttpStatus.OK));
+    void validate_stripsTrailingSlash_fromJiraUrl() {
+        when(restTemplate.exchange(eq(EXPECTED_URL), eq(HttpMethod.GET), any(HttpEntity.class), eq(Map.class)))
+                .thenReturn(searchResponse(1));
 
-        assertThatNoException().isThrownBy(() -> service.validate(urlWithSlash, PROJECT_KEY, API_TOKEN));
-        verify(restTemplate).exchange(eq(EXPECTED_URL), eq(HttpMethod.GET), any(HttpEntity.class), eq(Void.class));
+        assertThatNoException().isThrownBy(
+                () -> service.validate(JIRA_URL + "/", JIRA_EMAIL, PROJECT_KEY, API_TOKEN));
+        verify(restTemplate).exchange(eq(EXPECTED_URL), eq(HttpMethod.GET), any(HttpEntity.class), eq(Map.class));
     }
 
     @Test
     void validate_stripsTrailingWhitespace_fromJiraUrl() {
-        String urlWithSpaces = JIRA_URL + "   ";
-        when(restTemplate.exchange(eq(EXPECTED_URL), eq(HttpMethod.GET), any(HttpEntity.class), eq(Void.class)))
-                .thenReturn(new ResponseEntity<>(HttpStatus.OK));
+        when(restTemplate.exchange(eq(EXPECTED_URL), eq(HttpMethod.GET), any(HttpEntity.class), eq(Map.class)))
+                .thenReturn(searchResponse(1));
 
-        assertThatNoException().isThrownBy(() -> service.validate(urlWithSpaces, PROJECT_KEY, API_TOKEN));
-        verify(restTemplate).exchange(eq(EXPECTED_URL), eq(HttpMethod.GET), any(HttpEntity.class), eq(Void.class));
+        assertThatNoException().isThrownBy(
+                () -> service.validate(JIRA_URL + "   ", JIRA_EMAIL, PROJECT_KEY, API_TOKEN));
+        verify(restTemplate).exchange(eq(EXPECTED_URL), eq(HttpMethod.GET), any(HttpEntity.class), eq(Map.class));
     }
 
-    // ── Exception hierarchy — GlobalExceptionHandler relies on this ───────
+    // ── Project key normalisation ─────────────────────────────────────────────
 
     @Test
-    void validate_throwsExternalToolValidationException_onFailure() {
-        // JiraValidationException must extend ExternalToolValidationException so that
-        // GlobalExceptionHandler.handleExternalToolValidation() catches it and returns 422.
-        // If this hierarchy breaks, failures silently become 500s instead of 422s.
-        when(restTemplate.exchange(eq(EXPECTED_URL), eq(HttpMethod.GET), any(HttpEntity.class), eq(Void.class)))
-                .thenThrow(new HttpClientErrorException(HttpStatus.UNAUTHORIZED));
+    void validate_uppercasesProjectKey_beforeBuildingUrl() {
+        String expectedUrl = JIRA_URL + "/rest/api/3/project/search?keys=SPM";
+        when(restTemplate.exchange(eq(expectedUrl), eq(HttpMethod.GET), any(HttpEntity.class), eq(Map.class)))
+                .thenReturn(searchResponse(1));
 
-        assertThatThrownBy(() -> service.validate(JIRA_URL, PROJECT_KEY, API_TOKEN))
-                .isInstanceOf(ExternalToolValidationException.class);
+        assertThatNoException().isThrownBy(
+                () -> service.validate(JIRA_URL, JIRA_EMAIL, "spm", API_TOKEN));
+        verify(restTemplate).exchange(eq(expectedUrl), eq(HttpMethod.GET), any(HttpEntity.class), eq(Map.class));
     }
 
-    // ── Authorization header ──────────────────────────────────────────────
+    // ── Authorization header — Basic Auth ─────────────────────────────────────
 
     @SuppressWarnings("unchecked")
     @Test
-    void validate_setsBearerHeader() {
-        when(restTemplate.exchange(eq(EXPECTED_URL), eq(HttpMethod.GET), any(HttpEntity.class), eq(Void.class)))
-                .thenReturn(new ResponseEntity<>(HttpStatus.OK));
+    void validate_setsBasicAuthHeader_whenEmailProvided() {
+        when(restTemplate.exchange(eq(EXPECTED_URL), eq(HttpMethod.GET), any(HttpEntity.class), eq(Map.class)))
+                .thenReturn(searchResponse(1));
 
-        service.validate(JIRA_URL, PROJECT_KEY, API_TOKEN);
+        service.validate(JIRA_URL, JIRA_EMAIL, PROJECT_KEY, API_TOKEN);
 
-        ArgumentCaptor<HttpEntity<Void>> captor = ArgumentCaptor.forClass(HttpEntity.class);
-        verify(restTemplate).exchange(eq(EXPECTED_URL), eq(HttpMethod.GET), captor.capture(), eq(Void.class));
-        String authHeader = captor.getValue().getHeaders().getFirst("Authorization");
-        org.assertj.core.api.Assertions.assertThat(authHeader).isEqualTo("Bearer " + API_TOKEN);
+        ArgumentCaptor<HttpEntity<?>> captor = ArgumentCaptor.forClass(HttpEntity.class);
+        verify(restTemplate).exchange(eq(EXPECTED_URL), eq(HttpMethod.GET), captor.capture(), eq(Map.class));
+
+        String expectedBase64 = Base64.getEncoder()
+                .encodeToString((JIRA_EMAIL + ":" + API_TOKEN).getBytes(StandardCharsets.UTF_8));
+        assertThat(captor.getValue().getHeaders().getFirst(HttpHeaders.AUTHORIZATION))
+                .isEqualTo("Basic " + expectedBase64);
+    }
+
+    // ── Authorization header — Bearer fallback ────────────────────────────────
+
+    @SuppressWarnings("unchecked")
+    @Test
+    void validate_setsBearerHeader_whenEmailIsNull() {
+        when(restTemplate.exchange(eq(EXPECTED_URL), eq(HttpMethod.GET), any(HttpEntity.class), eq(Map.class)))
+                .thenReturn(searchResponse(1));
+
+        service.validate(JIRA_URL, null, PROJECT_KEY, API_TOKEN);
+
+        ArgumentCaptor<HttpEntity<?>> captor = ArgumentCaptor.forClass(HttpEntity.class);
+        verify(restTemplate).exchange(eq(EXPECTED_URL), eq(HttpMethod.GET), captor.capture(), eq(Map.class));
+
+        assertThat(captor.getValue().getHeaders().getFirst(HttpHeaders.AUTHORIZATION))
+                .isEqualTo("Bearer " + API_TOKEN);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    void validate_setsBearerHeader_whenEmailIsBlank() {
+        when(restTemplate.exchange(eq(EXPECTED_URL), eq(HttpMethod.GET), any(HttpEntity.class), eq(Map.class)))
+                .thenReturn(searchResponse(1));
+
+        service.validate(JIRA_URL, "   ", PROJECT_KEY, API_TOKEN);
+
+        ArgumentCaptor<HttpEntity<?>> captor = ArgumentCaptor.forClass(HttpEntity.class);
+        verify(restTemplate).exchange(eq(EXPECTED_URL), eq(HttpMethod.GET), captor.capture(), eq(Map.class));
+
+        assertThat(captor.getValue().getHeaders().getFirst(HttpHeaders.AUTHORIZATION))
+                .isEqualTo("Bearer " + API_TOKEN);
+    }
+
+    // ── Accept header ─────────────────────────────────────────────────────────
+
+    @SuppressWarnings("unchecked")
+    @Test
+    void validate_setsAcceptJsonHeader() {
+        when(restTemplate.exchange(eq(EXPECTED_URL), eq(HttpMethod.GET), any(HttpEntity.class), eq(Map.class)))
+                .thenReturn(searchResponse(1));
+
+        service.validate(JIRA_URL, JIRA_EMAIL, PROJECT_KEY, API_TOKEN);
+
+        ArgumentCaptor<HttpEntity<?>> captor = ArgumentCaptor.forClass(HttpEntity.class);
+        verify(restTemplate).exchange(eq(EXPECTED_URL), eq(HttpMethod.GET), captor.capture(), eq(Map.class));
+
+        assertThat(captor.getValue().getHeaders().getFirst(HttpHeaders.ACCEPT))
+                .contains("application/json");
+    }
+
+    // ── Exception hierarchy — GlobalExceptionHandler maps this to 422 ─────────
+
+    @Test
+    void validate_throwsExternalToolValidationException_onAnyFailure() {
+        // JiraValidationException must extend ExternalToolValidationException so that
+        // GlobalExceptionHandler.handleExternalToolValidation() catches it and maps to 422.
+        when(restTemplate.exchange(eq(EXPECTED_URL), eq(HttpMethod.GET), any(HttpEntity.class), eq(Map.class)))
+                .thenThrow(new HttpClientErrorException(HttpStatus.UNAUTHORIZED));
+
+        assertThatThrownBy(() -> service.validate(JIRA_URL, JIRA_EMAIL, PROJECT_KEY, API_TOKEN))
+                .isInstanceOf(ExternalToolValidationException.class);
     }
 }

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -326,9 +326,11 @@ components:
 
     BindJiraRequest:
       type: object
-      required: [jiraSpaceUrl, jiraProjectKey, jiraApiToken]
+      required: [jiraSpaceUrl, jiraEmail, jiraProjectKey, jiraApiToken]
       properties:
         jiraSpaceUrl:
+          type: string
+        jiraEmail:
           type: string
         jiraProjectKey:
           type: string

--- a/frontend/components/ToolBindingForm.vue
+++ b/frontend/components/ToolBindingForm.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { CheckCircle2, Lock, Loader2 } from "lucide-vue-next";
+import { CheckCircle2, Lock, Loader2, Info } from "lucide-vue-next";
 
 defineOptions({
   name: "ToolBindingFormCard",
@@ -8,7 +8,7 @@ defineOptions({
 type ToolBindingField = {
   name: string;
   label: string;
-  type?: "text" | "url" | "password";
+  type?: "text" | "url" | "password" | "email";
   placeholder?: string;
   autocomplete?: string;
   helpText?: string;
@@ -137,8 +137,17 @@ function handleSubmit() {
         :key="field.name"
         class="block space-y-1.5"
       >
-        <span class="text-sm font-medium text-slate-700 dark:text-slate-300">
+        <span class="flex items-center gap-1.5 text-sm font-medium text-slate-700 dark:text-slate-300">
           {{ field.label }}
+          <span
+            v-if="field.helpText"
+            class="group relative inline-flex cursor-default"
+          >
+            <Info class="h-3.5 w-3.5 shrink-0 text-slate-400 dark:text-slate-500" />
+            <span class="pointer-events-none absolute bottom-full left-1/2 z-10 mb-2 w-64 -translate-x-1/2 rounded-lg border border-slate-200 bg-white px-3 py-2 text-xs font-normal leading-relaxed text-slate-600 opacity-0 shadow-md transition-opacity group-hover:opacity-100 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-300">
+              {{ field.helpText }}
+            </span>
+          </span>
         </span>
 
         <input
@@ -155,9 +164,6 @@ function handleSubmit() {
           @input="updateFieldValue(field.name, ($event.target as HTMLInputElement).value)"
         />
 
-        <p v-if="field.helpText" class="text-xs text-slate-500 dark:text-slate-400">
-          {{ field.helpText }}
-        </p>
         <p v-if="fieldErrors[field.name]" class="text-xs text-red-600 dark:text-red-400">
           {{ fieldErrors[field.name] }}
         </p>

--- a/frontend/composables/useApiClient.ts
+++ b/frontend/composables/useApiClient.ts
@@ -109,8 +109,11 @@ export interface SanitizationReport {
   autoRejectedRequestCount?: number;
   rejectedRequestCount?: number;
   triggeredAt: string;
+}
+
 export interface BindJiraRequest {
   jiraSpaceUrl: string;
+  jiraEmail: string;
   jiraProjectKey: string;
   jiraApiToken: string;
 }
@@ -364,6 +367,10 @@ export function useApiClient() {
       `/coordinator/groups/${encodeURIComponent(groupId)}/advisor`,
       "PATCH",
       { action: "ASSIGN", advisorId },
+      token
+    );
+  }
+
   async function bindJiraTool(
     groupId: string,
     payload: BindJiraRequest,
@@ -397,6 +404,10 @@ export function useApiClient() {
       "/coordinator/sanitize",
       "POST",
       force ? { force: true } : undefined,
+      token
+    );
+  }
+
   async function bindGithubTool(
     groupId: string,
     payload: BindGithubRequest,

--- a/frontend/pages/student/group/tools.vue
+++ b/frontend/pages/student/group/tools.vue
@@ -32,6 +32,7 @@ const githubFieldErrors = ref<Record<string, string>>({});
 
 const jiraSchema = z.object({
   jiraSpaceUrl: z.string().trim().url("Enter a valid JIRA space URL."),
+  jiraEmail: z.string().trim().email("Enter a valid Atlassian account email."),
   jiraProjectKey: z.string().trim().min(1, "JIRA project key is required."),
   jiraApiToken: z.string().trim().min(1, "JIRA API token is required."),
 });
@@ -56,6 +57,7 @@ const isTeamLeader = computed(() =>
 
 const jiraFormValues = computed(() => ({
   jiraSpaceUrl: group.value?.jiraSpaceUrl ?? "",
+  jiraEmail: group.value?.jiraEmail ?? "",
   jiraProjectKey: group.value?.jiraProjectKey ?? "",
   jiraApiToken: "",
 }));
@@ -115,6 +117,7 @@ async function handleJiraSubmit(payload: Record<string, string>) {
     const fields = result.error.flatten().fieldErrors;
     jiraFieldErrors.value = {
       jiraSpaceUrl: fields.jiraSpaceUrl?.[0] ?? "",
+      jiraEmail: fields.jiraEmail?.[0] ?? "",
       jiraProjectKey: fields.jiraProjectKey?.[0] ?? "",
       jiraApiToken: fields.jiraApiToken?.[0] ?? "",
     };
@@ -233,7 +236,7 @@ async function handleGithubSubmit(payload: Record<string, string>) {
       </div>
 
       <section v-else-if="group && isTeamLeader" class="space-y-6">
-        <div class="grid gap-4 lg:grid-cols-[1.2fr_0.8fr]">
+        <div class="grid gap-6 xl:grid-cols-2">
           <div class="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm dark:border-slate-700 dark:bg-slate-800">
             <h2 class="flex items-center gap-2 text-lg font-semibold text-slate-900 dark:text-white">
               <ShieldCheck class="h-5 w-5 text-emerald-600 dark:text-emerald-400" />
@@ -251,7 +254,7 @@ async function handleGithubSubmit(payload: Record<string, string>) {
               Binding checklist
             </h2>
             <ul class="mt-3 space-y-2 text-sm text-slate-600 dark:text-slate-400">
-              <li>Enter the JIRA workspace URL, project key, and API token.</li>
+              <li>Enter the JIRA workspace URL, Atlassian account email, project key, and API token.</li>
               <li>Enter the GitHub organization name and a PAT with repository access.</li>
               <li>Watch each form switch into a locked state after a successful bind.</li>
             </ul>
@@ -270,6 +273,15 @@ async function handleGithubSubmit(payload: Record<string, string>) {
                 type: 'url',
                 placeholder: 'https://your-team.atlassian.net',
                 autocomplete: 'url',
+                helpText: 'Your Atlassian site base URL. Open Jira in your browser — it is the part before /jira in the address bar (e.g. https://yourteam.atlassian.net).',
+              },
+              {
+                name: 'jiraEmail',
+                label: 'Atlassian Account Email',
+                type: 'email',
+                placeholder: 'you@example.com',
+                autocomplete: 'email',
+                helpText: 'The exact email of your Atlassian account. To verify: click your profile picture in Jira → Manage account → Profile. Use whatever email is shown there.',
               },
               {
                 name: 'jiraProjectKey',
@@ -277,6 +289,7 @@ async function handleGithubSubmit(payload: Record<string, string>) {
                 type: 'text',
                 placeholder: 'SPM',
                 autocomplete: 'off',
+                helpText: 'The short uppercase code for your project. Find it in the Jira board URL: .../projects/PROJECTKEY/boards — the all-caps part is your key.',
               },
               {
                 name: 'jiraApiToken',
@@ -285,6 +298,7 @@ async function handleGithubSubmit(payload: Record<string, string>) {
                 placeholder: 'Enter a JIRA API token',
                 autocomplete: 'new-password',
                 lockedPlaceholder: 'Stored securely after validation',
+                helpText: 'Generate one at id.atlassian.com → Security → API tokens → Create API token. Must be created while logged in as the same email above.',
               },
             ]"
             :model-value="jiraFormValues"
@@ -307,6 +321,7 @@ async function handleGithubSubmit(payload: Record<string, string>) {
                 type: 'text',
                 placeholder: 'senior-project-team',
                 autocomplete: 'organization',
+                helpText: 'Your GitHub organization name — not your personal username. Find it in the org URL: github.com/ORG-NAME. Ask your team lead if you are unsure which org to use.',
               },
               {
                 name: 'githubPat',
@@ -314,8 +329,8 @@ async function handleGithubSubmit(payload: Record<string, string>) {
                 type: 'password',
                 placeholder: 'Enter a GitHub PAT',
                 autocomplete: 'new-password',
-                helpText: 'Use a token with the required repository scope.',
                 lockedPlaceholder: 'Stored securely after validation',
+                helpText: 'Generate at github.com → Settings → Developer settings → Personal access tokens → Tokens (classic). Select the repo scope. The token must have access to the organization above.',
               },
             ]"
             :model-value="githubFormValues"

--- a/frontend/types/group.ts
+++ b/frontend/types/group.ts
@@ -30,6 +30,7 @@ export interface GroupDetailResponse {
   members: GroupMember[]
   createdAt?: string
   jiraSpaceUrl?: string
+  jiraEmail?: string
   jiraProjectKey?: string
   jiraBound?: boolean
   githubOrgName?: string


### PR DESCRIPTION
# Description

Resolves #133

This PR addresses the authorization errors (401/403/422) encountered during Jira Cloud (.atlassian.net) and GitHub integrations. 

Jira Cloud systems reject API tokens sent directly as `Bearer` tokens and require `Basic Auth` using a Base64 encoded `email:token` format. Similarly, the GitHub REST API occasionally blocks requests and returns a 403 error if the `User-Agent` header is missing. This PR implements the necessary standards for both services to ensure successful API validation.

### Notable Decisions & Changes

* **Backend Services:**
  * `JiraValidationService`: Updated to perform authentication using `Basic <Base64 Auth>` when a `jiraEmail` is provided. If no email is provided, it falls back to the existing `Bearer` token logic for backward compatibility (e.g., Jira Server).
  * `GitHubValidationService`: Added the required `User-Agent` (`HttpHeaders.USER_AGENT`) to the request headers.
* **Database Entity:** Added a nullable `jiraEmail` column to the `ProjectGroup` table to track the email associated with the Jira integration.
* **API Documentation:** Updated `docs/openapi.yaml` to include `jiraEmail` as a *required* field in the `BindJiraRequest` schema for the Frontend team.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have updated the API documentation (`openapi.yaml`) accordingly
- [x] My changes generate no new warnings or compilation errors