### PR TITLE
feat: Implement issue #103 and #114 committee backend flow

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -1,114 +1,149 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+
     <modelVersion>4.0.0</modelVersion>
+
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
         <version>3.5.13</version>
-        <relativePath/> <!-- lookup parent from repository -->
+        <relativePath/>
     </parent>
+
     <groupId>com.senior</groupId>
     <artifactId>spm</artifactId>
     <version>0.0.1-SNAPSHOT</version>
-    <name/>
-    <description/>
-    <url/>
-    <licenses>
-        <license/>
-    </licenses>
-    <developers>
-        <developer/>
-    </developers>
-    <scm>
-        <connection/>
-        <developerConnection/>
-        <tag/>
-        <url/>
-    </scm>
+    <name>spm</name>
+    <description>Senior Project Management Backend</description>
+
     <properties>
         <java.version>21</java.version>
+        <lombok.version>1.18.36</lombok.version>
+        <jjwt.version>0.12.6</jjwt.version>
+        <springdoc.version>2.8.6</springdoc.version>
+        <wiremock.version>3.9.2</wiremock.version>
     </properties>
+
     <dependencies>
+        <!-- Spring Boot -->
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-data-jpa</artifactId>
         </dependency>
+
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-security</artifactId>
         </dependency>
+
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-validation</artifactId>
         </dependency>
+
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web</artifactId>
         </dependency>
+
+        <!-- JWT -->
         <dependency>
             <groupId>io.jsonwebtoken</groupId>
             <artifactId>jjwt-api</artifactId>
-            <version>0.12.6</version>
+            <version>${jjwt.version}</version>
         </dependency>
+
         <dependency>
             <groupId>io.jsonwebtoken</groupId>
             <artifactId>jjwt-impl</artifactId>
-            <version>0.12.6</version>
+            <version>${jjwt.version}</version>
             <scope>runtime</scope>
         </dependency>
+
         <dependency>
             <groupId>io.jsonwebtoken</groupId>
             <artifactId>jjwt-jackson</artifactId>
-            <version>0.12.6</version>
+            <version>${jjwt.version}</version>
             <scope>runtime</scope>
         </dependency>
+
+        <!-- Lombok -->
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
+            <version>${lombok.version}</version>
+            <scope>provided</scope>
         </dependency>
 
+        <!-- Devtools -->
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-devtools</artifactId>
             <scope>runtime</scope>
             <optional>true</optional>
         </dependency>
+
+        <!-- Database -->
         <dependency>
             <groupId>com.mysql</groupId>
             <artifactId>mysql-connector-j</artifactId>
             <scope>runtime</scope>
         </dependency>
+
+        <!-- Swagger / OpenAPI -->
+        <dependency>
+            <groupId>org.springdoc</groupId>
+            <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+            <version>${springdoc.version}</version>
+        </dependency>
+
+        <!-- Test -->
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>
         </dependency>
+
         <dependency>
             <groupId>com.h2database</groupId>
             <artifactId>h2</artifactId>
             <scope>test</scope>
         </dependency>
+
         <dependency>
             <groupId>org.springframework.security</groupId>
             <artifactId>spring-security-test</artifactId>
             <scope>test</scope>
         </dependency>
+
         <dependency>
             <groupId>org.wiremock</groupId>
             <artifactId>wiremock-standalone</artifactId>
-            <version>3.9.2</version>
+            <version>${wiremock.version}</version>
             <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.springdoc</groupId>
-            <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
-            <version>2.8.6</version>
         </dependency>
     </dependencies>
 
     <build>
         <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <release>${java.version}</release>
+                    <parameters>true</parameters>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>org.projectlombok</groupId>
+                            <artifactId>lombok</artifactId>
+                            <version>${lombok.version}</version>
+                        </path>
+                    </annotationProcessorPaths>
+                </configuration>
+            </plugin>
+
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>

--- a/backend/src/main/java/com/senior/spm/config/SecurityConfig.java
+++ b/backend/src/main/java/com/senior/spm/config/SecurityConfig.java
@@ -1,11 +1,13 @@
 package com.senior.spm.config;
 
+import java.util.Collection;
+
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
-import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -35,48 +37,65 @@ public class SecurityConfig {
     }
 
     @Bean
-    public SecurityFilterChain filterChain(HttpSecurity http, CorsConfigurationSource corsConfigurationSource) throws Exception {
+    public SecurityFilterChain filterChain(
+            HttpSecurity http,
+            CorsConfigurationSource corsConfigurationSource
+    ) throws Exception {
         return http
                 .cors(cors -> cors.configurationSource(corsConfigurationSource))
                 .csrf(csrf -> csrf.disable())
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
-                .authorizeHttpRequests(
-                        auth -> auth
-                                .requestMatchers("/api/auth/**").permitAll()
-                                .requestMatchers("/v3/api-docs/**", "/swagger-ui/**", "/swagger-ui.html").permitAll()
-                                .requestMatchers("/api/admin/**").hasRole("ADMIN")
-                                .requestMatchers("/api/coordinator/**").hasRole("COORDINATOR")
-                                .requestMatchers("/api/professor/**").hasRole("PROFESSOR")
-                                // P3: Professor-only endpoints live under /api/advisor/**
-                                .requestMatchers("/api/advisor/**").hasRole("PROFESSOR")
-                                // P3: Student-facing advisor request endpoints.
-                                .requestMatchers("/api/advisors").hasRole("STUDENT")
-                                .requestMatchers("/api/groups/*/advisor-request").hasRole("STUDENT")
-                                .anyRequest().authenticated())
-                .exceptionHandling(
-                        ex -> ex.accessDeniedHandler(
-                                (request, response, exception) -> {
-                                    response.setStatus(403);
-                                    response.setContentType("application/json");
-                                    var authority = (SimpleGrantedAuthority) SecurityContextHolder
-                                            .getContext()
-                                            .getAuthentication()
-                                            .getAuthorities()
-                                            .iterator().next();
-                                    var message = "Role: " + authority.getAuthority() + " does not have permission to access this resource.";
-                                    response.getWriter().write(
-                                            objectMapper.writeValueAsString(
-                                                    new ErrorMessage(message + "Exception: " + exception.getMessage())
-                                            ));
-                                }).authenticationEntryPoint((request, response, exception) -> {
-                                    response.setStatus(401);
-                                    response.setContentType("application/json");
-                                    response.getWriter().write(
-                                            objectMapper.writeValueAsString(
-                                                    new ErrorMessage("Unauthorized: " + exception.getMessage())
-                                            ));
-                                }))
+                .authorizeHttpRequests(auth -> auth
+                        .requestMatchers("/api/auth/**").permitAll()
+                        .requestMatchers("/v3/api-docs/**", "/swagger-ui/**", "/swagger-ui.html").permitAll()
+
+                        .requestMatchers("/api/admin/**")
+                        .hasAnyAuthority("ROLE_Admin", "ROLE_ADMIN")
+
+                        .requestMatchers("/api/coordinator/**", "/api/committees/**")
+                        .hasAnyAuthority("ROLE_Coordinator", "ROLE_COORDINATOR")
+
+                        .requestMatchers("/api/professor/**", "/api/professors/**", "/api/advisor/**")
+                        .hasAnyAuthority("ROLE_Professor", "ROLE_PROFESSOR")
+
+                        .requestMatchers("/api/advisors", "/api/groups/*/advisor-request")
+                        .hasAnyAuthority("ROLE_Student", "ROLE_STUDENT")
+
+                        .anyRequest().authenticated()
+                )
+                .exceptionHandling(ex -> ex
+                        .accessDeniedHandler((request, response, exception) -> {
+                            response.setStatus(403);
+                            response.setContentType("application/json");
+
+                            String authorityText = "UNKNOWN";
+                            if (SecurityContextHolder.getContext().getAuthentication() != null) {
+                                Collection<? extends GrantedAuthority> authorities =
+                                        SecurityContextHolder.getContext().getAuthentication().getAuthorities();
+                                if (authorities != null && !authorities.isEmpty()) {
+                                    authorityText = authorities.iterator().next().getAuthority();
+                                }
+                            }
+
+                            String message = "Role: " + authorityText
+                                    + " does not have permission to access this resource. "
+                                    + "Exception: " + exception.getMessage();
+
+                            response.getWriter().write(
+                                    objectMapper.writeValueAsString(new ErrorMessage(message))
+                            );
+                        })
+                        .authenticationEntryPoint((request, response, exception) -> {
+                            response.setStatus(401);
+                            response.setContentType("application/json");
+                            response.getWriter().write(
+                                    objectMapper.writeValueAsString(
+                                            new ErrorMessage("Unauthorized: " + exception.getMessage())
+                                    )
+                            );
+                        })
+                )
                 .build();
     }
 }

--- a/backend/src/main/java/com/senior/spm/controller/CommitteeController.java
+++ b/backend/src/main/java/com/senior/spm/controller/CommitteeController.java
@@ -1,0 +1,123 @@
+package com.senior.spm.controller;
+
+import java.util.List;
+import java.util.UUID;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.senior.spm.controller.request.AssignCommitteeGroupsRequest;
+import com.senior.spm.controller.request.AssignCommitteeProfessorsRequest;
+import com.senior.spm.controller.request.CreateCommitteeRequest;
+import com.senior.spm.controller.response.CommitteeDetailResponse;
+import com.senior.spm.controller.response.CommitteeSummaryResponse;
+import com.senior.spm.controller.response.ErrorMessage;
+import com.senior.spm.controller.response.ProfessorCommitteeSummaryResponse;
+import com.senior.spm.exception.AlreadyExistsException;
+import com.senior.spm.exception.BusinessRuleException;
+import com.senior.spm.exception.NotFoundException;
+import com.senior.spm.service.CommitteeService;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+public class CommitteeController {
+
+    private final CommitteeService committeeService;
+
+    @PostMapping("/api/committees")
+    public ResponseEntity<?> createCommittee(@Valid @RequestBody CreateCommitteeRequest request) {
+        try {
+            CommitteeSummaryResponse response = committeeService.createCommittee(
+                    request.getCommitteeName(),
+                    request.getTermId()
+            );
+            return ResponseEntity.status(HttpStatus.CREATED).body(response);
+        } catch (AlreadyExistsException e) {
+            return ResponseEntity.status(HttpStatus.CONFLICT).body(new ErrorMessage(e.getMessage()));
+        }
+    }
+
+    @GetMapping("/api/committees")
+    public ResponseEntity<List<CommitteeSummaryResponse>> listCommittees(
+            @RequestParam(required = false) String termId
+    ) {
+        return ResponseEntity.ok(committeeService.listCommittees(termId));
+    }
+
+    @GetMapping("/api/committees/{id}")
+    public ResponseEntity<?> getCommitteeDetail(@PathVariable UUID id) {
+        try {
+            CommitteeDetailResponse response = committeeService.getCommitteeDetail(id);
+            return ResponseEntity.ok(response);
+        } catch (NotFoundException e) {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).body(new ErrorMessage(e.getMessage()));
+        }
+    }
+
+    @PostMapping("/api/committees/{id}/professors")
+    public ResponseEntity<?> assignProfessors(
+            @PathVariable UUID id,
+            @Valid @RequestBody AssignCommitteeProfessorsRequest request
+    ) {
+        try {
+            CommitteeDetailResponse response = committeeService.assignProfessors(id, request.getProfessors());
+            return ResponseEntity.ok(response);
+        } catch (NotFoundException e) {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).body(new ErrorMessage(e.getMessage()));
+        } catch (BusinessRuleException e) {
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(new ErrorMessage(e.getMessage()));
+        }
+    }
+
+    @PostMapping("/api/committees/{id}/groups")
+    public ResponseEntity<?> assignGroups(
+            @PathVariable UUID id,
+            @Valid @RequestBody AssignCommitteeGroupsRequest request
+    ) {
+        try {
+            CommitteeDetailResponse response = committeeService.assignGroups(id, request.getGroupIds());
+            return ResponseEntity.ok(response);
+        } catch (NotFoundException e) {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).body(new ErrorMessage(e.getMessage()));
+        } catch (BusinessRuleException e) {
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(new ErrorMessage(e.getMessage()));
+        }
+    }
+
+    @GetMapping("/api/professors/me/committees")
+    public ResponseEntity<List<ProfessorCommitteeSummaryResponse>> getMyCommittees() {
+        UUID professorId = extractStaffUUIDFromJWT();
+        return ResponseEntity.ok(committeeService.getCommitteesForProfessor(professorId));
+    }
+
+    private UUID extractStaffUUIDFromJWT() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+
+        if (authentication == null || authentication.getPrincipal() == null) {
+            throw new IllegalStateException("Authenticated professor information could not be found.");
+        }
+
+        Object principal = authentication.getPrincipal();
+
+        if (!(principal instanceof String principalText)) {
+            throw new IllegalStateException("JWT principal is not in the expected format.");
+        }
+
+        try {
+            return UUID.fromString(principalText);
+        } catch (IllegalArgumentException e) {
+            throw new IllegalStateException("JWT principal is not a valid UUID.");
+        }
+    }
+}

--- a/backend/src/main/java/com/senior/spm/controller/request/AssignCommitteeGroupsRequest.java
+++ b/backend/src/main/java/com/senior/spm/controller/request/AssignCommitteeGroupsRequest.java
@@ -1,0 +1,18 @@
+package com.senior.spm.controller.request;
+
+import java.util.List;
+import java.util.UUID;
+
+import jakarta.validation.constraints.NotEmpty;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class AssignCommitteeGroupsRequest {
+
+    @NotEmpty(message = "Group ids list cannot be empty")
+    private List<UUID> groupIds;
+}

--- a/backend/src/main/java/com/senior/spm/controller/request/AssignCommitteeProfessorsRequest.java
+++ b/backend/src/main/java/com/senior/spm/controller/request/AssignCommitteeProfessorsRequest.java
@@ -1,0 +1,19 @@
+package com.senior.spm.controller.request;
+
+import java.util.List;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotEmpty;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class AssignCommitteeProfessorsRequest {
+
+    @NotEmpty(message = "Professors list cannot be empty")
+    @Valid
+    private List<ProfessorAssignmentRequest> professors;
+}

--- a/backend/src/main/java/com/senior/spm/controller/request/CreateCommitteeRequest.java
+++ b/backend/src/main/java/com/senior/spm/controller/request/CreateCommitteeRequest.java
@@ -1,0 +1,18 @@
+package com.senior.spm.controller.request;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class CreateCommitteeRequest {
+
+    @NotBlank(message = "Committee name is required")
+    private String committeeName;
+
+    @NotBlank(message = "Term id is required")
+    private String termId;
+}

--- a/backend/src/main/java/com/senior/spm/controller/request/ProfessorAssignmentRequest.java
+++ b/backend/src/main/java/com/senior/spm/controller/request/ProfessorAssignmentRequest.java
@@ -1,0 +1,25 @@
+package com.senior.spm.controller.request;
+
+import java.util.UUID;
+
+import com.senior.spm.entity.CommitteeProfessor.CommitteeRole;
+
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class ProfessorAssignmentRequest {
+
+    @NotNull(message = "Professor id is required")
+    private UUID professorId;
+
+    @NotNull(message = "Role is required")
+    @Enumerated(EnumType.STRING)
+    private CommitteeRole role;
+}

--- a/backend/src/main/java/com/senior/spm/controller/response/CommitteeDetailResponse.java
+++ b/backend/src/main/java/com/senior/spm/controller/response/CommitteeDetailResponse.java
@@ -1,0 +1,19 @@
+package com.senior.spm.controller.response;
+
+import java.util.List;
+import java.util.UUID;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class CommitteeDetailResponse {
+    private UUID id;
+    private String committeeName;
+    private String termId;
+    private List<ProfessorAssignmentResponse> professors;
+    private List<UUID> groupIds;
+}

--- a/backend/src/main/java/com/senior/spm/controller/response/CommitteeGroupSummaryResponse.java
+++ b/backend/src/main/java/com/senior/spm/controller/response/CommitteeGroupSummaryResponse.java
@@ -1,5 +1,7 @@
 package com.senior.spm.controller.response;
 
+import java.util.UUID;
+
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -7,6 +9,8 @@ import lombok.NoArgsConstructor;
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
-public class ErrorMessage {
-    private String message;
+public class CommitteeGroupSummaryResponse {
+    private UUID groupId;
+    private String groupName;
+    private String status;
 }

--- a/backend/src/main/java/com/senior/spm/controller/response/CommitteeSummaryResponse.java
+++ b/backend/src/main/java/com/senior/spm/controller/response/CommitteeSummaryResponse.java
@@ -1,5 +1,7 @@
 package com.senior.spm.controller.response;
 
+import java.util.UUID;
+
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -7,6 +9,8 @@ import lombok.NoArgsConstructor;
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
-public class ErrorMessage {
-    private String message;
+public class CommitteeSummaryResponse {
+    private UUID id;
+    private String committeeName;
+    private String termId;
 }

--- a/backend/src/main/java/com/senior/spm/controller/response/ProfessorAssignmentResponse.java
+++ b/backend/src/main/java/com/senior/spm/controller/response/ProfessorAssignmentResponse.java
@@ -1,0 +1,18 @@
+package com.senior.spm.controller.response;
+
+import java.util.UUID;
+
+import com.senior.spm.entity.CommitteeProfessor.CommitteeRole;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class ProfessorAssignmentResponse {
+    private UUID professorId;
+    private String mail;
+    private CommitteeRole role;
+}

--- a/backend/src/main/java/com/senior/spm/controller/response/ProfessorCommitteeSummaryResponse.java
+++ b/backend/src/main/java/com/senior/spm/controller/response/ProfessorCommitteeSummaryResponse.java
@@ -1,0 +1,20 @@
+package com.senior.spm.controller.response;
+
+import java.util.List;
+import java.util.UUID;
+
+import com.senior.spm.entity.CommitteeProfessor.CommitteeRole;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class ProfessorCommitteeSummaryResponse {
+    private UUID committeeId;
+    private String committeeName;
+    private CommitteeRole role;
+    private List<CommitteeGroupSummaryResponse> groups;
+}

--- a/backend/src/main/java/com/senior/spm/entity/Committee.java
+++ b/backend/src/main/java/com/senior/spm/entity/Committee.java
@@ -1,0 +1,45 @@
+package com.senior.spm.entity;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Table(
+        name = "committee",
+        uniqueConstraints = @UniqueConstraint(name = "uk_committee_term_name", columnNames = {"term_id", "committee_name"})
+)
+@Getter
+@Setter
+@NoArgsConstructor
+public class Committee {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID id;
+
+    @Column(name = "committee_name", nullable = false)
+    private String committeeName;
+
+    @Column(name = "term_id", nullable = false)
+    private String termId;
+
+    @OneToMany(mappedBy = "committee", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<CommitteeProfessor> professors = new ArrayList<>();
+
+    @OneToMany(mappedBy = "committee")
+    private List<ProjectGroup> groups = new ArrayList<>();
+}

--- a/backend/src/main/java/com/senior/spm/entity/CommitteeProfessor.java
+++ b/backend/src/main/java/com/senior/spm/entity/CommitteeProfessor.java
@@ -1,0 +1,51 @@
+package com.senior.spm.entity;
+
+import java.util.UUID;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.ForeignKey;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Table(
+        name = "committee_professor",
+        uniqueConstraints = @UniqueConstraint(name = "uk_committee_professor", columnNames = {"committee_id", "professor_id"})
+)
+@Getter
+@Setter
+@NoArgsConstructor
+public class CommitteeProfessor {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID id;
+
+    @ManyToOne(optional = false)
+    @JoinColumn(name = "committee_id", nullable = false, foreignKey = @ForeignKey(name = "fk_committee_professor_committee"))
+    private Committee committee;
+
+    @ManyToOne(optional = false)
+    @JoinColumn(name = "professor_id", nullable = false, foreignKey = @ForeignKey(name = "fk_committee_professor_staff"))
+    private StaffUser professor;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private CommitteeRole role;
+
+    public enum CommitteeRole {
+        ADVISOR,
+        JURY
+    }
+}

--- a/backend/src/main/java/com/senior/spm/entity/ProjectGroup.java
+++ b/backend/src/main/java/com/senior/spm/entity/ProjectGroup.java
@@ -67,6 +67,10 @@ public class ProjectGroup {
     @JoinColumn(name = "advisor_id", nullable = true, foreignKey = @ForeignKey(name = "fk_project_group_advisor"))
     private StaffUser advisor;
 
+    @ManyToOne
+    @JoinColumn(name = "committee_id", nullable = true, foreignKey = @ForeignKey(name = "fk_project_group_committee"))
+    private Committee committee;
+
     @OneToMany(mappedBy = "group")
     private List<GroupMembership> members;
 

--- a/backend/src/main/java/com/senior/spm/repository/CommitteeProfessorRepository.java
+++ b/backend/src/main/java/com/senior/spm/repository/CommitteeProfessorRepository.java
@@ -1,0 +1,23 @@
+package com.senior.spm.repository;
+
+import java.util.List;
+import java.util.UUID;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import com.senior.spm.entity.CommitteeProfessor;
+
+@Repository
+public interface CommitteeProfessorRepository extends JpaRepository<CommitteeProfessor, UUID> {
+
+    List<CommitteeProfessor> findByCommitteeId(UUID committeeId);
+
+    List<CommitteeProfessor> findByProfessor_Id(UUID professorId);
+
+    boolean existsByProfessor_IdAndCommittee_TermIdAndCommittee_IdNot(UUID professorId, String termId, UUID committeeId);
+
+    boolean existsByProfessor_IdAndCommittee_TermId(UUID professorId, String termId);
+
+    void deleteByCommitteeId(UUID committeeId);
+}

--- a/backend/src/main/java/com/senior/spm/repository/CommitteeRepository.java
+++ b/backend/src/main/java/com/senior/spm/repository/CommitteeRepository.java
@@ -1,0 +1,25 @@
+package com.senior.spm.repository;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import org.springframework.data.jpa.repository.EntityGraph;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import com.senior.spm.entity.Committee;
+
+@Repository
+public interface CommitteeRepository extends JpaRepository<Committee, UUID> {
+
+    boolean existsByCommitteeNameAndTermId(String committeeName, String termId);
+
+    List<Committee> findByTermId(String termId);
+
+    @EntityGraph(attributePaths = {"professors", "professors.professor", "groups"})
+    @Query("select c from Committee c where c.id = :id")
+    Optional<Committee> findDetailedById(@Param("id") UUID id);
+}

--- a/backend/src/main/java/com/senior/spm/service/CommitteeAssignmentNotificationPayload.java
+++ b/backend/src/main/java/com/senior/spm/service/CommitteeAssignmentNotificationPayload.java
@@ -1,0 +1,28 @@
+package com.senior.spm.service;
+
+import java.util.List;
+import java.util.UUID;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class CommitteeAssignmentNotificationPayload {
+    private UUID committeeId;
+    private List<UUID> professorIds;
+    private List<AssignedGroupPayload> assignedGroups;
+
+    @Data
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class AssignedGroupPayload {
+        private UUID groupId;
+        private String groupName;
+    }
+}

--- a/backend/src/main/java/com/senior/spm/service/CommitteeNotificationService.java
+++ b/backend/src/main/java/com/senior/spm/service/CommitteeNotificationService.java
@@ -1,0 +1,21 @@
+package com.senior.spm.service;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+
+@Service
+public class CommitteeNotificationService {
+
+    private static final Logger log = LoggerFactory.getLogger(CommitteeNotificationService.class);
+
+    public void sendAssignmentNotification(CommitteeAssignmentNotificationPayload payload) {
+        // Bu aşamada gerçek mail / queue / websocket altyapısı olmadığı için
+        // notification payload'ını logluyoruz.
+        // İleride bu method gerçek NotificationService entegrasyonuna çevrilebilir.
+        log.info("Committee assignment notification triggered: committeeId={}, professorIds={}, assignedGroups={}",
+                payload.getCommitteeId(),
+                payload.getProfessorIds(),
+                payload.getAssignedGroups());
+    }
+}

--- a/backend/src/main/java/com/senior/spm/service/CommitteeService.java
+++ b/backend/src/main/java/com/senior/spm/service/CommitteeService.java
@@ -1,0 +1,241 @@
+package com.senior.spm.service;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.senior.spm.controller.request.ProfessorAssignmentRequest;
+import com.senior.spm.controller.response.CommitteeDetailResponse;
+import com.senior.spm.controller.response.CommitteeGroupSummaryResponse;
+import com.senior.spm.controller.response.CommitteeSummaryResponse;
+import com.senior.spm.controller.response.ProfessorAssignmentResponse;
+import com.senior.spm.controller.response.ProfessorCommitteeSummaryResponse;
+import com.senior.spm.entity.Committee;
+import com.senior.spm.entity.CommitteeProfessor;
+import com.senior.spm.entity.ProjectGroup;
+import com.senior.spm.entity.StaffUser;
+import com.senior.spm.exception.AlreadyExistsException;
+import com.senior.spm.exception.BusinessRuleException;
+import com.senior.spm.exception.NotFoundException;
+import com.senior.spm.repository.CommitteeProfessorRepository;
+import com.senior.spm.repository.CommitteeRepository;
+import com.senior.spm.repository.ProjectGroupRepository;
+import com.senior.spm.repository.StaffUserRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class CommitteeService {
+
+    private final CommitteeRepository committeeRepository;
+    private final CommitteeProfessorRepository committeeProfessorRepository;
+    private final StaffUserRepository staffUserRepository;
+    private final ProjectGroupRepository projectGroupRepository;
+    private final CommitteeNotificationService committeeNotificationService;
+
+    @Transactional
+    public CommitteeSummaryResponse createCommittee(String committeeName, String termId) {
+        if (committeeRepository.existsByCommitteeNameAndTermId(committeeName, termId)) {
+            throw new AlreadyExistsException("A committee with the same name already exists for this term");
+        }
+
+        Committee committee = new Committee();
+        committee.setCommitteeName(committeeName);
+        committee.setTermId(termId);
+
+        Committee saved = committeeRepository.save(committee);
+        return new CommitteeSummaryResponse(saved.getId(), saved.getCommitteeName(), saved.getTermId());
+    }
+
+    @Transactional(readOnly = true)
+    public List<CommitteeSummaryResponse> listCommittees(String termId) {
+        List<Committee> committees = (termId == null || termId.isBlank())
+                ? committeeRepository.findAll()
+                : committeeRepository.findByTermId(termId);
+
+        return committees.stream()
+                .map(c -> new CommitteeSummaryResponse(c.getId(), c.getCommitteeName(), c.getTermId()))
+                .collect(Collectors.toList());
+    }
+
+    @Transactional(readOnly = true)
+    public CommitteeDetailResponse getCommitteeDetail(UUID committeeId) {
+        Committee committee = committeeRepository.findDetailedById(committeeId)
+                .orElseThrow(() -> new NotFoundException("Committee not found"));
+
+        return toDetailResponse(committee);
+    }
+
+    @Transactional
+    public CommitteeDetailResponse assignProfessors(UUID committeeId, List<ProfessorAssignmentRequest> professorRequests) {
+        Committee committee = committeeRepository.findDetailedById(committeeId)
+                .orElseThrow(() -> new NotFoundException("Committee not found"));
+
+        validateProfessorAssignments(committee, professorRequests);
+
+        committeeProfessorRepository.deleteByCommitteeId(committeeId);
+
+        List<CommitteeProfessor> assignments = new ArrayList<>();
+        for (ProfessorAssignmentRequest request : professorRequests) {
+            StaffUser professor = staffUserRepository.findById(request.getProfessorId())
+                    .orElseThrow(() -> new NotFoundException("Professor not found: " + request.getProfessorId()));
+
+            CommitteeProfessor assignment = new CommitteeProfessor();
+            assignment.setCommittee(committee);
+            assignment.setProfessor(professor);
+            assignment.setRole(request.getRole());
+            assignments.add(assignment);
+        }
+
+        committeeProfessorRepository.saveAll(assignments);
+        return getCommitteeDetail(committeeId);
+    }
+
+    @Transactional
+    public CommitteeDetailResponse assignGroups(UUID committeeId, List<UUID> groupIds) {
+        Committee committee = committeeRepository.findDetailedById(committeeId)
+                .orElseThrow(() -> new NotFoundException("Committee not found"));
+
+        List<ProjectGroup> groups = projectGroupRepository.findAllById(groupIds);
+        if (groups.size() != groupIds.size()) {
+            throw new BusinessRuleException("One or more group ids are invalid");
+        }
+
+        for (ProjectGroup group : groups) {
+            if (!committee.getTermId().equals(group.getTermId())) {
+                throw new BusinessRuleException("Group term does not match the committee term");
+            }
+
+            if (group.getStatus() != ProjectGroup.GroupStatus.ADVISOR_ASSIGNED) {
+                throw new BusinessRuleException("Group must complete Advisor Association before committee assignment");
+            }
+
+            if (group.getCommittee() != null && !group.getCommittee().getId().equals(committeeId)) {
+                throw new BusinessRuleException("Group is already assigned to another committee");
+            }
+        }
+
+        for (ProjectGroup group : groups) {
+            group.setCommittee(committee);
+        }
+        projectGroupRepository.saveAll(groups);
+
+        triggerAssignmentNotification(committeeId);
+        return getCommitteeDetail(committeeId);
+    }
+
+    @Transactional(readOnly = true)
+    public List<ProfessorCommitteeSummaryResponse> getCommitteesForProfessor(UUID professorId) {
+        List<CommitteeProfessor> memberships = committeeProfessorRepository.findByProfessor_Id(professorId);
+
+        return memberships.stream()
+                .map(membership -> {
+                    Committee committee = committeeRepository.findDetailedById(membership.getCommittee().getId())
+                            .orElseThrow(() -> new NotFoundException("Committee not found"));
+
+                    List<CommitteeGroupSummaryResponse> groups = committee.getGroups().stream()
+                            .map(group -> new CommitteeGroupSummaryResponse(
+                                    group.getId(),
+                                    group.getGroupName(),
+                                    group.getStatus().name()
+                            ))
+                            .collect(Collectors.toList());
+
+                    return new ProfessorCommitteeSummaryResponse(
+                            committee.getId(),
+                            committee.getCommitteeName(),
+                            membership.getRole(),
+                            groups
+                    );
+                })
+                .collect(Collectors.toList());
+    }
+
+    private void validateProfessorAssignments(Committee committee, List<ProfessorAssignmentRequest> professorRequests) {
+        long advisorCount = professorRequests.stream()
+                .filter(p -> p.getRole() == CommitteeProfessor.CommitteeRole.ADVISOR)
+                .count();
+
+        if (advisorCount != 1) {
+            throw new BusinessRuleException("Exactly one ADVISOR must be assigned to a committee");
+        }
+
+        Set<UUID> seenProfessorIds = new HashSet<>();
+        for (ProfessorAssignmentRequest request : professorRequests) {
+            if (!seenProfessorIds.add(request.getProfessorId())) {
+                throw new BusinessRuleException("Duplicate professor id in request: " + request.getProfessorId());
+            }
+
+            StaffUser professor = staffUserRepository.findById(request.getProfessorId())
+                    .orElseThrow(() -> new NotFoundException("Professor not found: " + request.getProfessorId()));
+
+            if (professor.getRole() != StaffUser.Role.Professor) {
+                throw new BusinessRuleException("Only users with Professor role can be assigned to a committee");
+            }
+
+            boolean hasConflict = committeeProfessorRepository
+                    .existsByProfessor_IdAndCommittee_TermIdAndCommittee_IdNot(
+                            professor.getId(),
+                            committee.getTermId(),
+                            committee.getId()
+                    );
+
+            if (hasConflict) {
+                throw new BusinessRuleException("Professor already belongs to another committee in the same term");
+            }
+        }
+    }
+
+    private void triggerAssignmentNotification(UUID committeeId) {
+        Committee committee = committeeRepository.findDetailedById(committeeId)
+                .orElseThrow(() -> new NotFoundException("Committee not found"));
+
+        List<UUID> professorIds = committee.getProfessors().stream()
+                .map(cp -> cp.getProfessor().getId())
+                .distinct()
+                .collect(Collectors.toList());
+
+        List<CommitteeAssignmentNotificationPayload.AssignedGroupPayload> assignedGroups = committee.getGroups().stream()
+                .map(group -> CommitteeAssignmentNotificationPayload.AssignedGroupPayload.builder()
+                        .groupId(group.getId())
+                        .groupName(group.getGroupName())
+                        .build())
+                .collect(Collectors.toList());
+
+        CommitteeAssignmentNotificationPayload payload = CommitteeAssignmentNotificationPayload.builder()
+                .committeeId(committee.getId())
+                .professorIds(professorIds)
+                .assignedGroups(assignedGroups)
+                .build();
+
+        committeeNotificationService.sendAssignmentNotification(payload);
+    }
+
+    private CommitteeDetailResponse toDetailResponse(Committee committee) {
+        List<ProfessorAssignmentResponse> professors = committee.getProfessors().stream()
+                .map(cp -> new ProfessorAssignmentResponse(
+                        cp.getProfessor().getId(),
+                        cp.getProfessor().getMail(),
+                        cp.getRole()))
+                .collect(Collectors.toList());
+
+        List<UUID> groupIds = committee.getGroups().stream()
+                .map(ProjectGroup::getId)
+                .collect(Collectors.toList());
+
+        return new CommitteeDetailResponse(
+                committee.getId(),
+                committee.getCommitteeName(),
+                committee.getTermId(),
+                professors,
+                groupIds
+        );
+    }
+}


### PR DESCRIPTION
## Summary
This PR implements the committee backend flow for issues #103 and #114.

### Added
- Committee entity and committee-professor relation
- Committee repositories
- Committee service and controller
- Request/response DTOs for committee operations
- Committee assignment notification payload and notification service

### Implemented Endpoints
- `POST /api/committees`
- `POST /api/committees/{id}/professors`
- `POST /api/committees/{id}/groups`
- `GET /api/committees/{id}`
- `GET /api/professors/me/committees`

### Covered Issues
- #103 Backend | Implement Automated Committee Assignment Notifications
- #114 Backend | Implement GET /api/professors/me/committees endpoint

## Notes
- Project compiles successfully
- Application starts successfully
- Manual API verification is partially done / can be continued if needed