### PR TITLE
feat: (committee) implement get /api/committees

### DIFF
--- a/backend/src/main/java/com/senior/spm/controller/CommitteeController.java
+++ b/backend/src/main/java/com/senior/spm/controller/CommitteeController.java
@@ -44,6 +44,13 @@ public class CommitteeController {
             return ResponseEntity.status(HttpStatus.NOT_FOUND).body(new ErrorMessage(e.getMessage()));
         }
     }
+
+    @GetMapping
+    public ResponseEntity<?> getCommittees(@RequestParam(required = false) String termId) {
+        var result = committeeService.getCommittees(termId);
+        return ResponseEntity.ok(result);
+    }
+
     @GetMapping("/{id}")
     public ResponseEntity<?> getCommitteeDetail(@PathVariable UUID id) {
         try {

--- a/backend/src/main/java/com/senior/spm/controller/CommitteeController.java
+++ b/backend/src/main/java/com/senior/spm/controller/CommitteeController.java
@@ -9,11 +9,14 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.senior.spm.controller.request.AddGroupsToCommitteeRequest;
 import com.senior.spm.controller.request.AddProfessorsToCommitteeRequest;
+import com.senior.spm.controller.request.CreateCommitteeRequest;
 import com.senior.spm.controller.response.ErrorMessage;
+import com.senior.spm.exception.AlreadyExistsException;
 import com.senior.spm.exception.ConflictException;
 import com.senior.spm.exception.NotFoundException;
 import com.senior.spm.service.CommitteeService;
@@ -30,6 +33,17 @@ public class CommitteeController {
         this.committeeService = committeeService;
     }
 
+    @PostMapping
+    public ResponseEntity<?> createCommittee(@Valid @RequestBody CreateCommitteeRequest request) {
+        try {
+            var result = committeeService.createCommittee(request);
+            return ResponseEntity.status(HttpStatus.CREATED).body(result);
+        } catch (AlreadyExistsException e) {
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(new ErrorMessage(e.getMessage()));
+        } catch (NotFoundException e) {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).body(new ErrorMessage(e.getMessage()));
+        }
+    }
     @GetMapping("/{id}")
     public ResponseEntity<?> getCommitteeDetail(@PathVariable UUID id) {
         try {

--- a/backend/src/main/java/com/senior/spm/controller/request/CreateCommitteeRequest.java
+++ b/backend/src/main/java/com/senior/spm/controller/request/CreateCommitteeRequest.java
@@ -1,0 +1,20 @@
+package com.senior.spm.controller.request;
+
+import java.util.UUID;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Data;
+
+@Data
+public class CreateCommitteeRequest {
+
+    @NotBlank
+    private String committeeName;
+
+    @NotBlank
+    private String termId;
+
+    @NotNull
+    private UUID deliverableId;
+}

--- a/backend/src/main/java/com/senior/spm/controller/response/CommitteeSummaryResponse.java
+++ b/backend/src/main/java/com/senior/spm/controller/response/CommitteeSummaryResponse.java
@@ -1,0 +1,16 @@
+package com.senior.spm.controller.response;
+
+import java.util.UUID;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class CommitteeSummaryResponse {
+
+    private UUID id;
+    private String committeeName;
+    private String termId;
+    private UUID deliverableId;
+}

--- a/backend/src/main/java/com/senior/spm/repository/CommitteeRepository.java
+++ b/backend/src/main/java/com/senior/spm/repository/CommitteeRepository.java
@@ -13,6 +13,8 @@ import com.senior.spm.entity.Committee;
 @Repository
 public interface CommitteeRepository extends JpaRepository<Committee, UUID> {
 
+    List<Committee> findByTermId(String termId);
+
     boolean existsByCommitteeNameAndTermId(String committeeName, String termId);
 
     @Query("SELECT COUNT(c) > 0 FROM Committee c JOIN c.professors cp WHERE cp.professor.id = :professorId AND c.deliverable.id = :deliverableId")

--- a/backend/src/main/java/com/senior/spm/repository/CommitteeRepository.java
+++ b/backend/src/main/java/com/senior/spm/repository/CommitteeRepository.java
@@ -1,5 +1,6 @@
 package com.senior.spm.repository;
 
+import java.util.List;
 import java.util.UUID;
 
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -11,6 +12,8 @@ import com.senior.spm.entity.Committee;
 
 @Repository
 public interface CommitteeRepository extends JpaRepository<Committee, UUID> {
+
+    boolean existsByCommitteeNameAndTermId(String committeeName, String termId);
 
     @Query("SELECT COUNT(c) > 0 FROM Committee c JOIN c.professors cp WHERE cp.professor.id = :professorId AND c.deliverable.id = :deliverableId")
     boolean existsByProfessorIdAndDeliverableId(@Param("professorId") UUID professorId, @Param("deliverableId") UUID deliverableId);

--- a/backend/src/main/java/com/senior/spm/service/CommitteeService.java
+++ b/backend/src/main/java/com/senior/spm/service/CommitteeService.java
@@ -9,16 +9,20 @@ import org.springframework.transaction.annotation.Transactional;
 
 import com.senior.spm.controller.request.AddGroupsToCommitteeRequest;
 import com.senior.spm.controller.request.AddProfessorsToCommitteeRequest;
+import com.senior.spm.controller.request.CreateCommitteeRequest;
 import com.senior.spm.controller.response.CommitteeDetailResponse;
 import com.senior.spm.controller.response.CommitteeGroupResponse;
 import com.senior.spm.controller.response.CommitteeProfessorResponse;
+import com.senior.spm.controller.response.CommitteeSummaryResponse;
 import com.senior.spm.entity.Committee;
 import com.senior.spm.entity.CommitteeProfessor;
 import com.senior.spm.entity.CommitteeProfessor.ProfessorRole;
 import com.senior.spm.entity.ProjectGroup;
 import com.senior.spm.entity.ProjectGroup.GroupStatus;
+import com.senior.spm.exception.AlreadyExistsException;
 import com.senior.spm.exception.NotFoundException;
 import com.senior.spm.repository.CommitteeRepository;
+import com.senior.spm.repository.DeliverableRepository;
 import com.senior.spm.repository.ProjectGroupRepository;
 import com.senior.spm.repository.StaffUserRepository;
 
@@ -31,8 +35,26 @@ public class CommitteeService {
     private final CommitteeRepository committeeRepository;
     private final StaffUserRepository staffUserRepository;
     private final ProjectGroupRepository projectGroupRepository;
+    private final DeliverableRepository deliverableRepository;
     private final CommitteeValidationService committeeValidationService;
 
+    @Transactional
+    public CommitteeSummaryResponse createCommittee(CreateCommitteeRequest request) {
+        if (committeeRepository.existsByCommitteeNameAndTermId(request.getCommitteeName(), request.getTermId())) {
+            throw new AlreadyExistsException("Committee with this name already exists for the given term");
+        }
+
+        var deliverable = deliverableRepository.findById(request.getDeliverableId())
+                .orElseThrow(() -> new NotFoundException("Deliverable not found: " + request.getDeliverableId()));
+
+        var committee = new Committee();
+        committee.setCommitteeName(request.getCommitteeName());
+        committee.setTermId(request.getTermId());
+        committee.setDeliverable(deliverable);
+
+        var saved = committeeRepository.save(committee);
+        return new CommitteeSummaryResponse(saved.getId(), saved.getCommitteeName(), saved.getTermId(), deliverable.getId());
+    }
     @Transactional
     public List<CommitteeProfessorResponse> addProfessorsToCommittee(UUID committeeId, AddProfessorsToCommitteeRequest request) {
         var committee = committeeRepository.findById(committeeId)

--- a/backend/src/main/java/com/senior/spm/service/CommitteeService.java
+++ b/backend/src/main/java/com/senior/spm/service/CommitteeService.java
@@ -55,6 +55,16 @@ public class CommitteeService {
         var saved = committeeRepository.save(committee);
         return new CommitteeSummaryResponse(saved.getId(), saved.getCommitteeName(), saved.getTermId(), deliverable.getId());
     }
+
+    @Transactional(readOnly = true)
+    public List<CommitteeSummaryResponse> getCommittees(String termId) {
+        var committees = (termId != null) ? committeeRepository.findByTermId(termId) : committeeRepository.findAll();
+
+        return committees.stream()
+                .map(c -> new CommitteeSummaryResponse(c.getId(), c.getCommitteeName(), c.getTermId(), c.getDeliverable().getId()))
+                .toList();
+    }
+
     @Transactional
     public List<CommitteeProfessorResponse> addProfessorsToCommittee(UUID committeeId, AddProfessorsToCommitteeRequest request) {
         var committee = committeeRepository.findById(committeeId)


### PR DESCRIPTION
feat(committee): implement GET /api/committees endpoint for dashboard

- Add `findByTermId` query to `CommitteeRepository` to support filtering.
- Implement `getCommittees` in `CommitteeService` to map database entities to summary DTOs.
- Expose GET endpoint in `CommitteeController` supporting an optional `termId` query parameter.