### PR TITLE
fix(invitations): implement student search & send flow (#161)

### DIFF
--- a/backend/src/main/java/com/senior/spm/controller/StudentController.java
+++ b/backend/src/main/java/com/senior/spm/controller/StudentController.java
@@ -9,24 +9,27 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.senior.spm.controller.response.StudentSearchResponse;
+import com.senior.spm.service.StudentService;
+
 import lombok.RequiredArgsConstructor;
 
-// TODO: Implement student search endpoint — requires StudentService.searchAvailableStudents(q)
 @RestController
 @RequestMapping("/api/students")
 @RequiredArgsConstructor
 @Validated
 public class StudentController {
 
+    private final StudentService studentService;
+
     /**
      * Search for students not currently in any group.
      * Auth: Student JWT
      * GET /api/students/search?q={query} (min 3 chars)
-     * Returns students with studentId, githubUsername, inGroup=false
+     * Returns students with studentId, githubUsername (null if not yet OAuth'd)
      */
     @GetMapping("/search")
-    public ResponseEntity<List<?>> searchStudents(@RequestParam String q) {
-        // TODO: wire to StudentService.searchAvailableStudents(q)
-        throw new UnsupportedOperationException("Not implemented yet");
+    public ResponseEntity<List<StudentSearchResponse>> searchStudents(@RequestParam String q) {
+        return ResponseEntity.ok(studentService.searchAvailableStudents(q));
     }
 }

--- a/backend/src/main/java/com/senior/spm/controller/response/StudentSearchResponse.java
+++ b/backend/src/main/java/com/senior/spm/controller/response/StudentSearchResponse.java
@@ -1,0 +1,15 @@
+package com.senior.spm.controller.response;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public final class StudentSearchResponse {
+
+    private String studentId;
+    private String githubUsername;
+}

--- a/backend/src/main/java/com/senior/spm/repository/StudentRepository.java
+++ b/backend/src/main/java/com/senior/spm/repository/StudentRepository.java
@@ -1,9 +1,12 @@
 package com.senior.spm.repository;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import com.senior.spm.entity.Student;
@@ -16,4 +19,12 @@ public interface StudentRepository extends JpaRepository<Student, UUID> {
     Optional<Student> findByStudentId(String studentId);
 
     Optional<Student> findByGithubUsername(String githubUsername);
+
+    @Query("""
+        SELECT s FROM Student s
+        LEFT JOIN s.memberships m
+        WHERE m IS NULL
+          AND s.studentId LIKE CONCAT('%', :q, '%')
+    """)
+    List<Student> findUngroupedByStudentIdContaining(@Param("q") String q);
 }

--- a/backend/src/main/java/com/senior/spm/service/StudentService.java
+++ b/backend/src/main/java/com/senior/spm/service/StudentService.java
@@ -1,9 +1,12 @@
 package com.senior.spm.service;
 
+import java.util.List;
+
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.senior.spm.controller.request.StudentUploadRequest;
+import com.senior.spm.controller.response.StudentSearchResponse;
 import com.senior.spm.entity.Student;
 import com.senior.spm.exception.AlreadyExistsException;
 import com.senior.spm.repository.StudentRepository;
@@ -40,5 +43,16 @@ public class StudentService {
         }
 
         studentRepository.saveAll(students);
+    }
+
+    @Transactional(readOnly = true)
+    public List<StudentSearchResponse> searchAvailableStudents(String q) {
+        if (q == null || q.trim().length() < 3) {
+            throw new IllegalArgumentException("Query must be at least 3 characters");
+        }
+        return studentRepository.findUngroupedByStudentIdContaining(q.trim())
+            .stream()
+            .map(s -> new StudentSearchResponse(s.getStudentId(), s.getGithubUsername()))
+            .toList();
     }
 }

--- a/frontend/composables/useApiClient.ts
+++ b/frontend/composables/useApiClient.ts
@@ -165,7 +165,21 @@ export interface BindToolResponse {
   githubBound: boolean;
 }
 
-export type InvitationStatus = "PENDING" | "ACCEPTED" | "DECLINED" | "AUTO_DENIED";
+export type InvitationStatus = "PENDING" | "ACCEPTED" | "DECLINED" | "AUTO_DENIED" | "CANCELLED";
+
+export interface StudentSearchResult {
+  studentId: string;
+  githubUsername: string | null;
+}
+
+export interface SentGroupInvitation {
+  invitationId: string;
+  groupId: string;
+  targetStudentId: string;
+  status: InvitationStatus;
+  sentAt: string;
+  respondedAt?: string | null;
+}
 
 export interface GroupInvitation {
   invitationId: string;
@@ -579,6 +593,53 @@ export function useApiClient() {
     return apiCall<AdvisorRespondResponse>(`/advisor/requests/${encodeURIComponent(requestId)}/respond`, "PATCH", { accept }, token);
   }
 
+  /**
+   * Search for ungrouped students by studentId substring (min 3 chars)
+   */
+  async function searchStudents(q: string, token?: string): Promise<StudentSearchResult[]> {
+    return apiCall<StudentSearchResult[]>(`/students/search?q=${encodeURIComponent(q)}`, "GET", undefined, token);
+  }
+
+  /**
+   * Send a group invitation to a target student (Team Leader only)
+   */
+  async function sendGroupInvitation(
+    groupId: string,
+    targetStudentId: string,
+    token?: string
+  ): Promise<SentGroupInvitation> {
+    return apiCall<SentGroupInvitation>(
+      `/groups/${encodeURIComponent(groupId)}/invitations`,
+      "POST",
+      { targetStudentId },
+      token
+    );
+  }
+
+  /**
+   * Fetch all outbound invitations sent by the group (Team Leader only)
+   */
+  async function fetchGroupInvitations(groupId: string, token?: string): Promise<SentGroupInvitation[]> {
+    return apiCall<SentGroupInvitation[]>(
+      `/groups/${encodeURIComponent(groupId)}/invitations`,
+      "GET",
+      undefined,
+      token
+    );
+  }
+
+  /**
+   * Cancel a pending outbound invitation (Team Leader only)
+   */
+  async function cancelGroupInvitation(invitationId: string, token?: string): Promise<SentGroupInvitation> {
+    return apiCall<SentGroupInvitation>(
+      `/invitations/${encodeURIComponent(invitationId)}`,
+      "DELETE",
+      undefined,
+      token
+    );
+  }
+
   return {
     getAuthToken,
     loginFaculty,
@@ -620,5 +681,9 @@ export function useApiClient() {
     fetchAdvisorRequests,
     fetchAdvisorRequestDetail,
     respondToAdvisorRequest,
+    searchStudents,
+    sendGroupInvitation,
+    fetchGroupInvitations,
+    cancelGroupInvitation,
   };
 }

--- a/frontend/pages/student/group/invitations.vue
+++ b/frontend/pages/student/group/invitations.vue
@@ -23,7 +23,7 @@
 							Group Invitations
 						</h1>
 						<p class="mt-2 text-sm text-slate-600 dark:text-slate-400">
-							Manage your pending group invitations from teammates.
+							Manage your group invitations.
 						</p>
 					</div>
 					<div class="flex items-center gap-2 rounded-lg bg-slate-100 px-3 py-2 dark:bg-slate-700">
@@ -35,56 +35,229 @@
 				</div>
 			</header>
 
-			<!-- Loading state -->
-			<div
-				v-if="isLoading"
-				class="rounded-2xl border border-slate-200 bg-white p-8 text-center dark:border-slate-700 dark:bg-slate-800"
-			>
-				<div
-					class="inline-flex h-8 w-8 animate-spin rounded-full border-4 border-slate-300 border-t-blue-600 dark:border-slate-600 dark:border-t-blue-400"
-				></div>
-				<p class="mt-4 text-slate-600 dark:text-slate-400">Loading invitations...</p>
-			</div>
+			<!-- ── LEADER SECTION ─────────────────────────────────────────────── -->
+			<template v-if="isLeader">
 
-			<!-- Error state -->
-			<div
-				v-else-if="error"
-				class="rounded-2xl border border-red-200 bg-red-50 p-6 dark:border-red-900/50 dark:bg-red-900/20"
-			>
-				<h3 class="font-semibold text-red-900 dark:text-red-200">Error</h3>
-				<p class="mt-2 text-sm text-red-700 dark:text-red-300">{{ error }}</p>
-				<button
-					@click="refreshInvitations"
-					class="mt-4 rounded-md bg-red-600 px-4 py-2 text-sm font-medium text-white transition hover:bg-red-700 dark:bg-red-700 dark:hover:bg-red-600"
+				<!-- Send Invitation card -->
+				<section
+					class="rounded-2xl border border-slate-200 bg-white/90 p-6 shadow-sm backdrop-blur transition-colors dark:border-slate-700 dark:bg-slate-800/90 dark:shadow-lg"
 				>
-					Try Again
-				</button>
-			</div>
+					<div class="mb-4 flex items-center gap-3">
+						<UserRoundPlus class="h-5 w-5 text-blue-600 dark:text-blue-400" />
+						<h2 class="text-lg font-semibold text-slate-900 dark:text-white">Send Invitation</h2>
+					</div>
 
-			<!-- Empty state -->
-			<div
-				v-else-if="pendingCount === 0"
-				class="rounded-2xl border-2 border-dashed border-slate-300 bg-slate-50 p-12 text-center dark:border-slate-600 dark:bg-slate-800"
-			>
-				<MailX class="mx-auto h-12 w-12 text-slate-400 dark:text-slate-500" />
-				<h3 class="mt-4 font-semibold text-slate-900 dark:text-white">No pending invitations</h3>
-				<p class="mt-2 text-sm text-slate-600 dark:text-slate-400">
-					You're all caught up! Check back later for new group invitations.
-				</p>
-			</div>
+					<!-- Locked notice -->
+					<div
+						v-if="!canSendInvitations"
+						class="flex items-center gap-2 rounded-lg border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-800 dark:border-amber-800/40 dark:bg-amber-900/20 dark:text-amber-300"
+					>
+						<AlertCircle class="h-4 w-4 shrink-0" />
+						{{ sendBlockedReason }}
+					</div>
 
-			<!-- Invitations list -->
-			<div v-else class="space-y-4">
-				<InvitationCard
-					v-for="invitation in pendingInvitations"
-					:key="invitation.invitationId"
-					:invitation="invitation"
-					@accept="handleAccept"
-					@decline="handleDecline"
-				/>
-			</div>
+					<!-- Search + send form -->
+					<div v-else class="space-y-4">
+						<!-- Search input with dropdown -->
+						<div class="relative">
+							<div class="relative">
+								<Search class="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-slate-400" />
+								<input
+									v-model="searchQuery"
+									type="text"
+									placeholder="Search by student ID (min 3 characters)…"
+									class="w-full rounded-lg border border-slate-200 bg-white py-2.5 pl-9 pr-4 text-sm text-slate-900 placeholder-slate-400 transition focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500/20 dark:border-slate-600 dark:bg-slate-700 dark:text-white dark:placeholder-slate-400 dark:focus:border-blue-400"
+									@input="onSearchInput"
+								/>
+							</div>
 
-			<!-- Refresh hint -->
+							<!-- Dropdown results -->
+							<div
+								v-if="isSearching || searchResults.length > 0"
+								class="absolute z-10 mt-1 w-full rounded-lg border border-slate-200 bg-white shadow-lg dark:border-slate-600 dark:bg-slate-800"
+							>
+								<div
+									v-if="isSearching"
+									class="px-4 py-3 text-sm text-slate-500 dark:text-slate-400"
+								>
+									Searching…
+								</div>
+								<button
+									v-for="student in searchResults"
+									:key="student.studentId"
+									type="button"
+									class="flex w-full items-center gap-3 px-4 py-3 text-left text-sm transition hover:bg-slate-50 dark:hover:bg-slate-700/60"
+									@click="selectStudent(student)"
+								>
+									<span class="font-mono font-medium text-slate-900 dark:text-white">{{ student.studentId }}</span>
+									<span v-if="student.githubUsername" class="text-slate-500 dark:text-slate-400">
+										({{ student.githubUsername }})
+									</span>
+								</button>
+							</div>
+						</div>
+
+						<!-- Selected student chip + Send button -->
+						<div v-if="selectedStudent" class="flex items-center gap-3">
+							<div class="flex items-center gap-2 rounded-lg bg-blue-50 px-3 py-2 dark:bg-blue-900/30">
+								<span class="font-mono text-sm font-medium text-blue-800 dark:text-blue-300">
+									{{ selectedStudent.studentId }}
+								</span>
+								<span v-if="selectedStudent.githubUsername" class="text-xs text-blue-600 dark:text-blue-400">
+									({{ selectedStudent.githubUsername }})
+								</span>
+								<button
+									type="button"
+									class="ml-1 text-blue-500 hover:text-blue-700 dark:text-blue-400 dark:hover:text-blue-200"
+									@click="clearSelection"
+								>
+									<XCircle class="h-4 w-4" />
+								</button>
+							</div>
+							<button
+								type="button"
+								:disabled="isSending"
+								class="inline-flex items-center gap-2 rounded-lg bg-blue-600 px-4 py-2 text-sm font-medium text-white transition hover:bg-blue-700 disabled:cursor-not-allowed disabled:opacity-50 dark:bg-blue-600 dark:hover:bg-blue-500"
+								@click="handleSendInvitation"
+							>
+								<Send class="h-4 w-4" />
+								{{ isSending ? "Sending…" : "Send Invitation" }}
+							</button>
+						</div>
+
+						<!-- Feedback -->
+						<p v-if="sendError" class="text-sm text-red-600 dark:text-red-400">{{ sendError }}</p>
+						<p v-if="sendSuccess" class="text-sm text-green-600 dark:text-green-400">
+							Invitation sent successfully.
+						</p>
+					</div>
+				</section>
+
+				<!-- Sent Invitations list -->
+				<section
+					class="rounded-2xl border border-slate-200 bg-white/90 shadow-sm backdrop-blur transition-colors dark:border-slate-700 dark:bg-slate-800/90 dark:shadow-lg"
+				>
+					<div class="border-b border-slate-100 p-6 dark:border-slate-700">
+						<div class="flex items-center gap-3">
+							<Send class="h-5 w-5 text-slate-500 dark:text-slate-400" />
+							<h2 class="text-lg font-semibold text-slate-900 dark:text-white">Sent Invitations</h2>
+						</div>
+					</div>
+
+					<!-- Loading -->
+					<div
+						v-if="isSentLoading"
+						class="p-8 text-center"
+					>
+						<div class="inline-flex h-6 w-6 animate-spin rounded-full border-4 border-slate-300 border-t-blue-600 dark:border-slate-600 dark:border-t-blue-400"></div>
+						<p class="mt-3 text-sm text-slate-500 dark:text-slate-400">Loading…</p>
+					</div>
+
+					<!-- Empty -->
+					<div
+						v-else-if="sentInvitations.length === 0"
+						class="p-8 text-center"
+					>
+						<p class="text-sm text-slate-500 dark:text-slate-400">No invitations sent yet.</p>
+					</div>
+
+					<!-- List -->
+					<ul v-else class="divide-y divide-slate-100 dark:divide-slate-700">
+						<li
+							v-for="inv in sentInvitations"
+							:key="inv.invitationId"
+							class="flex items-center justify-between gap-4 px-6 py-4"
+						>
+							<div class="min-w-0 space-y-0.5">
+								<p class="font-mono text-sm font-medium text-slate-900 dark:text-white">
+									{{ inv.targetStudentId }}
+								</p>
+								<p class="text-xs text-slate-500 dark:text-slate-400">
+									Sent {{ formatDate(inv.sentAt) }}
+									<template v-if="inv.respondedAt">
+										· Responded {{ formatDate(inv.respondedAt) }}
+									</template>
+								</p>
+							</div>
+							<div class="flex shrink-0 items-center gap-3">
+								<span
+									class="inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium"
+									:class="statusClass(inv.status)"
+								>
+									{{ inv.status }}
+								</span>
+								<button
+									v-if="inv.status === 'PENDING'"
+									type="button"
+									:disabled="cancellingId === inv.invitationId"
+									class="inline-flex items-center gap-1 rounded-md border border-slate-200 bg-white px-2.5 py-1.5 text-xs font-medium text-slate-600 transition hover:border-red-300 hover:bg-red-50 hover:text-red-600 disabled:cursor-not-allowed disabled:opacity-50 dark:border-slate-600 dark:bg-slate-700 dark:text-slate-300 dark:hover:border-red-600 dark:hover:bg-red-900/20 dark:hover:text-red-400"
+									@click="handleCancelInvitation(inv.invitationId)"
+								>
+									<XCircle class="h-3 w-3" />
+									{{ cancellingId === inv.invitationId ? "Cancelling…" : "Cancel" }}
+								</button>
+							</div>
+						</li>
+					</ul>
+				</section>
+
+			</template>
+
+			<!-- ── INBOX (all students) ───────────────────────────────────────── -->
+			<section>
+				<div class="mb-3 flex items-center gap-3 px-1">
+					<MailOpen class="h-5 w-5 text-slate-500 dark:text-slate-400" />
+					<h2 class="text-base font-semibold text-slate-700 dark:text-slate-300">Received Invitations</h2>
+				</div>
+
+				<!-- Loading -->
+				<div
+					v-if="isLoading"
+					class="rounded-2xl border border-slate-200 bg-white p-8 text-center dark:border-slate-700 dark:bg-slate-800"
+				>
+					<div class="inline-flex h-8 w-8 animate-spin rounded-full border-4 border-slate-300 border-t-blue-600 dark:border-slate-600 dark:border-t-blue-400"></div>
+					<p class="mt-4 text-slate-600 dark:text-slate-400">Loading invitations…</p>
+				</div>
+
+				<!-- Error -->
+				<div
+					v-else-if="error"
+					class="rounded-2xl border border-red-200 bg-red-50 p-6 dark:border-red-900/50 dark:bg-red-900/20"
+				>
+					<h3 class="font-semibold text-red-900 dark:text-red-200">Error</h3>
+					<p class="mt-2 text-sm text-red-700 dark:text-red-300">{{ error }}</p>
+					<button
+						class="mt-4 rounded-md bg-red-600 px-4 py-2 text-sm font-medium text-white transition hover:bg-red-700 dark:bg-red-700 dark:hover:bg-red-600"
+						@click="refreshInvitations"
+					>
+						Try Again
+					</button>
+				</div>
+
+				<!-- Empty -->
+				<div
+					v-else-if="pendingCount === 0"
+					class="rounded-2xl border-2 border-dashed border-slate-300 bg-slate-50 p-12 text-center dark:border-slate-600 dark:bg-slate-800"
+				>
+					<MailX class="mx-auto h-12 w-12 text-slate-400 dark:text-slate-500" />
+					<h3 class="mt-4 font-semibold text-slate-900 dark:text-white">No pending invitations</h3>
+					<p class="mt-2 text-sm text-slate-600 dark:text-slate-400">
+						You're all caught up! Check back later for new group invitations.
+					</p>
+				</div>
+
+				<!-- Invitation cards -->
+				<div v-else class="space-y-4">
+					<InvitationCard
+						v-for="invitation in pendingInvitations"
+						:key="invitation.invitationId"
+						:invitation="invitation"
+						@accept="handleAccept"
+						@decline="handleDecline"
+					/>
+				</div>
+			</section>
+
 			<p class="text-center text-sm text-slate-500 dark:text-slate-400">
 				Last updated: {{ lastUpdateTime || "Just now" }}
 			</p>
@@ -94,10 +267,12 @@
 
 <script setup lang="ts">
 	import { computed, onMounted, ref } from "vue";
-	import { ArrowLeft, MailOpen, MailX } from "lucide-vue-next";
+	import { AlertCircle, ArrowLeft, MailOpen, MailX, Search, Send, UserRoundPlus, XCircle } from "lucide-vue-next";
 	import { usePendingInvitations } from "~/composables/usePendingInvitations";
+	import type { StudentSearchResult, SentGroupInvitation } from "~/composables/useApiClient";
+	import type { GroupDetailResponse } from "~/types/group";
+	import { useAuthStore } from "~/stores/auth";
 
-	// Define page metadata for authentication middleware
 	definePageMeta({
 		middleware: "auth",
 		roles: ["Student"]
@@ -114,43 +289,177 @@
 		declineInvitation
 	} = usePendingInvitations();
 
+	const {
+		getAuthToken,
+		fetchMyGroup,
+		searchStudents,
+		sendGroupInvitation,
+		fetchGroupInvitations,
+		cancelGroupInvitation
+	} = useApiClient();
+
+	const authStore = useAuthStore();
+
+	// ─── Group + leader state ────────────────────────────────────────────
+	const myGroup = ref<GroupDetailResponse | null>(null);
+
+	const isLeader = computed(() => {
+		if (!myGroup.value || !authStore.userInfo) return false;
+		const userInfo = authStore.userInfo;
+		const me = myGroup.value.members.find(
+			(m) => m.studentId === (userInfo.userType === "Student" ? userInfo.studentId : undefined)
+		);
+		return me?.role === "TEAM_LEADER";
+	});
+
+	const canSendInvitations = computed(() => {
+		if (!myGroup.value) return false;
+		const { status } = myGroup.value;
+		return status === "FORMING" || status === "TOOLS_PENDING";
+	});
+
+	const sendBlockedReason = computed(() => {
+		if (!myGroup.value) return "";
+		switch (myGroup.value.status) {
+			case "DISBANDED": return "This group has been disbanded.";
+			case "TOOLS_BOUND":
+			case "ADVISOR_ASSIGNED": return "Roster is locked after tool binding.";
+			default: return "";
+		}
+	});
+
+	// ─── Search state ────────────────────────────────────────────────────
+	const searchQuery = ref("");
+	const searchResults = ref<StudentSearchResult[]>([]);
+	const isSearching = ref(false);
+	const selectedStudent = ref<StudentSearchResult | null>(null);
+	const sendError = ref("");
+	const sendSuccess = ref(false);
+	const isSending = ref(false);
+	let searchTimeout: ReturnType<typeof setTimeout> | null = null;
+
+	const onSearchInput = () => {
+		sendError.value = "";
+		sendSuccess.value = false;
+		selectedStudent.value = null;
+		searchResults.value = [];
+		if (searchTimeout) clearTimeout(searchTimeout);
+		if (searchQuery.value.trim().length < 3) return;
+		searchTimeout = setTimeout(async () => {
+			isSearching.value = true;
+			try {
+				const token = getAuthToken();
+				searchResults.value = await searchStudents(searchQuery.value.trim(), token ?? undefined);
+			} catch {
+				searchResults.value = [];
+			} finally {
+				isSearching.value = false;
+			}
+		}, 300);
+	};
+
+	const selectStudent = (student: StudentSearchResult) => {
+		selectedStudent.value = student;
+		searchQuery.value = student.studentId;
+		searchResults.value = [];
+	};
+
+	const clearSelection = () => {
+		selectedStudent.value = null;
+		searchQuery.value = "";
+		searchResults.value = [];
+	};
+
+	// ─── Send invitation ─────────────────────────────────────────────────
+	const sentInvitations = ref<SentGroupInvitation[]>([]);
+	const isSentLoading = ref(false);
+
+	const handleSendInvitation = async () => {
+		if (!selectedStudent.value || !myGroup.value) return;
+		isSending.value = true;
+		sendError.value = "";
+		sendSuccess.value = false;
+		try {
+			const token = getAuthToken();
+			await sendGroupInvitation(myGroup.value.id, selectedStudent.value.studentId, token ?? undefined);
+			sendSuccess.value = true;
+			clearSelection();
+			await loadSentInvitations();
+		} catch (err: unknown) {
+			const apiErr = err as { message?: string };
+			sendError.value = apiErr?.message ?? "Failed to send invitation.";
+		} finally {
+			isSending.value = false;
+		}
+	};
+
+	// ─── Sent invitations list ───────────────────────────────────────────
+	const loadSentInvitations = async () => {
+		if (!myGroup.value) return;
+		isSentLoading.value = true;
+		try {
+			const token = getAuthToken();
+			sentInvitations.value = await fetchGroupInvitations(myGroup.value.id, token ?? undefined);
+		} catch {
+			sentInvitations.value = [];
+		} finally {
+			isSentLoading.value = false;
+		}
+	};
+
+	const cancellingId = ref<string | null>(null);
+
+	const handleCancelInvitation = async (invitationId: string) => {
+		cancellingId.value = invitationId;
+		try {
+			const token = getAuthToken();
+			await cancelGroupInvitation(invitationId, token ?? undefined);
+			await loadSentInvitations();
+		} catch {
+			// list unchanged — user can retry
+		} finally {
+			cancellingId.value = null;
+		}
+	};
+
+	// ─── Status badge helpers ─────────────────────────────────────────────
+	const statusClass = (status: string) => {
+		switch (status) {
+			case "PENDING":
+				return "bg-yellow-100 text-yellow-800 dark:bg-yellow-900/30 dark:text-yellow-300";
+			case "ACCEPTED":
+				return "bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-300";
+			default:
+				return "bg-slate-100 text-slate-600 dark:bg-slate-700 dark:text-slate-400";
+		}
+	};
+
+	const formatDate = (iso: string) =>
+		new Date(iso).toLocaleDateString(undefined, {
+			month: "short",
+			day: "numeric",
+			hour: "2-digit",
+			minute: "2-digit"
+		});
+
+	// ─── Inbox ────────────────────────────────────────────────────────────
 	const lastUpdateTime = ref<string>("");
 
-	/**
-	 * Refresh invitations from server
-	 */
 	const refreshInvitations = async () => {
 		await fetchInvitations();
 		updateLastUpdateTime();
 	};
 
-	/**
-	 * Update last update time display
-	 */
 	const updateLastUpdateTime = () => {
 		if (lastFetchTime.value) {
-			const now = new Date();
-			const diffSeconds = Math.floor((now.getTime() - lastFetchTime.value.getTime()) / 1000);
-
-			if (diffSeconds < 60) {
-				lastUpdateTime.value = "Just now";
-			} else if (diffSeconds < 3600) {
-				const minutes = Math.floor(diffSeconds / 60);
-				lastUpdateTime.value = `${minutes}m ago`;
-			} else if (diffSeconds < 86400) {
-				const hours = Math.floor(diffSeconds / 3600);
-				lastUpdateTime.value = `${hours}h ago`;
-			} else {
-				lastUpdateTime.value = lastFetchTime.value.toLocaleDateString();
-			}
+			const diffSeconds = Math.floor((new Date().getTime() - lastFetchTime.value.getTime()) / 1000);
+			if (diffSeconds < 60) lastUpdateTime.value = "Just now";
+			else if (diffSeconds < 3600) lastUpdateTime.value = `${Math.floor(diffSeconds / 60)}m ago`;
+			else if (diffSeconds < 86400) lastUpdateTime.value = `${Math.floor(diffSeconds / 3600)}h ago`;
+			else lastUpdateTime.value = lastFetchTime.value.toLocaleDateString();
 		}
 	};
 
-	/**
-	 * Executes the API call to accept an invitation and updates the timestamp.
-	 * Acceptance criteria: Navigation badge updates automatically without page reload
-	 * via the shared composable state.
-	 */
 	const handleAccept = async (invitationId: string) => {
 		try {
 			await acceptInvitation(invitationId);
@@ -160,11 +469,6 @@
 		}
 	};
 
-	/**
-	 * Executes the API call to decline an invitation and updates the timestamp.
-	 * Acceptance criteria: Navigation badge updates automatically without page reload
-	 * via the shared composable state.
-	 */
 	const handleDecline = async (invitationId: string) => {
 		try {
 			await declineInvitation(invitationId);
@@ -174,7 +478,17 @@
 		}
 	};
 
+	// ─── Mount ────────────────────────────────────────────────────────────
 	onMounted(async () => {
 		await refreshInvitations();
+		try {
+			const token = getAuthToken();
+			myGroup.value = await fetchMyGroup(token ?? undefined);
+			if (isLeader.value) {
+				await loadSentInvitations();
+			}
+		} catch {
+			// no group or not in group — leader section hidden
+		}
 	});
 </script>


### PR DESCRIPTION
Implements the missing send-invitation UI for group leaders.

- Backend: StudentSearchResponse DTO, searchAvailableStudents() service method,
  findUngroupedByStudentIdContaining() JPQL query, wired GET /api/students/search
- Frontend: debounced search input with dropdown, send button, sent invitations
  list with cancel; leader-only section guarded by isLeader + roster lock check
    


  fixes #161 