### PR TITLE
fix(test): align JiraValidationWireMockTest with JIRA bug fix changes

### DIFF
--- a/backend/src/test/java/com/senior/spm/service/JiraValidationWireMockTest.java
+++ b/backend/src/test/java/com/senior/spm/service/JiraValidationWireMockTest.java
@@ -12,6 +12,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
 import org.springframework.test.context.TestPropertySource;
 
 import com.github.tomakehurst.wiremock.junit5.WireMockExtension;
@@ -37,26 +38,42 @@ class JiraValidationWireMockTest {
     private JiraValidationService service;
 
     private static final String PROJECT_KEY = "SPM";
+    private static final String EMAIL = "test@example.com";
     private static final String TOKEN = "test-jira-token";
-    private static final String PROJECT_PATH = "/rest/api/3/project/" + PROJECT_KEY;
+    private static final String SEARCH_PATH = "/rest/api/3/project/search?keys=" + PROJECT_KEY;
 
     @Test
-    @DisplayName("JIRA returns 200 — validate succeeds without exception")
+    @DisplayName("JIRA returns 200 with total=1 — validate succeeds without exception")
     void validate_success_whenJiraReturns200() {
-        wireMock.stubFor(get(urlEqualTo(PROJECT_PATH))
-                .willReturn(aResponse().withStatus(200)));
+        wireMock.stubFor(get(urlEqualTo(SEARCH_PATH))
+                .willReturn(aResponse().withStatus(200)
+                        .withHeader("Content-Type", MediaType.APPLICATION_JSON_VALUE)
+                        .withBody("{\"total\":1}")));
 
         assertThatNoException().isThrownBy(
-                () -> service.validate(wireMock.baseUrl(), PROJECT_KEY, TOKEN));
+                () -> service.validate(wireMock.baseUrl(), EMAIL, PROJECT_KEY, TOKEN));
+    }
+
+    @Test
+    @DisplayName("JIRA returns 200 with total=0 — throws JiraValidationException: project key not found")
+    void validate_success_total0_throwsProjectNotFound() {
+        wireMock.stubFor(get(urlEqualTo(SEARCH_PATH))
+                .willReturn(aResponse().withStatus(200)
+                        .withHeader("Content-Type", MediaType.APPLICATION_JSON_VALUE)
+                        .withBody("{\"total\":0}")));
+
+        assertThatThrownBy(() -> service.validate(wireMock.baseUrl(), EMAIL, PROJECT_KEY, TOKEN))
+                .isInstanceOf(JiraValidationException.class)
+                .hasMessageContaining("Project key '" + PROJECT_KEY + "' not found");
     }
 
     @Test
     @DisplayName("JIRA returns 401 — throws JiraValidationException: token invalid or expired")
     void validate_401_throwsInvalidToken() {
-        wireMock.stubFor(get(urlEqualTo(PROJECT_PATH))
+        wireMock.stubFor(get(urlEqualTo(SEARCH_PATH))
                 .willReturn(aResponse().withStatus(401)));
 
-        assertThatThrownBy(() -> service.validate(wireMock.baseUrl(), PROJECT_KEY, TOKEN))
+        assertThatThrownBy(() -> service.validate(wireMock.baseUrl(), EMAIL, PROJECT_KEY, TOKEN))
                 .isInstanceOf(JiraValidationException.class)
                 .hasMessageContaining("API token is invalid or expired");
     }
@@ -64,32 +81,32 @@ class JiraValidationWireMockTest {
     @Test
     @DisplayName("JIRA returns 403 — throws JiraValidationException: token invalid or expired")
     void validate_403_throwsInvalidToken() {
-        wireMock.stubFor(get(urlEqualTo(PROJECT_PATH))
+        wireMock.stubFor(get(urlEqualTo(SEARCH_PATH))
                 .willReturn(aResponse().withStatus(403)));
 
-        assertThatThrownBy(() -> service.validate(wireMock.baseUrl(), PROJECT_KEY, TOKEN))
+        assertThatThrownBy(() -> service.validate(wireMock.baseUrl(), EMAIL, PROJECT_KEY, TOKEN))
                 .isInstanceOf(JiraValidationException.class)
                 .hasMessageContaining("API token is invalid or expired");
     }
 
     @Test
-    @DisplayName("JIRA returns 404 — throws JiraValidationException: project key not found")
-    void validate_404_throwsProjectNotFound() {
-        wireMock.stubFor(get(urlEqualTo(PROJECT_PATH))
+    @DisplayName("JIRA returns 404 — throws JiraValidationException: URL unreachable")
+    void validate_404_throwsUnreachable() {
+        wireMock.stubFor(get(urlEqualTo(SEARCH_PATH))
                 .willReturn(aResponse().withStatus(404)));
 
-        assertThatThrownBy(() -> service.validate(wireMock.baseUrl(), PROJECT_KEY, TOKEN))
+        assertThatThrownBy(() -> service.validate(wireMock.baseUrl(), EMAIL, PROJECT_KEY, TOKEN))
                 .isInstanceOf(JiraValidationException.class)
-                .hasMessageContaining("Project key '" + PROJECT_KEY + "' not found");
+                .hasMessageContaining("JIRA space URL is unreachable");
     }
 
     @Test
     @DisplayName("JIRA returns other 4xx — throws JiraValidationException: URL unreachable")
     void validate_other4xx_throwsUnreachable() {
-        wireMock.stubFor(get(urlEqualTo(PROJECT_PATH))
+        wireMock.stubFor(get(urlEqualTo(SEARCH_PATH))
                 .willReturn(aResponse().withStatus(400)));
 
-        assertThatThrownBy(() -> service.validate(wireMock.baseUrl(), PROJECT_KEY, TOKEN))
+        assertThatThrownBy(() -> service.validate(wireMock.baseUrl(), EMAIL, PROJECT_KEY, TOKEN))
                 .isInstanceOf(JiraValidationException.class)
                 .hasMessageContaining("JIRA space URL is unreachable");
     }
@@ -97,10 +114,10 @@ class JiraValidationWireMockTest {
     @Test
     @DisplayName("JiraValidationException is an ExternalToolValidationException (422-equivalent)")
     void validate_throwsExternalToolValidationException_subtype() {
-        wireMock.stubFor(get(urlEqualTo(PROJECT_PATH))
+        wireMock.stubFor(get(urlEqualTo(SEARCH_PATH))
                 .willReturn(aResponse().withStatus(401)));
 
-        assertThatThrownBy(() -> service.validate(wireMock.baseUrl(), PROJECT_KEY, TOKEN))
+        assertThatThrownBy(() -> service.validate(wireMock.baseUrl(), EMAIL, PROJECT_KEY, TOKEN))
                 .isInstanceOf(ExternalToolValidationException.class);
     }
 }


### PR DESCRIPTION
PR #135 changed JiraValidationService.validate() to require a jiraEmail parameter (4 args) and switched the endpoint from /rest/api/3/project/{key} to /rest/api/3/project/search?keys={key} with total-count   
  response parsing. The WireMock tests merged in #128 were written against the old signature and failed to compile.
                                                                                                                                                                                                                  
  Changes:                                              
  - Added jiraEmail arg to all service.validate() calls
  - Updated WireMock stubs to use the new search endpoint
  - Replaced HTTP 404 → "project not found" test with 200 + total=0 body (matching actual service behavior)
  - Added total=1 response body to the success test