### PR TITLE
feat: (backend): implement GET committee details endpoint

### DIFF
--- a/backend/src/main/java/com/senior/spm/controller/CoordinatorController.java
+++ b/backend/src/main/java/com/senior/spm/controller/CoordinatorController.java
@@ -18,6 +18,7 @@ import com.senior.spm.controller.request.AddProfessorToCommitteeRequest;
 import com.senior.spm.controller.response.AdvisorCapacityResponse;
 import com.senior.spm.controller.request.AdvisorOverrideRequest;
 import com.senior.spm.controller.response.AdvisorOverrideResponse;
+import com.senior.spm.controller.response.CommitteeDetailResponse;
 import com.senior.spm.controller.response.CommitteeGroupResponse;
 import com.senior.spm.controller.response.CommitteeProfessorResponse;
 import com.senior.spm.controller.response.GroupDetailResponse;
@@ -355,6 +356,29 @@ public class CoordinatorController {
     }
 
     // ========== COMMITTEE MANAGEMENT ENDPOINTS (Process 4) ==========
+
+    /**
+     * Fetches detailed information for a specific committee, including assigned professors (ADVISOR and JURY roles) and bounded student groups.
+     *
+     * <p>Auth: Staff JWT with role=Coordinator (enforced by SecurityConfig).
+     *
+     * <p>REST Endpoint: {@code GET /api/coordinator/committees/{committeeId}}
+     *
+     * @param committeeId UUID of the target committee
+     * @return 200 with {@link CommitteeDetailResponse}
+     *
+     *         Error responses:
+     *         - 404: committee not found
+     */
+    @GetMapping("/committees/{committeeId}")
+    public ResponseEntity<?> getCommitteeDetail(@PathVariable UUID committeeId) {
+        try {
+            CommitteeDetailResponse result = committeeService.getCommitteeDetails(committeeId);
+            return ResponseEntity.ok(result);
+        } catch (NotFoundException e) {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).body(new ErrorMessage(e.getMessage()));
+        }
+    }
 
     /**
      * Adds a professor to a committee with validation.

--- a/backend/src/main/java/com/senior/spm/controller/response/CommitteeDetailResponse.java
+++ b/backend/src/main/java/com/senior/spm/controller/response/CommitteeDetailResponse.java
@@ -1,0 +1,23 @@
+package com.senior.spm.controller.response;
+
+import java.util.List;
+import java.util.UUID;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class CommitteeDetailResponse {
+
+    private UUID id;
+    private String committeeName;
+    private String termId;
+    private UUID deliverableId;
+    private List<CommitteeProfessorResponse> professors;
+    private List<CommitteeGroupResponse> groups;
+}

--- a/backend/src/main/java/com/senior/spm/service/CommitteeService.java
+++ b/backend/src/main/java/com/senior/spm/service/CommitteeService.java
@@ -1,5 +1,7 @@
 package com.senior.spm.service;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.UUID;
 
 import org.springframework.stereotype.Service;
@@ -7,6 +9,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import com.senior.spm.controller.request.AddGroupToCommitteeRequest;
 import com.senior.spm.controller.request.AddProfessorToCommitteeRequest;
+import com.senior.spm.controller.response.CommitteeDetailResponse;
 import com.senior.spm.controller.response.CommitteeGroupResponse;
 import com.senior.spm.controller.response.CommitteeProfessorResponse;
 import com.senior.spm.entity.Committee;
@@ -98,6 +101,51 @@ public class CommitteeService {
                 group.getId(),
                 group.getGroupName(),
                 group.getStatus().name()
+        );
+    }
+
+    /**
+     * Fetches detailed information for a specific committee, including assigned professors and bounded student groups.
+     *
+     * @param id the committee ID
+     * @return the fully populated CommitteeDetailResponse
+     * @throws NotFoundException if the committee does not exist
+     */
+    @Transactional(readOnly = true)
+    public CommitteeDetailResponse getCommitteeDetails(UUID id) {
+        Committee committee = committeeRepository.findById(id)
+                .orElseThrow(() -> new NotFoundException("Committee not found: " + id));
+
+        // Map professors
+        List<CommitteeProfessorResponse> professorResponses = new ArrayList<>();
+        for (CommitteeProfessor cp : committee.getProfessors()) {
+            professorResponses.add(new CommitteeProfessorResponse(
+                    cp.getId(),
+                    cp.getProfessor().getId(),
+                    cp.getProfessor().getMail(),
+                    cp.getProfessor().getMail(),
+                    cp.getRole()
+            ));
+        }
+
+        // Map groups
+        List<CommitteeGroupResponse> groupResponses = new ArrayList<>();
+        for (ProjectGroup group : committee.getGroups()) {
+            groupResponses.add(new CommitteeGroupResponse(
+                    group.getId(),
+                    group.getId(),
+                    group.getGroupName(),
+                    group.getStatus().name()
+            ));
+        }
+
+        return new CommitteeDetailResponse(
+                committee.getId(),
+                committee.getCommitteeName(),
+                committee.getTermId(),
+                committee.getDeliverable().getId(),
+                professorResponses,
+                groupResponses
         );
     }
 }


### PR DESCRIPTION
## Overview
This PR introduces the `GET /api/coordinator/committees/{committeeId}` endpoint to fetch comprehensive details of a specific committee. 

## Key Features
Detailed DTO Aggregation: Fetches and aggregates the base committee data alongside assigned professors (categorized by `ADVISOR` and `JURY` roles) and bounded student groups into a single `CommitteeDetailResponse` DTO.
Not Found Handling: Gracefully handles invalid requests by throwing a `NotFoundException` (returns `404 Not Found`) if the requested committee ID does not exist in the database.
Security & RBAC: Strictly enforces Role-Based Access Control. This endpoint is secured and accessible *only* to users with the `COORDINATOR` role (returns `403 Forbidden` for unauthorized access).