### PR TITLE
fix(advisor-flow): expose advisor state in API and polish UX

### DIFF
--- a/backend/src/main/java/com/senior/spm/controller/response/GroupDetailResponse.java
+++ b/backend/src/main/java/com/senior/spm/controller/response/GroupDetailResponse.java
@@ -21,6 +21,8 @@ public final class GroupDetailResponse implements InvitationActionResponse {
     private String githubOrgName;
     private Boolean githubBound;
     private List<MemberResponse> members;
+    private UUID advisorId;
+    private String advisorMail;
 
     @Data
     public static class MemberResponse {

--- a/backend/src/main/java/com/senior/spm/service/GroupService.java
+++ b/backend/src/main/java/com/senior/spm/service/GroupService.java
@@ -315,6 +315,12 @@ public class GroupService {
             .collect(Collectors.toList());
 
         response.setMembers(memberResponses);
+
+        if (group.getAdvisor() != null) {
+            response.setAdvisorId(group.getAdvisor().getId());
+            response.setAdvisorMail(group.getAdvisor().getMail());
+        }
+
         return response;
     }
 

--- a/frontend/components/AdvisorRequestModal.vue
+++ b/frontend/components/AdvisorRequestModal.vue
@@ -62,9 +62,9 @@ const respond = async (accept: boolean) => {
     if (!token) throw new Error('Authentication required');
     
     await respondToAdvisorRequest(props.requestId, accept, token);
-    
+
     emit('responded', props.requestId, accept);
-    closeModal();
+    emit('close');
   } catch (e: any) {
     console.error('Error responding to request:', e);
     if (e.status === 400 && e.message?.toLowerCase().includes('capacity')) {

--- a/frontend/pages/student/group/index.vue
+++ b/frontend/pages/student/group/index.vue
@@ -70,6 +70,13 @@
 
 	const isLeader = computed(() => state.value === "leader");
 	const hasPendingAdvisorRequest = computed(() => activeAdvisorRequest.value?.status === "PENDING");
+	// True only when the group actually has an advisor currently assigned.
+	// If the coordinator removed the advisor, advisorId becomes null even if the
+	// latest request still carries status ACCEPTED — that's the stale case.
+	const isAdvisorAssigned = computed(() => !!group.value?.advisorId);
+	const isAcceptedRequestStale = computed(() =>
+		activeAdvisorRequest.value?.status === "ACCEPTED" && !isAdvisorAssigned.value,
+	);
 	const canSendAdvisorRequest = computed(() => (
 		isLeader.value &&
 		group.value?.status === "TOOLS_BOUND" &&
@@ -543,7 +550,14 @@
               </div>
 
               <div
-                v-if="activeAdvisorRequest"
+                v-if="isAcceptedRequestStale"
+                class="mt-5 rounded-xl border border-amber-300 bg-amber-50 p-4 text-sm text-amber-900 dark:border-amber-800 dark:bg-amber-950/40 dark:text-amber-200"
+              >
+                Your previously assigned advisor was removed by the coordinator. You can send a new request below.
+              </div>
+
+              <div
+                v-else-if="activeAdvisorRequest"
                 class="mt-5 rounded-xl border border-slate-200 bg-white/80 p-4 dark:border-slate-700 dark:bg-slate-900/50"
               >
                 <div class="flex items-center justify-between gap-3">
@@ -586,7 +600,7 @@
               </div>
 
               <div
-                v-else
+                v-else-if="!isAcceptedRequestStale"
                 class="mt-5 rounded-xl border border-slate-200 bg-white/80 p-4 text-sm text-slate-600 dark:border-slate-700 dark:bg-slate-900/50 dark:text-slate-400"
               >
                 No advisor request has been submitted yet.
@@ -594,12 +608,19 @@
 
               <template v-if="state === 'leader'">
                 <div
-                  v-if="group.status !== 'TOOLS_BOUND'"
+                  v-if="group.status === 'FORMING' || group.status === 'TOOLS_PENDING'"
                   class="mt-5 rounded-xl border border-amber-300 bg-amber-50 p-4 text-sm text-amber-900 dark:border-amber-800 dark:bg-amber-950/40 dark:text-amber-200"
                 >
                   Your group must be in
                   <span class="font-semibold">TOOLS_BOUND</span>
                   status before requesting an advisor.
+                </div>
+
+                <div
+                  v-else-if="group.status === 'ADVISOR_ASSIGNED'"
+                  class="mt-5 rounded-xl border border-green-200 bg-green-50 p-4 text-sm text-green-900 dark:border-green-800 dark:bg-green-950/40 dark:text-green-200"
+                >
+                  Your group already has an assigned advisor.
                 </div>
 
                 <div

--- a/frontend/pages/student/group/tools.vue
+++ b/frontend/pages/student/group/tools.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { z } from "zod";
-import { AlertCircle, FolderGit2, Loader2, ShieldCheck } from "lucide-vue-next";
+import { AlertCircle, ArrowLeft, FolderGit2, Loader2, ShieldCheck } from "lucide-vue-next";
 import type { BindGithubRequest, BindJiraRequest } from "~/composables/useApiClient";
 import type { GroupDetailResponse } from "~/types/group";
 import { useAuthStore } from "~/stores/auth";
@@ -180,6 +180,14 @@ async function handleGithubSubmit(payload: Record<string, string>) {
 <template>
   <main class="min-h-screen bg-gradient-to-br from-slate-50 via-white to-slate-100 p-4 transition-colors dark:from-slate-950 dark:via-slate-900 dark:to-slate-950 md:p-8">
     <div class="mx-auto w-full max-w-6xl space-y-6">
+      <NuxtLink
+        to="/student/group"
+        class="inline-flex items-center gap-2 text-sm font-medium text-slate-600 transition hover:text-slate-900 dark:text-slate-400 dark:hover:text-white"
+      >
+        <ArrowLeft class="h-4 w-4" />
+        Back to group hub
+      </NuxtLink>
+
       <header class="rounded-2xl border border-slate-200 bg-white/90 p-6 shadow-sm backdrop-blur transition-colors dark:border-slate-700 dark:bg-slate-800/90 dark:shadow-lg">
         <div class="flex flex-col gap-4 md:flex-row md:items-start md:justify-between">
           <div>


### PR DESCRIPTION
### Summary:
  - Expose advisorId/advisorMail in GroupDetailResponse so frontend reflects
    real assignment state, not just request history
  - Fix advisor modal not closing after professor accepts or declines a request
  - Show contextual notice when advisor was removed by coordinator (stale
    ACCEPTED request) and re-expose advisor list so group can retry
  - Fix TOOLS_BOUND warning showing incorrectly on ADVISOR_ASSIGNED groups
  - Add back-navigation link on tool binding page
