### PR TITLE
feat(p5-05): implement end-of-sprint tracking orchestrator

### DIFF
--- a/backend/src/main/java/com/senior/spm/repository/ProjectGroupRepository.java
+++ b/backend/src/main/java/com/senior/spm/repository/ProjectGroupRepository.java
@@ -28,4 +28,6 @@ public interface ProjectGroupRepository extends JpaRepository<ProjectGroup, UUID
     List<ProjectGroup> findByTermIdAndStatusInAndAdvisorIsNull(String termId, List<GroupStatus> statuses);
 
     List<ProjectGroup> findByAdvisor_IdAndTermId(UUID advisorId, String termId);
+
+    List<ProjectGroup> findByTermIdAndStatusIn(String termId, List<GroupStatus> statuses);
 }

--- a/backend/src/main/java/com/senior/spm/service/AiValidationService.java
+++ b/backend/src/main/java/com/senior/spm/service/AiValidationService.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.senior.spm.entity.SprintTrackingLog.AiValidationResult;
 import com.senior.spm.repository.SystemConfigRepository;
+import com.senior.spm.service.dto.GithubFileDiffDto;
 import jakarta.annotation.PostConstruct;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -197,6 +198,11 @@ public class AiValidationService {
             log.warn("Failed to parse LLM response structure — defaulting to WARN");
             return AiValidationResult.WARN;
         }
+    }
+
+    // TODO: replaced by P5-04b (Batıkan) — stub returns PENDING during development
+    public AiValidationResult validateIssueDiff(String issueDescription, List<GithubFileDiffDto> fileDiffs) {
+        return AiValidationResult.PENDING;
     }
 
     // ── Gemini request records ────────────────────────────────────────────────

--- a/backend/src/main/java/com/senior/spm/service/GithubSprintService.java
+++ b/backend/src/main/java/com/senior/spm/service/GithubSprintService.java
@@ -150,14 +150,15 @@ public class GithubSprintService {
                 return Optional.empty();
             }
 
-            JsonNode first  = response.get(0);
-            Long prNumber   = first.path("number").asLong();
-            String state    = first.path("state").asText(null);
-            String mergedAt = first.hasNonNull("merged_at")
+            JsonNode first   = response.get(0);
+            Long prNumber    = first.path("number").asLong();
+            String state     = first.path("state").asText(null);
+            String mergedAt  = first.hasNonNull("merged_at")
                     ? first.path("merged_at").asText(null)
                     : null;
+            String authorLogin = first.path("user").path("login").asText(null);
 
-            return Optional.of(GithubPrDto.of(prNumber, state, mergedAt));
+            return Optional.of(GithubPrDto.of(prNumber, state, mergedAt, authorLogin));
 
         } catch (RestClientException ex) {
             log.warn("GitHub API error finding merged PR for group {} branch {}: {}",

--- a/backend/src/main/java/com/senior/spm/service/JiraSprintService.java
+++ b/backend/src/main/java/com/senior/spm/service/JiraSprintService.java
@@ -30,6 +30,77 @@ public class JiraSprintService {
         this.encryptionService = encryptionService;
     }
 
+    /**
+     * Resolves the active JIRA sprint for {@code group} internally via a 3-step API chain
+     * (board lookup → active sprint → issue fetch) and delegates to
+     * {@link #fetchSprintStories(ProjectGroup, String)}.
+     *
+     * <p>Board not found or no active sprint → logs WARN and returns empty list. Never throws.
+     */
+    public List<JiraIssueDto> fetchSprintStories(ProjectGroup group) {
+        if (group.getJiraSpaceUrl() == null || group.getJiraEmail() == null
+                || group.getEncryptedJiraToken() == null || group.getJiraProjectKey() == null) {
+            log.warn("JIRA credentials or project key missing for group {}", group.getId());
+            return Collections.emptyList();
+        }
+        try {
+            String decryptedToken = encryptionService.decrypt(group.getEncryptedJiraToken());
+            String authString = group.getJiraEmail().strip() + ":" + decryptedToken;
+            String base64Auth = Base64.getEncoder().encodeToString(authString.getBytes(StandardCharsets.UTF_8));
+            String baseUrl = group.getJiraSpaceUrl().strip().replaceAll("/+$", "");
+
+            // Step 1: resolve boardId from project key
+            String boardUrl = baseUrl + "/rest/agile/1.0/board?projectKeyOrId=" + group.getJiraProjectKey();
+            JsonNode boardResp = restClient.get()
+                    .uri(boardUrl)
+                    .header(HttpHeaders.AUTHORIZATION, "Basic " + base64Auth)
+                    .header(HttpHeaders.ACCEPT, "application/json")
+                    .retrieve()
+                    .body(JsonNode.class);
+
+            JsonNode boardValues = boardResp != null ? boardResp.path("values") : null;
+            if (boardValues == null || !boardValues.isArray() || boardValues.isEmpty()) {
+                log.warn("No JIRA board found for group {} project key {}", group.getId(), group.getJiraProjectKey());
+                return Collections.emptyList();
+            }
+            long boardId = boardValues.get(0).path("id").asLong();
+
+            // Step 2: resolve active jiraSprintId from board
+            String sprintUrl = baseUrl + "/rest/agile/1.0/board/" + boardId + "/sprint?state=active";
+            JsonNode sprintResp = restClient.get()
+                    .uri(sprintUrl)
+                    .header(HttpHeaders.AUTHORIZATION, "Basic " + base64Auth)
+                    .header(HttpHeaders.ACCEPT, "application/json")
+                    .retrieve()
+                    .body(JsonNode.class);
+
+            JsonNode sprintValues = sprintResp != null ? sprintResp.path("values") : null;
+            if (sprintValues == null || !sprintValues.isArray() || sprintValues.isEmpty()) {
+                log.warn("No active JIRA sprint found for group {} board {}", group.getId(), boardId);
+                return Collections.emptyList();
+            }
+            String jiraSprintId = sprintValues.get(0).path("id").asText(null);
+            if (jiraSprintId == null) {
+                log.warn("Active sprint has no id for group {} board {}", group.getId(), boardId);
+                return Collections.emptyList();
+            }
+
+            // Step 3: fetch issues for the resolved sprint
+            return fetchSprintStories(group, jiraSprintId);
+
+        } catch (HttpClientErrorException ex) {
+            log.warn("JIRA API returned HTTP {} during sprint resolution for group {}",
+                    ex.getStatusCode().value(), group.getId());
+            return Collections.emptyList();
+        } catch (RestClientException ex) {
+            log.warn("Network error during JIRA sprint resolution for group {}: {}", group.getId(), ex.getMessage());
+            return Collections.emptyList();
+        } catch (Exception ex) {
+            log.warn("Unexpected error during JIRA sprint resolution for group {}", group.getId(), ex);
+            return Collections.emptyList();
+        }
+    }
+
     public List<JiraIssueDto> fetchSprintStories(ProjectGroup group, String jiraSprintId) {
         if (group.getJiraSpaceUrl() == null || group.getJiraEmail() == null || group.getEncryptedJiraToken() == null) {
             log.warn("JIRA credentials or configurations missing for group {}", group.getId());

--- a/backend/src/main/java/com/senior/spm/service/SprintTrackingOrchestrator.java
+++ b/backend/src/main/java/com/senior/spm/service/SprintTrackingOrchestrator.java
@@ -1,0 +1,258 @@
+package com.senior.spm.service;
+
+import com.senior.spm.entity.ProjectGroup;
+import com.senior.spm.entity.ProjectGroup.GroupStatus;
+import com.senior.spm.entity.Sprint;
+import com.senior.spm.entity.SprintTrackingLog;
+import com.senior.spm.entity.SprintTrackingLog.AiValidationResult;
+import com.senior.spm.exception.BusinessRuleException;
+import com.senior.spm.exception.NotFoundException;
+import com.senior.spm.repository.ProjectGroupRepository;
+import com.senior.spm.repository.SprintRepository;
+import com.senior.spm.repository.SprintTrackingLogRepository;
+import com.senior.spm.service.dto.GithubFileDiffDto;
+import com.senior.spm.service.dto.GithubPrDto;
+import com.senior.spm.service.dto.JiraIssueDto;
+import com.senior.spm.service.dto.SprintRefreshStats;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Lazy;
+import org.springframework.dao.OptimisticLockingFailureException;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * Orchestrates the end-of-sprint tracking pipeline (sub-processes 5.1–5.4).
+ *
+ * <p>Transaction design (identical pattern to {@link SanitizationService}):
+ * <ul>
+ *   <li>{@code runDailyTracking} — {@code @Scheduled}, no transaction; calls self-proxy.</li>
+ *   <li>{@code processGroupsForSprint} — no transaction; outer loop with per-group try-catch
+ *       to ensure one failing group never blocks others.</li>
+ *   <li>{@code processGroup} — {@code REQUIRES_NEW}; one commit per group. An
+ *       {@code OptimisticLockingFailureException} rolls back only this group.</li>
+ * </ul>
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class SprintTrackingOrchestrator {
+
+    private final SprintRepository              sprintRepository;
+    private final ProjectGroupRepository        projectGroupRepository;
+    private final SprintTrackingLogRepository   sprintTrackingLogRepository;
+    private final JiraSprintService             jiraSprintService;
+    private final GithubSprintService           githubSprintService;
+    private final AiValidationService           aiValidationService;
+    private final TermConfigService             termConfigService;
+
+    /**
+     * Self-proxy — injected lazily to avoid circular dependency.
+     * Required so that internal calls to {@code processGroup} pass through the
+     * Spring AOP proxy, activating its {@code @Transactional(REQUIRES_NEW)}.
+     */
+    @Autowired
+    @Lazy
+    private SprintTrackingOrchestrator self;
+
+    // ── scheduled entry point ────────────────────────────────────────────────
+
+    /**
+     * Fires daily at 01:00 UTC. Finds all sprints whose {@code endDate} was yesterday
+     * and runs the full 5.1–5.4 pipeline for every eligible group.
+     */
+    @Scheduled(cron = "0 0 1 * * *")
+    public void runDailyTracking() {
+        LocalDate yesterday = LocalDate.now(ZoneId.of("UTC")).minusDays(1);
+        List<Sprint> endedSprints = sprintRepository.findByEndDate(yesterday);
+        if (endedSprints.isEmpty()) {
+            return;
+        }
+        log.info("Daily sprint tracking: {} sprint(s) ended on {}", endedSprints.size(), yesterday);
+        for (Sprint sprint : endedSprints) {
+            try {
+                processGroupsForSprint(sprint);
+            } catch (Exception e) {
+                log.error("Sprint tracking failed for sprint {}: {}", sprint.getId(), e.getMessage(), e);
+            }
+        }
+    }
+
+    // ── coordinator manual entry point ───────────────────────────────────────
+
+    /**
+     * Manual trigger exposed via {@code POST /api/coordinator/sprints/{sprintId}/refresh}.
+     *
+     * <p>Guard: when {@code force=false} and the sprint has not yet ended,
+     * throws {@link BusinessRuleException} (→ HTTP 400).
+     *
+     * <p>Deletes all existing {@code SprintTrackingLog} rows for the sprint before
+     * re-fetching — ensures idempotency (running twice yields the same result).
+     *
+     * @param sprintId target sprint
+     * @param force    when {@code true}, bypasses the sprint-end-date guard
+     * @return counts of groups processed, issues fetched, and AI validations run
+     * @throws NotFoundException     if the sprint does not exist
+     * @throws BusinessRuleException if the sprint has not ended and {@code force=false}
+     */
+    public SprintRefreshStats triggerForSprint(UUID sprintId, boolean force) {
+        Sprint sprint = sprintRepository.findById(sprintId)
+                .orElseThrow(() -> new NotFoundException("Sprint not found"));
+
+        if (!force && !sprint.getEndDate().isBefore(LocalDate.now(ZoneId.of("UTC")))) {
+            throw new BusinessRuleException(
+                    "Sprint has not ended yet — use ?force=true to refresh early");
+        }
+
+        // Wipe existing rows so re-run is idempotent
+        sprintTrackingLogRepository.deleteBySprintId(sprintId);
+
+        AtomicInteger groupsProcessed   = new AtomicInteger();
+        AtomicInteger issuesFetched     = new AtomicInteger();
+        AtomicInteger aiValidationsRun  = new AtomicInteger();
+
+        String termId = termConfigService.getActiveTermId();
+        List<ProjectGroup> groups = projectGroupRepository.findByTermIdAndStatusIn(
+                termId, List.of(GroupStatus.TOOLS_BOUND, GroupStatus.ADVISOR_ASSIGNED));
+
+        for (ProjectGroup group : groups) {
+            try {
+                int[] counts = self.processGroup(group, sprint);
+                groupsProcessed.incrementAndGet();
+                issuesFetched.addAndGet(counts[0]);
+                aiValidationsRun.addAndGet(counts[1]);
+            } catch (OptimisticLockingFailureException e) {
+                log.warn("Skipping group {} — optimistic lock conflict during sprint refresh", group.getId());
+            } catch (Exception e) {
+                log.error("Error processing group {} during sprint refresh: {}", group.getId(), e.getMessage(), e);
+            }
+        }
+
+        return new SprintRefreshStats(groupsProcessed.get(), issuesFetched.get(), aiValidationsRun.get());
+    }
+
+    // ── per-sprint outer loop ────────────────────────────────────────────────
+
+    private void processGroupsForSprint(Sprint sprint) {
+        String termId = termConfigService.getActiveTermId();
+        List<ProjectGroup> groups = projectGroupRepository.findByTermIdAndStatusIn(
+                termId, List.of(GroupStatus.TOOLS_BOUND, GroupStatus.ADVISOR_ASSIGNED));
+
+        log.info("Sprint {} tracking: {} eligible group(s)", sprint.getId(), groups.size());
+
+        for (ProjectGroup group : groups) {
+            try {
+                self.processGroup(group, sprint);
+            } catch (OptimisticLockingFailureException e) {
+                log.warn("Skipping group {} (sprint {}) — optimistic lock conflict; next run will retry",
+                        group.getId(), sprint.getId());
+            } catch (Exception e) {
+                log.error("Error processing group {} for sprint {}: {}",
+                        group.getId(), sprint.getId(), e.getMessage(), e);
+            }
+        }
+    }
+
+    // ── per-group atomic unit ────────────────────────────────────────────────
+
+    /**
+     * Runs the full 5.1–5.4 pipeline for one group in its own transaction.
+     *
+     * <p>Returns {@code int[2]}: {@code [issuesFetched, aiValidationsRun]}.
+     * Uses {@code REQUIRES_NEW} so a failure rolls back only this group without
+     * poisoning any outer session.
+     */
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public int[] processGroup(ProjectGroup group, Sprint sprint) {
+        // 5.1 — fetch JIRA stories (resolves active sprint internally)
+        List<JiraIssueDto> issues = jiraSprintService.fetchSprintStories(group);
+
+        // Wipe any pre-existing rows for this group+sprint (handles per-group re-runs)
+        sprintTrackingLogRepository.deleteByGroupIdAndSprintId(group.getId(), sprint.getId());
+
+        if (issues.isEmpty()) {
+            log.info("No JIRA issues found for group {} sprint {}", group.getId(), sprint.getId());
+            return new int[]{0, 0};
+        }
+
+        LocalDateTime fetchedAt = LocalDateTime.now(ZoneId.of("UTC"));
+        List<SprintTrackingLog> logs = new ArrayList<>(issues.size());
+
+        for (JiraIssueDto issue : issues) {
+            SprintTrackingLog entry = new SprintTrackingLog();
+            entry.setGroup(group);
+            entry.setSprint(sprint);
+            entry.setIssueKey(issue.issueKey());
+            entry.setAssigneeGithubUsername(issue.assigneeEmail());
+            entry.setStoryPoints(issue.storyPoints());
+            entry.setFetchedAt(fetchedAt);
+            entry.setAiPrResult(AiValidationResult.PENDING);
+            entry.setAiDiffResult(AiValidationResult.PENDING);
+            logs.add(entry);
+        }
+
+        // Persist initial rows before GitHub/AI calls
+        List<SprintTrackingLog> savedLogs = sprintTrackingLogRepository.saveAll(logs);
+
+        int aiValidationsRun = 0;
+
+        for (int i = 0; i < savedLogs.size(); i++) {
+            SprintTrackingLog log = savedLogs.get(i);
+            JiraIssueDto issue = issues.get(i);
+
+            // 5.2 — GitHub branch + PR match
+            Optional<String> branchOpt = githubSprintService.findBranchByIssueKey(group, issue.issueKey());
+            if (branchOpt.isEmpty()) {
+                // No branch found — skip AI, leave prMerged=null, set AI to SKIPPED
+                log.setAiPrResult(AiValidationResult.SKIPPED);
+                log.setAiDiffResult(AiValidationResult.SKIPPED);
+                continue;
+            }
+
+            Optional<GithubPrDto> prOpt = githubSprintService.findMergedPR(group, branchOpt.get());
+            if (prOpt.isEmpty()) {
+                // Branch found but no closed PR
+                log.setPrMerged(false);
+                log.setAiPrResult(AiValidationResult.SKIPPED);
+                log.setAiDiffResult(AiValidationResult.SKIPPED);
+                continue;
+            }
+
+            GithubPrDto pr = prOpt.get();
+            log.setPrNumber(pr.prNumber());
+            log.setPrMerged(pr.merged());
+
+            if (!pr.merged()) {
+                log.setAiPrResult(AiValidationResult.SKIPPED);
+                log.setAiDiffResult(AiValidationResult.SKIPPED);
+                continue;
+            }
+
+            // 5.3 — AI PR review validation
+            List<String> comments = githubSprintService.fetchPRReviewComments(group, pr.prNumber());
+            log.setAiPrResult(aiValidationService.validatePRReview(comments));
+            aiValidationsRun++;
+
+            // 5.4 — AI diff semantics validation
+            List<GithubFileDiffDto> diffs = githubSprintService.fetchFileDiffs(group, pr.prNumber());
+            log.setAiDiffResult(aiValidationService.validateIssueDiff(issue.description(), diffs));
+            aiValidationsRun++;
+        }
+
+        sprintTrackingLogRepository.saveAll(savedLogs);
+
+        return new int[]{savedLogs.size(), aiValidationsRun};
+    }
+}

--- a/backend/src/main/java/com/senior/spm/service/SprintTrackingOrchestrator.java
+++ b/backend/src/main/java/com/senior/spm/service/SprintTrackingOrchestrator.java
@@ -98,8 +98,8 @@ public class SprintTrackingOrchestrator {
      * <p>Guard: when {@code force=false} and the sprint has not yet ended,
      * throws {@link BusinessRuleException} (→ HTTP 400).
      *
-     * <p>Deletes all existing {@code SprintTrackingLog} rows for the sprint before
-     * re-fetching — ensures idempotency (running twice yields the same result).
+     * <p>Idempotency is handled per-group inside {@code processGroup} via
+     * {@code deleteByGroupIdAndSprintId} — no outer bulk delete is needed here.
      *
      * @param sprintId target sprint
      * @param force    when {@code true}, bypasses the sprint-end-date guard
@@ -115,9 +115,6 @@ public class SprintTrackingOrchestrator {
             throw new BusinessRuleException(
                     "Sprint has not ended yet — use ?force=true to refresh early");
         }
-
-        // Wipe existing rows so re-run is idempotent
-        sprintTrackingLogRepository.deleteBySprintId(sprintId);
 
         AtomicInteger groupsProcessed   = new AtomicInteger();
         AtomicInteger issuesFetched     = new AtomicInteger();
@@ -195,7 +192,8 @@ public class SprintTrackingOrchestrator {
             entry.setGroup(group);
             entry.setSprint(sprint);
             entry.setIssueKey(issue.issueKey());
-            entry.setAssigneeGithubUsername(issue.assigneeEmail());
+            // assigneeGithubUsername is set later from pr.authorLogin() (GitHub PR author)
+            // because JIRA assigneeEmail does not match Student.githubUsername
             entry.setStoryPoints(issue.storyPoints());
             entry.setFetchedAt(fetchedAt);
             entry.setAiPrResult(AiValidationResult.PENDING);
@@ -233,6 +231,8 @@ public class SprintTrackingOrchestrator {
             GithubPrDto pr = prOpt.get();
             log.setPrNumber(pr.prNumber());
             log.setPrMerged(pr.merged());
+            // PR author (user.login) is the authoritative GitHub username — overrides JIRA email
+            log.setAssigneeGithubUsername(pr.authorLogin());
 
             if (!pr.merged()) {
                 log.setAiPrResult(AiValidationResult.SKIPPED);

--- a/backend/src/main/java/com/senior/spm/service/dto/GithubPrDto.java
+++ b/backend/src/main/java/com/senior/spm/service/dto/GithubPrDto.java
@@ -24,20 +24,28 @@ public record GithubPrDto(
          * {@code true} when the PR was merged ({@code state=closed} AND
          * {@code merged_at != null}); {@code false} otherwise.
          */
-        boolean merged
+        boolean merged,
+
+        /**
+         * GitHub username of the PR author ({@code user.login} in the API response).
+         * Used as the authoritative identity source for {@code assigneeGithubUsername}
+         * in {@code SprintTrackingLog} — JIRA assignee email is not a reliable match.
+         */
+        String authorLogin
 ) {
 
     /**
      * Factory used by {@link com.senior.spm.service.GithubSprintService} to
-     * derive the merged flag from the raw GitHub API response fields.
+     * derive the merged flag and author from the raw GitHub API response fields.
      *
-     * @param prNumber  the PR number from GitHub's {@code "number"} field
-     * @param state     the value of GitHub's {@code "state"} field
-     * @param mergedAt  the value of GitHub's {@code "merged_at"} field (nullable)
-     * @return a {@code GithubPrDto} with {@code merged} set correctly
+     * @param prNumber    the PR number from GitHub's {@code "number"} field
+     * @param state       the value of GitHub's {@code "state"} field
+     * @param mergedAt    the value of GitHub's {@code "merged_at"} field (nullable)
+     * @param authorLogin the value of GitHub's {@code "user.login"} field (nullable)
+     * @return a {@code GithubPrDto} with {@code merged} and {@code authorLogin} set correctly
      */
-    public static GithubPrDto of(Long prNumber, String state, String mergedAt) {
+    public static GithubPrDto of(Long prNumber, String state, String mergedAt, String authorLogin) {
         boolean merged = "closed".equalsIgnoreCase(state) && mergedAt != null;
-        return new GithubPrDto(prNumber, merged);
+        return new GithubPrDto(prNumber, merged, authorLogin);
     }
 }

--- a/backend/src/main/java/com/senior/spm/service/dto/SprintRefreshStats.java
+++ b/backend/src/main/java/com/senior/spm/service/dto/SprintRefreshStats.java
@@ -1,0 +1,7 @@
+package com.senior.spm.service.dto;
+
+/**
+ * Internal result returned by {@code SprintTrackingOrchestrator.triggerForSprint()}.
+ * The controller maps this to the public {@code SprintRefreshResponse} DTO.
+ */
+public record SprintRefreshStats(int groupsProcessed, int issuesFetched, int aiValidationsRun) {}

--- a/backend/src/test/java/com/senior/spm/service/SprintTrackingOrchestratorTest.java
+++ b/backend/src/test/java/com/senior/spm/service/SprintTrackingOrchestratorTest.java
@@ -1,0 +1,256 @@
+package com.senior.spm.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import com.senior.spm.entity.ProjectGroup;
+import com.senior.spm.entity.ProjectGroup.GroupStatus;
+import com.senior.spm.entity.Sprint;
+import com.senior.spm.entity.SprintTrackingLog;
+import com.senior.spm.entity.SprintTrackingLog.AiValidationResult;
+import com.senior.spm.exception.BusinessRuleException;
+import com.senior.spm.exception.NotFoundException;
+import com.senior.spm.repository.ProjectGroupRepository;
+import com.senior.spm.repository.SprintRepository;
+import com.senior.spm.repository.SprintTrackingLogRepository;
+import com.senior.spm.service.dto.JiraIssueDto;
+import com.senior.spm.service.dto.SprintRefreshStats;
+
+/**
+ * Unit tests for {@link SprintTrackingOrchestrator}.
+ *
+ * <p>Self-proxy design note: {@code SprintTrackingOrchestrator.self} is set to the
+ * real service instance via {@link ReflectionTestUtils} in {@code setUp()}, mirroring
+ * what Spring's {@code @Lazy @Autowired} does at runtime. This is required so that
+ * calls to {@code self.processGroup()} invoke the real method rather than a missing
+ * proxy.
+ *
+ * <p>LENIENT strictness is used because the {@code termConfigService} stub in
+ * {@code @BeforeEach} is not consumed by guard tests that throw before reaching it.
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class SprintTrackingOrchestratorTest {
+
+    @Mock private SprintRepository             sprintRepository;
+    @Mock private ProjectGroupRepository       projectGroupRepository;
+    @Mock private SprintTrackingLogRepository  sprintTrackingLogRepository;
+    @Mock private JiraSprintService            jiraSprintService;
+    @Mock private GithubSprintService          githubSprintService;
+    @Mock private AiValidationService          aiValidationService;
+    @Mock private TermConfigService            termConfigService;
+
+    @InjectMocks
+    private SprintTrackingOrchestrator orchestrator;
+
+    private static final String TERM_ID = "2025-SPRING";
+
+    @BeforeEach
+    void setUp() {
+        // Wire the self-proxy field the same way Spring would at runtime
+        ReflectionTestUtils.setField(orchestrator, "self", orchestrator);
+        when(termConfigService.getActiveTermId()).thenReturn(TERM_ID);
+    }
+
+    // ── helpers ───────────────────────────────────────────────────────────────
+
+    private Sprint sprintEnded(LocalDate endDate) {
+        Sprint s = new Sprint();
+        ReflectionTestUtils.setField(s, "id", UUID.randomUUID());
+        s.setStartDate(endDate.minusDays(14));
+        s.setEndDate(endDate);
+        return s;
+    }
+
+    private ProjectGroup group(GroupStatus status) {
+        ProjectGroup g = new ProjectGroup();
+        ReflectionTestUtils.setField(g, "id", UUID.randomUUID());
+        g.setStatus(status);
+        return g;
+    }
+
+    private JiraIssueDto issue(String key) {
+        return new JiraIssueDto(key, "dev@example.com", 3, "description");
+    }
+
+    // ── triggerForSprint guard tests ──────────────────────────────────────────
+
+    @Nested
+    @DisplayName("triggerForSprint — guard conditions")
+    class TriggerGuards {
+
+        @Test
+        @DisplayName("throws NotFoundException when sprint does not exist")
+        void unknownSprint() {
+            UUID id = UUID.randomUUID();
+            when(sprintRepository.findById(id)).thenReturn(Optional.empty());
+
+            assertThatThrownBy(() -> orchestrator.triggerForSprint(id, false))
+                    .isInstanceOf(NotFoundException.class);
+        }
+
+        @Test
+        @DisplayName("throws BusinessRuleException when sprint has not ended and force=false")
+        void sprintNotEnded_noForce() {
+            Sprint future = sprintEnded(LocalDate.now(ZoneId.of("UTC")).plusDays(3));
+            when(sprintRepository.findById(future.getId())).thenReturn(Optional.of(future));
+
+            assertThatThrownBy(() -> orchestrator.triggerForSprint(future.getId(), false))
+                    .isInstanceOf(BusinessRuleException.class)
+                    .hasMessageContaining("force=true");
+        }
+
+        @Test
+        @DisplayName("proceeds when sprint has not ended but force=true")
+        void sprintNotEnded_withForce() {
+            Sprint future = sprintEnded(LocalDate.now(ZoneId.of("UTC")).plusDays(3));
+            when(sprintRepository.findById(future.getId())).thenReturn(Optional.of(future));
+            when(projectGroupRepository.findByTermIdAndStatusIn(eq(TERM_ID), any()))
+                    .thenReturn(Collections.emptyList());
+
+            SprintRefreshStats stats = orchestrator.triggerForSprint(future.getId(), true);
+
+            assertThat(stats.groupsProcessed()).isZero();
+        }
+
+        @Test
+        @DisplayName("does NOT call deleteBySprintId — idempotency is per-group inside processGroup")
+        void noOuterBulkDelete() {
+            Sprint ended = sprintEnded(LocalDate.now(ZoneId.of("UTC")).minusDays(1));
+            when(sprintRepository.findById(ended.getId())).thenReturn(Optional.of(ended));
+            when(projectGroupRepository.findByTermIdAndStatusIn(eq(TERM_ID), any()))
+                    .thenReturn(Collections.emptyList());
+
+            orchestrator.triggerForSprint(ended.getId(), false);
+
+            verify(sprintTrackingLogRepository, never()).deleteBySprintId(any());
+        }
+    }
+
+    // ── per-group isolation (AC item 3) ───────────────────────────────────────
+
+    @Nested
+    @DisplayName("per-group isolation — failing group must not block others")
+    class GroupIsolation {
+
+        @Test
+        @DisplayName("group 2 JIRA failure does not prevent groups 1 and 3 from being tracked")
+        void jiraFailureOnGroup2_doesNotBlockOthers() {
+            Sprint ended = sprintEnded(LocalDate.now(ZoneId.of("UTC")).minusDays(1));
+            when(sprintRepository.findById(ended.getId())).thenReturn(Optional.of(ended));
+
+            ProjectGroup g1 = group(GroupStatus.TOOLS_BOUND);
+            ProjectGroup g2 = group(GroupStatus.ADVISOR_ASSIGNED);
+            ProjectGroup g3 = group(GroupStatus.TOOLS_BOUND);
+
+            when(projectGroupRepository.findByTermIdAndStatusIn(eq(TERM_ID), any()))
+                    .thenReturn(List.of(g1, g2, g3));
+
+            // g1 and g3 return one issue each; g2 throws
+            when(jiraSprintService.fetchSprintStories(g1))
+                    .thenReturn(List.of(issue("SPM-1")));
+            when(jiraSprintService.fetchSprintStories(g2))
+                    .thenThrow(new RuntimeException("JIRA auth failure for group 2"));
+            when(jiraSprintService.fetchSprintStories(g3))
+                    .thenReturn(List.of(issue("SPM-3")));
+
+            // GitHub returns empty for all — no branch found, AI skipped
+            when(githubSprintService.findBranchByIssueKey(any(), any()))
+                    .thenReturn(Optional.empty());
+
+            // saveAll echoes the argument back
+            when(sprintTrackingLogRepository.saveAll(any()))
+                    .thenAnswer(inv -> inv.getArgument(0));
+
+            SprintRefreshStats stats = orchestrator.triggerForSprint(ended.getId(), false);
+
+            // g1 and g3 processed successfully; g2 skipped due to exception
+            assertThat(stats.groupsProcessed()).isEqualTo(2);
+            assertThat(stats.issuesFetched()).isEqualTo(2);
+
+            // processGroup calls saveAll twice per group (initial persist + post-GitHub update)
+            // g2 threw before saveAll was reached → 2 groups × 2 calls = 4 total
+            verify(sprintTrackingLogRepository, times(4)).saveAll(any());
+
+            // JIRA was attempted for all three groups — failure on g2 did not abort the loop
+            verify(jiraSprintService, times(1)).fetchSprintStories(g1);
+            verify(jiraSprintService, times(1)).fetchSprintStories(g2);
+            verify(jiraSprintService, times(1)).fetchSprintStories(g3);
+        }
+
+        @Test
+        @DisplayName("rows for groups 1 and 3 have correct issueKey and SKIPPED AI (no branch found)")
+        void savedLogsHaveCorrectFinalState() {
+            Sprint ended = sprintEnded(LocalDate.now(ZoneId.of("UTC")).minusDays(1));
+            when(sprintRepository.findById(ended.getId())).thenReturn(Optional.of(ended));
+
+            ProjectGroup g1 = group(GroupStatus.TOOLS_BOUND);
+            ProjectGroup g3 = group(GroupStatus.ADVISOR_ASSIGNED);
+
+            when(projectGroupRepository.findByTermIdAndStatusIn(eq(TERM_ID), any()))
+                    .thenReturn(List.of(g1, g3));
+
+            when(jiraSprintService.fetchSprintStories(g1))
+                    .thenReturn(List.of(issue("SPM-10")));
+            when(jiraSprintService.fetchSprintStories(g3))
+                    .thenReturn(List.of(issue("SPM-30")));
+
+            // No branch found → AI results set to SKIPPED
+            when(githubSprintService.findBranchByIssueKey(any(), any()))
+                    .thenReturn(Optional.empty());
+
+            // saveAll echoes argument back; the list is mutated in place between the two
+            // calls (initial persist → post-GitHub update), so we capture the final state
+            @SuppressWarnings("unchecked")
+            ArgumentCaptor<List<SprintTrackingLog>> captor =
+                    ArgumentCaptor.forClass(List.class);
+            when(sprintTrackingLogRepository.saveAll(captor.capture()))
+                    .thenAnswer(inv -> inv.getArgument(0));
+
+            orchestrator.triggerForSprint(ended.getId(), false);
+
+            // 2 groups × 2 saveAll calls each = 4 total captures
+            List<List<SprintTrackingLog>> allSaved = captor.getAllValues();
+            assertThat(allSaved).hasSize(4);
+
+            // Captures: [g1-initial, g1-final, g3-initial, g3-final]
+            // The list object is reused, so both g1 captures reference the same instance
+            // — check the final (index 1 and 3) which reflect post-GitHub state
+            SprintTrackingLog log1 = allSaved.get(1).get(0);
+            assertThat(log1.getIssueKey()).isEqualTo("SPM-10");
+            assertThat(log1.getAiPrResult()).isEqualTo(AiValidationResult.SKIPPED);
+            assertThat(log1.getAiDiffResult()).isEqualTo(AiValidationResult.SKIPPED);
+
+            SprintTrackingLog log3 = allSaved.get(3).get(0);
+            assertThat(log3.getIssueKey()).isEqualTo("SPM-30");
+            assertThat(log3.getAiPrResult()).isEqualTo(AiValidationResult.SKIPPED);
+            assertThat(log3.getAiDiffResult()).isEqualTo(AiValidationResult.SKIPPED);
+        }
+    }
+}


### PR DESCRIPTION
P5-05 (#153 )is complete. Here's a summary of what was implemented:

SprintTrackingOrchestrator.java — new service; @Scheduled daily job + triggerForSprint() with self-proxy + REQUIRES_NEW pattern 
SprintRefreshStats.java — new internal DTO record 
JiraSprintService.java — added fetchSprintStories(group) overload with 3-step JIRA resolution
ProjectGroupRepository.java — added findByTermIdAndStatusIn 
AiValidationService.java — added validateIssueDiff stub (returns PENDING; replaced by #152)

Resolved #153 