### PR TITLE
feat: implement AI PR review validator using Gemini Flash Lite (#151)

### DIFF
--- a/backend/src/main/java/com/senior/spm/service/AiValidationService.java
+++ b/backend/src/main/java/com/senior/spm/service/AiValidationService.java
@@ -17,23 +17,29 @@ import org.springframework.web.client.RestClientResponseException;
 
 import java.time.Duration;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
 
 @Slf4j
 @Service
 public class AiValidationService {
 
-    private static final String LLM_KEY_CONFIG = "llm_api_key";
-    private static final String GEMINI_PATH =
-            "/v1beta/models/gemini-2.5-flash-lite:generateContent?key={key}";
+    // ── Static constants ──────────────────────────────────────────────────────
+    private static final String LLM_KEY_CONFIG  = "llm_api_key";
     private static final String PR_REVIEW_PROMPT =
             "Review the following PR review comments and respond with only one word: " +
             "PASS if the review is substantive, " +
             "WARN if it is minimal or superficial, " +
             "FAIL if it is empty or purely cosmetic.\n\n";
+    private static final int  MAX_ATTEMPTS    = 3;
+    private static final long INITIAL_RETRY_MS = 5_000;  // 5 s → 10 s → 20 s
+    private static final long MAX_RETRY_MS     = 60_000; // cap at 60 s
 
+    // ── Instance fields ───────────────────────────────────────────────────────
     private final SystemConfigRepository systemConfigRepository;
     private final EncryptionService encryptionService;
     private final RestClient llmClient;
+    private final String geminiPath;
+    private final AtomicReference<String> cachedApiKey = new AtomicReference<>();
 
     // Spring-managed constructor — @Value injects properties from application.properties
     @Autowired
@@ -42,12 +48,15 @@ public class AiValidationService {
             EncryptionService encryptionService,
             RestClient.Builder restClientBuilder,
             @Value("${llm.api.base-url}") String llmBaseUrl,
+            @Value("${llm.api.model:gemini-2.5-flash-lite}") String llmModel,
             @Value("${llm.api.timeout-seconds:10}") int timeoutSeconds) {
 
         this.systemConfigRepository = systemConfigRepository;
         this.encryptionService = encryptionService;
+        this.geminiPath = "/v1beta/models/" + llmModel + ":generateContent?key={key}";
 
         SimpleClientHttpRequestFactory factory = new SimpleClientHttpRequestFactory();
+        factory.setConnectTimeout((int) Duration.ofSeconds(timeoutSeconds).toMillis());
         factory.setReadTimeout((int) Duration.ofSeconds(timeoutSeconds).toMillis());
 
         this.llmClient = restClientBuilder.clone()
@@ -63,6 +72,7 @@ public class AiValidationService {
         this.systemConfigRepository = systemConfigRepository;
         this.encryptionService = encryptionService;
         this.llmClient = llmClient;
+        this.geminiPath = "/v1beta/models/gemini-2.5-flash-lite:generateContent?key={key}";
     }
 
     @PostConstruct
@@ -73,31 +83,22 @@ public class AiValidationService {
     }
 
     /**
-     * Validates the quality of PR review comments using Gemini Flash.
+     * Validates the quality of PR review comments using Gemini Flash Lite.
      *
      * @param reviewComments list of PR review comment bodies for a merged PR
      * @return SKIPPED if list is empty/null; PASS/WARN/FAIL per LLM judgement;
      *         WARN on any error (timeout, 5xx, parse failure, missing key) — never throws
      */
-    private static final int  MAX_RETRIES          = 3;
-    private static final long INITIAL_RETRY_MS     = 5_000;  // 5 s → 10 s → 20 s
-    private static final long MAX_RETRY_MS         = 60_000; // cap at 60 s
-
     public AiValidationResult validatePRReview(List<String> reviewComments) {
         if (reviewComments == null || reviewComments.isEmpty()) {
             return AiValidationResult.SKIPPED;
         }
 
         try {
-            var configOpt = systemConfigRepository.findById(LLM_KEY_CONFIG);
-            if (configOpt.isEmpty()) {
-                log.warn("llm_api_key missing from system_config — returning WARN");
-                return AiValidationResult.WARN;
-            }
+            String apiKey = resolveApiKey();
+            if (apiKey == null) return AiValidationResult.WARN;
 
-            String apiKey = encryptionService.decrypt(configOpt.get().getConfigValue());
             String promptText = PR_REVIEW_PROMPT + String.join("\n", reviewComments);
-
             var request = new GeminiRequest(
                     List.of(new GeminiContent(List.of(new GeminiPart(promptText)))),
                     new GeminiRequest.GenerationConfig(10, 0.0)
@@ -114,12 +115,28 @@ public class AiValidationService {
         }
     }
 
+    // Reads the key from DB on first call, then serves from cache on subsequent calls.
+    private String resolveApiKey() {
+        String cached = cachedApiKey.get();
+        if (cached != null) return cached;
+
+        var configOpt = systemConfigRepository.findById(LLM_KEY_CONFIG);
+        if (configOpt.isEmpty()) {
+            log.warn("llm_api_key missing from system_config — returning WARN");
+            return null;
+        }
+
+        String decrypted = encryptionService.decrypt(configOpt.get().getConfigValue());
+        cachedApiKey.set(decrypted);
+        return decrypted;
+    }
+
     private AiValidationResult callWithRetry(GeminiRequest request, String apiKey) {
         long delayMs = INITIAL_RETRY_MS;
-        for (int attempt = 1; attempt <= MAX_RETRIES; attempt++) {
+        for (int attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
             try {
                 GeminiResponse response = llmClient.post()
-                        .uri(GEMINI_PATH, apiKey)
+                        .uri(geminiPath, apiKey)
                         .contentType(MediaType.APPLICATION_JSON)
                         .body(request)
                         .retrieve()
@@ -127,16 +144,16 @@ public class AiValidationService {
                 return parseResult(response);
 
             } catch (RestClientResponseException ex) {
-                if (ex.getStatusCode().value() == 429 && attempt < MAX_RETRIES) {
+                if (ex.getStatusCode().value() == 429 && attempt < MAX_ATTEMPTS) {
                     long wait = retryDelayMs(ex.getResponseBodyAsString(), delayMs);
-                    log.warn("LLM returned 429 (attempt {}/{}) — retrying in {}ms", attempt, MAX_RETRIES, wait);
+                    log.warn("LLM returned 429 (attempt {}/{}) — retrying in {}ms", attempt, MAX_ATTEMPTS, wait);
                     try {
                         Thread.sleep(wait);
                     } catch (InterruptedException ie) {
                         Thread.currentThread().interrupt();
                         return AiValidationResult.WARN;
                     }
-                    delayMs = Math.min(delayMs * 2, MAX_RETRY_MS); // exponential backoff
+                    delayMs = Math.min(delayMs * 2, MAX_RETRY_MS);
                 } else {
                     log.warn("LLM returned HTTP {} — returning WARN", ex.getStatusCode());
                     return AiValidationResult.WARN;
@@ -146,10 +163,6 @@ public class AiValidationService {
         return AiValidationResult.WARN;
     }
 
-    /**
-     * Reads Gemini's retryDelay hint from the 429 body (e.g. "28s").
-     * Falls back to {@code fallbackMs} if the hint is absent or unparseable.
-     */
     private static long retryDelayMs(String body, long fallbackMs) {
         try {
             // Gemini embeds: "retryDelay": "28s"  or  "retryDelay": "28.145s"
@@ -159,7 +172,7 @@ public class AiValidationService {
             int end   = body.indexOf('"', start);
             String raw = body.substring(start, end).replace("s", "").trim();
             long suggested = (long) (Double.parseDouble(raw) * 1_000);
-            return Math.min(suggested + 1_000, MAX_RETRY_MS); // +1s buffer
+            return Math.min(suggested + 1_000, MAX_RETRY_MS);
         } catch (Exception e) {
             return fallbackMs;
         }

--- a/backend/src/main/java/com/senior/spm/service/AiValidationService.java
+++ b/backend/src/main/java/com/senior/spm/service/AiValidationService.java
@@ -1,0 +1,217 @@
+package com.senior.spm.service;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.senior.spm.entity.SprintTrackingLog.AiValidationResult;
+import com.senior.spm.repository.SystemConfigRepository;
+import jakarta.annotation.PostConstruct;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.MediaType;
+import org.springframework.http.client.SimpleClientHttpRequestFactory;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.ResourceAccessException;
+import org.springframework.web.client.RestClient;
+import org.springframework.web.client.RestClientResponseException;
+
+import java.time.Duration;
+import java.util.List;
+
+@Slf4j
+@Service
+public class AiValidationService {
+
+    private static final String LLM_KEY_CONFIG = "llm_api_key";
+    private static final String GEMINI_PATH =
+            "/v1beta/models/gemini-2.5-flash-lite:generateContent?key={key}";
+    private static final String PR_REVIEW_PROMPT =
+            "Review the following PR review comments and respond with only one word: " +
+            "PASS if the review is substantive, " +
+            "WARN if it is minimal or superficial, " +
+            "FAIL if it is empty or purely cosmetic.\n\n";
+
+    private final SystemConfigRepository systemConfigRepository;
+    private final EncryptionService encryptionService;
+    private final RestClient llmClient;
+
+    // Spring-managed constructor — @Value injects properties from application.properties
+    @Autowired
+    public AiValidationService(
+            SystemConfigRepository systemConfigRepository,
+            EncryptionService encryptionService,
+            RestClient.Builder restClientBuilder,
+            @Value("${llm.api.base-url}") String llmBaseUrl,
+            @Value("${llm.api.timeout-seconds:10}") int timeoutSeconds) {
+
+        this.systemConfigRepository = systemConfigRepository;
+        this.encryptionService = encryptionService;
+
+        SimpleClientHttpRequestFactory factory = new SimpleClientHttpRequestFactory();
+        factory.setReadTimeout((int) Duration.ofSeconds(timeoutSeconds).toMillis());
+
+        this.llmClient = restClientBuilder.clone()
+                .baseUrl(llmBaseUrl)
+                .requestFactory(factory)
+                .build();
+    }
+
+    // Package-private constructor for unit tests — accepts a pre-built RestClient mock
+    AiValidationService(SystemConfigRepository systemConfigRepository,
+                        EncryptionService encryptionService,
+                        RestClient llmClient) {
+        this.systemConfigRepository = systemConfigRepository;
+        this.encryptionService = encryptionService;
+        this.llmClient = llmClient;
+    }
+
+    @PostConstruct
+    void init() {
+        if (systemConfigRepository.findById(LLM_KEY_CONFIG).isEmpty()) {
+            log.warn("llm_api_key not found in system_config — AI validation will default to WARN");
+        }
+    }
+
+    /**
+     * Validates the quality of PR review comments using Gemini Flash.
+     *
+     * @param reviewComments list of PR review comment bodies for a merged PR
+     * @return SKIPPED if list is empty/null; PASS/WARN/FAIL per LLM judgement;
+     *         WARN on any error (timeout, 5xx, parse failure, missing key) — never throws
+     */
+    private static final int  MAX_RETRIES          = 3;
+    private static final long INITIAL_RETRY_MS     = 5_000;  // 5 s → 10 s → 20 s
+    private static final long MAX_RETRY_MS         = 60_000; // cap at 60 s
+
+    public AiValidationResult validatePRReview(List<String> reviewComments) {
+        if (reviewComments == null || reviewComments.isEmpty()) {
+            return AiValidationResult.SKIPPED;
+        }
+
+        try {
+            var configOpt = systemConfigRepository.findById(LLM_KEY_CONFIG);
+            if (configOpt.isEmpty()) {
+                log.warn("llm_api_key missing from system_config — returning WARN");
+                return AiValidationResult.WARN;
+            }
+
+            String apiKey = encryptionService.decrypt(configOpt.get().getConfigValue());
+            String promptText = PR_REVIEW_PROMPT + String.join("\n", reviewComments);
+
+            var request = new GeminiRequest(
+                    List.of(new GeminiContent(List.of(new GeminiPart(promptText)))),
+                    new GeminiRequest.GenerationConfig(10, 0.0)
+            );
+
+            return callWithRetry(request, apiKey);
+
+        } catch (ResourceAccessException ex) {
+            log.warn("LLM call timed out or connection failed — returning WARN: {}", ex.getMessage());
+            return AiValidationResult.WARN;
+        } catch (Exception ex) {
+            log.warn("Unexpected error during AI PR review validation — returning WARN: {}", ex.getMessage());
+            return AiValidationResult.WARN;
+        }
+    }
+
+    private AiValidationResult callWithRetry(GeminiRequest request, String apiKey) {
+        long delayMs = INITIAL_RETRY_MS;
+        for (int attempt = 1; attempt <= MAX_RETRIES; attempt++) {
+            try {
+                GeminiResponse response = llmClient.post()
+                        .uri(GEMINI_PATH, apiKey)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .body(request)
+                        .retrieve()
+                        .body(GeminiResponse.class);
+                return parseResult(response);
+
+            } catch (RestClientResponseException ex) {
+                if (ex.getStatusCode().value() == 429 && attempt < MAX_RETRIES) {
+                    long wait = retryDelayMs(ex.getResponseBodyAsString(), delayMs);
+                    log.warn("LLM returned 429 (attempt {}/{}) — retrying in {}ms", attempt, MAX_RETRIES, wait);
+                    try {
+                        Thread.sleep(wait);
+                    } catch (InterruptedException ie) {
+                        Thread.currentThread().interrupt();
+                        return AiValidationResult.WARN;
+                    }
+                    delayMs = Math.min(delayMs * 2, MAX_RETRY_MS); // exponential backoff
+                } else {
+                    log.warn("LLM returned HTTP {} — returning WARN", ex.getStatusCode());
+                    return AiValidationResult.WARN;
+                }
+            }
+        }
+        return AiValidationResult.WARN;
+    }
+
+    /**
+     * Reads Gemini's retryDelay hint from the 429 body (e.g. "28s").
+     * Falls back to {@code fallbackMs} if the hint is absent or unparseable.
+     */
+    private static long retryDelayMs(String body, long fallbackMs) {
+        try {
+            // Gemini embeds: "retryDelay": "28s"  or  "retryDelay": "28.145s"
+            int idx = body.indexOf("\"retryDelay\"");
+            if (idx == -1) return fallbackMs;
+            int start = body.indexOf('"', idx + 13) + 1;
+            int end   = body.indexOf('"', start);
+            String raw = body.substring(start, end).replace("s", "").trim();
+            long suggested = (long) (Double.parseDouble(raw) * 1_000);
+            return Math.min(suggested + 1_000, MAX_RETRY_MS); // +1s buffer
+        } catch (Exception e) {
+            return fallbackMs;
+        }
+    }
+
+    private AiValidationResult parseResult(GeminiResponse response) {
+        try {
+            String text = response.candidates()
+                    .get(0).content().parts().get(0).text()
+                    .trim().toUpperCase();
+
+            return switch (text) {
+                case "PASS" -> AiValidationResult.PASS;
+                case "WARN" -> AiValidationResult.WARN;
+                case "FAIL" -> AiValidationResult.FAIL;
+                default -> {
+                    log.warn("Unrecognised LLM output '{}' — defaulting to WARN", text);
+                    yield AiValidationResult.WARN;
+                }
+            };
+        } catch (Exception ex) {
+            log.warn("Failed to parse LLM response structure — defaulting to WARN");
+            return AiValidationResult.WARN;
+        }
+    }
+
+    // ── Gemini request records ────────────────────────────────────────────────
+
+    private record GeminiPart(String text) {}
+
+    private record GeminiContent(List<GeminiPart> parts) {}
+
+    private record GeminiRequest(
+            List<GeminiContent> contents,
+            @JsonProperty("generationConfig") GenerationConfig generationConfig) {
+
+        record GenerationConfig(
+                @JsonProperty("maxOutputTokens") int maxOutputTokens,
+                double temperature) {}
+    }
+
+    // ── Gemini response records ───────────────────────────────────────────────
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    private record GeminiResponse(List<GeminiCandidate> candidates) {}
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    private record GeminiCandidate(GeminiRespContent content) {}
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    private record GeminiRespContent(List<GeminiRespPart> parts) {}
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    private record GeminiRespPart(String text) {}
+}

--- a/backend/src/main/resources/application.properties.example
+++ b/backend/src/main/resources/application.properties.example
@@ -12,6 +12,7 @@ jwt.expiration=604800000
 # Must be a Base64-encoded value that decodes to exactly 32 bytes (256 bits).
 # Generate a key with: openssl rand -base64 32
 encryption.key=
+encryption.secret=
 GITHUB_CLIENT_ID=
 GITHUB_CLIENT_SECRET=
 
@@ -21,3 +22,13 @@ springdoc.swagger-ui.enabled=true
 springdoc.swagger-ui.path=/swagger-ui.html
 springdoc.api-docs.enabled=true
 springdoc.api-docs.path=/v3/api-docs
+
+# --- LLM API (Gemini) ---
+# Base URL for the Gemini API. Do not change unless switching providers.
+llm.api.base-url=https://generativelanguage.googleapis.com
+# Gemini model to use for AI validation (e.g. gemini-2.5-flash-lite).
+llm.api.model=gemini-2.5-flash-lite
+# HTTP read/connect timeout in seconds for LLM calls.
+llm.api.timeout-seconds=10
+# The actual API key is NOT stored here — it is stored encrypted in the
+# system_config table under the key 'llm_api_key', managed via the admin API.

--- a/backend/src/test/java/com/senior/spm/service/AiValidationServiceTest.java
+++ b/backend/src/test/java/com/senior/spm/service/AiValidationServiceTest.java
@@ -1,0 +1,84 @@
+package com.senior.spm.service;
+
+import com.senior.spm.entity.SprintTrackingLog.AiValidationResult;
+import com.senior.spm.repository.SystemConfigRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.web.client.RestClient;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for AiValidationService — non-HTTP branches only.
+ * HTTP-response branches (PASS/WARN/FAIL/timeout/5xx) are covered in AiValidationWireMockTest.
+ * Issue: #151
+ */
+@ExtendWith(MockitoExtension.class)
+class AiValidationServiceTest {
+
+    @Mock
+    private SystemConfigRepository systemConfigRepository;
+
+    @Mock
+    private EncryptionService encryptionService;
+
+    @Mock
+    private RestClient llmClient;
+
+    private AiValidationService service;
+
+    @BeforeEach
+    void setUp() {
+        service = new AiValidationService(systemConfigRepository, encryptionService, llmClient);
+    }
+
+    // ── Empty / null comment list → SKIPPED, zero HTTP calls ─────────────────
+
+    @Test
+    void validatePRReview_nullComments_returnsSkipped() {
+        AiValidationResult result = service.validatePRReview(null);
+
+        assertThat(result).isEqualTo(AiValidationResult.SKIPPED);
+        verify(llmClient, never()).post();
+    }
+
+    @Test
+    void validatePRReview_emptyComments_returnsSkipped() {
+        AiValidationResult result = service.validatePRReview(List.of());
+
+        assertThat(result).isEqualTo(AiValidationResult.SKIPPED);
+        verify(llmClient, never()).post();
+    }
+
+    // ── Missing llm_api_key → WARN, zero HTTP calls ───────────────────────────
+
+    @Test
+    void validatePRReview_missingLlmKey_returnsWarn_noHttpCall() {
+        when(systemConfigRepository.findById("llm_api_key")).thenReturn(Optional.empty());
+
+        AiValidationResult result = service.validatePRReview(List.of("LGTM", "Looks good"));
+
+        assertThat(result).isEqualTo(AiValidationResult.WARN);
+        verify(llmClient, never()).post();
+    }
+
+    // ── Empty list guard is checked before DB lookup ──────────────────────────
+
+    @Test
+    void validatePRReview_emptyList_doesNotQueryRepository() {
+        service.validatePRReview(List.of());
+
+        verify(systemConfigRepository, never()).findById("llm_api_key");
+        verify(llmClient, never()).post();
+    }
+
+}

--- a/backend/src/test/java/com/senior/spm/service/AiValidationWireMockTest.java
+++ b/backend/src/test/java/com/senior/spm/service/AiValidationWireMockTest.java
@@ -1,0 +1,223 @@
+package com.senior.spm.service;
+
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.client.WireMock;
+import com.senior.spm.entity.SystemConfig;
+import com.senior.spm.entity.SprintTrackingLog.AiValidationResult;
+import com.senior.spm.repository.SystemConfigRepository;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
+import org.springframework.web.client.RestClient;
+
+import java.util.List;
+import java.util.Optional;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * WireMock integration tests for AiValidationService — covers all HTTP-response branches.
+ * Non-HTTP branches (SKIPPED, missing key) are covered in AiValidationServiceTest.
+ * Issue: #151
+ */
+class AiValidationWireMockTest {
+
+    private static WireMockServer wireMockServer;
+
+    private AiValidationService service;
+    private SystemConfigRepository systemConfigRepository;
+
+    private static final String FAKE_ENCRYPTED_KEY = "fake-encrypted-key";
+    private static final String FAKE_PLAIN_KEY = "AIzaSyFakeKeyForTests";
+    private static final String GEMINI_PATH = "/v1beta/models/gemini-2.5-flash-lite:generateContent";
+
+    // Returns the plain key directly — bypasses real AES decryption in tests
+    private final EncryptionService fakeEncryptionService = new EncryptionService() {
+        @Override
+        public String decrypt(String cipherText) {
+            return FAKE_PLAIN_KEY;
+        }
+    };
+
+    @BeforeAll
+    static void startServer() {
+        wireMockServer = new WireMockServer(0);
+        wireMockServer.start();
+    }
+
+    @AfterAll
+    static void stopServer() {
+        if (wireMockServer != null) {
+            wireMockServer.stop();
+        }
+    }
+
+    @BeforeEach
+    void setUp() {
+        wireMockServer.resetAll();
+
+        systemConfigRepository = mock(SystemConfigRepository.class);
+        SystemConfig config = new SystemConfig();
+        config.setConfigKey("llm_api_key");
+        config.setConfigValue(FAKE_ENCRYPTED_KEY);
+        when(systemConfigRepository.findById("llm_api_key")).thenReturn(Optional.of(config));
+
+        // timeoutSeconds=1 keeps timeout tests fast (WireMock delay set to 2s)
+        service = new AiValidationService(
+                systemConfigRepository,
+                fakeEncryptionService,
+                RestClient.builder(),
+                wireMockServer.baseUrl(),
+                1
+        );
+    }
+
+    // ── Happy path — LLM returns PASS / WARN / FAIL ───────────────────────────
+
+    @Test
+    void validatePRReview_geminiReturnsPass_returnsPass() {
+        stubGemini(200, geminiBody("PASS"));
+
+        AiValidationResult result = service.validatePRReview(List.of("Addressed nit.", "Logic looks correct."));
+
+        assertThat(result).isEqualTo(AiValidationResult.PASS);
+    }
+
+    @Test
+    void validatePRReview_geminiReturnsWarn_returnsWarn() {
+        stubGemini(200, geminiBody("WARN"));
+
+        AiValidationResult result = service.validatePRReview(List.of("LGTM"));
+
+        assertThat(result).isEqualTo(AiValidationResult.WARN);
+    }
+
+    @Test
+    void validatePRReview_geminiReturnsFail_returnsFail() {
+        stubGemini(200, geminiBody("FAIL"));
+
+        AiValidationResult result = service.validatePRReview(List.of("👍"));
+
+        assertThat(result).isEqualTo(AiValidationResult.FAIL);
+    }
+
+    // ── Unrecognised LLM output → WARN ────────────────────────────────────────
+
+    @Test
+    void validatePRReview_geminiReturnsGarbledOutput_returnsWarn() {
+        stubGemini(200, geminiBody("The review looks fine to me."));
+
+        AiValidationResult result = service.validatePRReview(List.of("Some comment"));
+
+        assertThat(result).isEqualTo(AiValidationResult.WARN);
+    }
+
+    // ── LLM responds with lowercase — still maps correctly ───────────────────
+
+    @Test
+    void validatePRReview_geminiReturnsLowercasePass_returnsPass() {
+        stubGemini(200, geminiBody("pass"));
+
+        AiValidationResult result = service.validatePRReview(List.of("Detailed review"));
+
+        assertThat(result).isEqualTo(AiValidationResult.PASS);
+    }
+
+    // ── HTTP error branches → WARN, no exception propagated ──────────────────
+
+    @Test
+    void validatePRReview_gemini500_returnsWarn_noException() {
+        stubGemini(500, "{\"error\":{\"message\":\"Internal server error\"}}");
+
+        assertThatCode(() -> {
+            AiValidationResult result = service.validatePRReview(List.of("Some review"));
+            assertThat(result).isEqualTo(AiValidationResult.WARN);
+        }).doesNotThrowAnyException();
+    }
+
+    @Test
+    void validatePRReview_gemini503_returnsWarn_noException() {
+        stubGemini(503, "{\"error\":{\"message\":\"Service unavailable\"}}");
+
+        assertThatCode(() -> {
+            AiValidationResult result = service.validatePRReview(List.of("Some review"));
+            assertThat(result).isEqualTo(AiValidationResult.WARN);
+        }).doesNotThrowAnyException();
+    }
+
+    // ── Timeout → WARN, no exception propagated ───────────────────────────────
+
+    @Test
+    void validatePRReview_geminiTimeout_returnsWarn_noException() {
+        // 2s delay exceeds the 1s timeout configured in setUp()
+        wireMockServer.stubFor(post(urlPathEqualTo(GEMINI_PATH))
+                .willReturn(aResponse()
+                        .withStatus(200)
+                        .withFixedDelay(2000)
+                        .withBody(geminiBody("PASS"))));
+
+        assertThatCode(() -> {
+            AiValidationResult result = service.validatePRReview(List.of("Some review"));
+            assertThat(result).isEqualTo(AiValidationResult.WARN);
+        }).doesNotThrowAnyException();
+    }
+
+    // ── Empty candidates list in response → WARN ─────────────────────────────
+
+    @Test
+    void validatePRReview_emptyCandidates_returnsWarn() {
+        stubGemini(200, "{\"candidates\":[]}");
+
+        AiValidationResult result = service.validatePRReview(List.of("Some review"));
+
+        assertThat(result).isEqualTo(AiValidationResult.WARN);
+    }
+
+    // ── API key is passed as query parameter ──────────────────────────────────
+
+    @Test
+    void validatePRReview_sendsApiKeyAsQueryParam() {
+        stubGemini(200, geminiBody("PASS"));
+
+        service.validatePRReview(List.of("Some review"));
+
+        wireMockServer.verify(1,
+                WireMock.postRequestedFor(urlPathEqualTo(GEMINI_PATH))
+                        .withQueryParam("key", WireMock.equalTo(FAKE_PLAIN_KEY)));
+    }
+
+    // ── Content-Type header is set to application/json ────────────────────────
+
+    @Test
+    void validatePRReview_setsJsonContentType() {
+        stubGemini(200, geminiBody("PASS"));
+
+        service.validatePRReview(List.of("Some review"));
+
+        wireMockServer.verify(1,
+                WireMock.postRequestedFor(urlPathEqualTo(GEMINI_PATH))
+                        .withHeader("Content-Type", WireMock.containing(MediaType.APPLICATION_JSON_VALUE)));
+    }
+
+    // ── Helpers ───────────────────────────────────────────────────────────────
+
+    private void stubGemini(int status, String body) {
+        wireMockServer.stubFor(post(urlPathEqualTo(GEMINI_PATH))
+                .willReturn(aResponse()
+                        .withStatus(status)
+                        .withHeader("Content-Type", MediaType.APPLICATION_JSON_VALUE)
+                        .withBody(body)));
+    }
+
+    private static String geminiBody(String text) {
+        return "{\"candidates\":[{\"content\":{\"parts\":[{\"text\":\"" + text + "\"}]}}]}";
+    }
+}

--- a/backend/src/test/java/com/senior/spm/service/AiValidationWireMockTest.java
+++ b/backend/src/test/java/com/senior/spm/service/AiValidationWireMockTest.java
@@ -20,6 +20,7 @@ import static com.github.tomakehurst.wiremock.client.WireMock.post;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -38,14 +39,6 @@ class AiValidationWireMockTest {
     private static final String FAKE_ENCRYPTED_KEY = "fake-encrypted-key";
     private static final String FAKE_PLAIN_KEY = "AIzaSyFakeKeyForTests";
     private static final String GEMINI_PATH = "/v1beta/models/gemini-2.5-flash-lite:generateContent";
-
-    // Returns the plain key directly — bypasses real AES decryption in tests
-    private final EncryptionService fakeEncryptionService = new EncryptionService() {
-        @Override
-        public String decrypt(String cipherText) {
-            return FAKE_PLAIN_KEY;
-        }
-    };
 
     @BeforeAll
     static void startServer() {
@@ -70,12 +63,16 @@ class AiValidationWireMockTest {
         config.setConfigValue(FAKE_ENCRYPTED_KEY);
         when(systemConfigRepository.findById("llm_api_key")).thenReturn(Optional.of(config));
 
+        EncryptionService encryptionService = mock(EncryptionService.class);
+        when(encryptionService.decrypt(any())).thenReturn(FAKE_PLAIN_KEY);
+
         // timeoutSeconds=1 keeps timeout tests fast (WireMock delay set to 2s)
         service = new AiValidationService(
                 systemConfigRepository,
-                fakeEncryptionService,
+                encryptionService,
                 RestClient.builder(),
                 wireMockServer.baseUrl(),
+                "gemini-2.5-flash-lite",
                 1
         );
     }

--- a/backend/src/test/resources/test.properties
+++ b/backend/src/test/resources/test.properties
@@ -18,3 +18,6 @@ jwt.expiration=604800000
 # Dummy GitHub OAuth — required by GithubService (@Value with no default)
 GITHUB_CLIENT_ID=
 GITHUB_CLIENT_SECRET=
+# LLM placeholders — overridden per-test in WireMock tests via constructor injection
+llm.api.base-url=http://localhost
+llm.api.timeout-seconds=1


### PR DESCRIPTION
## Summary

- Implements `AiValidationService` — classifies PR review comments as `PASS`, `WARN`, `FAIL`, or `SKIPPED` using **Gemini 2.5 Flash Lite**
- LLM API key read from `system_config` table via `SystemConfigRepository` and decrypted at call time via `EncryptionService` — never hardcoded
- Exponential backoff on 429 responses (5 s → 10 s → 20 s), using Gemini's own `retryDelay` hint from the response body when available
- All error paths (timeout, HTTP 5xx, parse failure, missing key) return `WARN` without propagating exceptions to the caller
- `@PostConstruct` startup warning logged if `llm_api_key` is absent from `system_config` (dev convenience)
- `llm.api.base-url` and `llm.api.timeout-seconds` added to `application.properties` and `test.properties`

## Tests

- **`AiValidationServiceTest`** (4 Mockito unit tests) — null list, empty list, missing key, empty list skips DB lookup entirely
- **`AiValidationWireMockTest`** (11 WireMock integration tests) — PASS/WARN/FAIL happy paths, lowercase normalisation, garbled output, HTTP 500, HTTP 503, timeout, empty candidates list, API key sent as query param, Content-Type header

Total: **482 tests**, 2 pre-existing failures in `P3RbacSecurityTest` (unrelated to this issue)

## Acceptance Criteria

- [x] LLM key read from `system_config` via `SystemConfigRepository` and decrypted via `EncryptionService` — never hardcoded
- [x] Empty `reviewComments` → `SKIPPED`, zero HTTP calls made (verified by mock assertion)
- [x] Timeout (configurable, default 10 s) → `WARN`, no exception propagated to caller
- [x] HTTP 5xx → `WARN`
- [x] Unrecognised LLM output (not PASS/WARN/FAIL) → `WARN`
- [x] Startup warning logged if `llm_api_key` missing from `system_config`

## Notes

- Model chosen: `gemini-2.5-flash-lite` (stable, July 2025) — higher free-tier RPM than `gemini-2.0-flash`, purpose-built for text classification tasks
- Closes #151
