### PR TITLE
feat: implement AI diff semantics validator (#152)

### DIFF
--- a/backend/src/main/java/com/senior/spm/service/AiValidationService.java
+++ b/backend/src/main/java/com/senior/spm/service/AiValidationService.java
@@ -19,6 +19,7 @@ import org.springframework.web.client.RestClientResponseException;
 import java.time.Duration;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Collectors;
 
 @Slf4j
 @Service
@@ -31,6 +32,14 @@ public class AiValidationService {
             "PASS if the review is substantive, " +
             "WARN if it is minimal or superficial, " +
             "FAIL if it is empty or purely cosmetic.\n\n";
+    // Section labels are included in the constant so the assembled prompt reads:
+    // [instruction] Issue description: [description] Code diff: [patches]
+    private static final String DIFF_VALIDATION_PROMPT =
+            "Compare the following issue description and code diff, then respond with only one word: " +
+            "PASS if the changes clearly implement the issue, " +
+            "WARN if the match is partial or unclear, " +
+            "FAIL if the changes are unrelated to the issue.\n\n" +
+            "Issue description:\n";
     private static final int  MAX_ATTEMPTS    = 3;
     private static final long INITIAL_RETRY_MS = 5_000;  // 5 s → 10 s → 20 s
     private static final long MAX_RETRY_MS     = 60_000; // cap at 60 s
@@ -200,9 +209,54 @@ public class AiValidationService {
         }
     }
 
-    // TODO: replaced by P5-04b (Batıkan) — stub returns PENDING during development
+    /**
+     * Validates whether the code diff implements the JIRA issue using Gemini Flash Lite.
+     *
+     * @param issueDescription JIRA issue description body
+     * @param fileDiffs        list of file diffs from the merged PR
+     * @return SKIPPED if fileDiffs is empty/null, issueDescription is blank/null,
+     *         or all patches are null (e.g. binary-only PR);
+     *         PASS/WARN/FAIL per LLM judgement;
+     *         WARN on any error (timeout, 5xx, parse failure, missing key) — never throws
+     */
     public AiValidationResult validateIssueDiff(String issueDescription, List<GithubFileDiffDto> fileDiffs) {
-        return AiValidationResult.PENDING;
+        if (fileDiffs == null || fileDiffs.isEmpty()) {
+            return AiValidationResult.SKIPPED;
+        }
+        if (issueDescription == null || issueDescription.isBlank()) {
+            return AiValidationResult.SKIPPED;
+        }
+
+        // Filter null patches upfront — GithubFileDiffDto.patch is null for binary/oversized files.
+        // If no usable patch text remains, there is nothing meaningful to validate.
+        String patches = fileDiffs.stream()
+                .map(GithubFileDiffDto::patch)
+                .filter(p -> p != null && !p.isBlank())
+                .collect(Collectors.joining("\n"));
+
+        if (patches.isBlank()) {
+            return AiValidationResult.SKIPPED;
+        }
+
+        try {
+            String apiKey = resolveApiKey();
+            if (apiKey == null) return AiValidationResult.WARN;
+
+            String promptText = DIFF_VALIDATION_PROMPT + issueDescription + "\n\nCode diff:\n" + patches;
+            var request = new GeminiRequest(
+                    List.of(new GeminiContent(List.of(new GeminiPart(promptText)))),
+                    new GeminiRequest.GenerationConfig(10, 0.0)
+            );
+
+            return callWithRetry(request, apiKey);
+
+        } catch (ResourceAccessException ex) {
+            log.warn("LLM diff validation timed out or connection failed — returning WARN: {}", ex.getMessage());
+            return AiValidationResult.WARN;
+        } catch (Exception ex) {
+            log.warn("Unexpected error during AI diff validation — returning WARN: {}", ex.getMessage());
+            return AiValidationResult.WARN;
+        }
     }
 
     // ── Gemini request records ────────────────────────────────────────────────

--- a/backend/src/test/java/com/senior/spm/service/AiValidationServiceTest.java
+++ b/backend/src/test/java/com/senior/spm/service/AiValidationServiceTest.java
@@ -2,6 +2,7 @@ package com.senior.spm.service;
 
 import com.senior.spm.entity.SprintTrackingLog.AiValidationResult;
 import com.senior.spm.repository.SystemConfigRepository;
+import com.senior.spm.service.dto.GithubFileDiffDto;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -20,7 +21,7 @@ import static org.mockito.Mockito.when;
 /**
  * Unit tests for AiValidationService — non-HTTP branches only.
  * HTTP-response branches (PASS/WARN/FAIL/timeout/5xx) are covered in AiValidationWireMockTest.
- * Issue: #151
+ * Issue: #151, #152
  */
 @ExtendWith(MockitoExtension.class)
 class AiValidationServiceTest {
@@ -78,6 +79,80 @@ class AiValidationServiceTest {
         service.validatePRReview(List.of());
 
         verify(systemConfigRepository, never()).findById("llm_api_key");
+        verify(llmClient, never()).post();
+    }
+
+    // ── validateIssueDiff — empty / null inputs → SKIPPED, zero HTTP calls ───
+
+    @Test
+    void validateIssueDiff_emptyFileDiffs_returnsSkipped() {
+        AiValidationResult result = service.validateIssueDiff("Implement login feature", List.of());
+
+        assertThat(result).isEqualTo(AiValidationResult.SKIPPED);
+        verify(llmClient, never()).post();
+    }
+
+    @Test
+    void validateIssueDiff_nullFileDiffs_returnsSkipped() {
+        AiValidationResult result = service.validateIssueDiff("Implement login feature", null);
+
+        assertThat(result).isEqualTo(AiValidationResult.SKIPPED);
+        verify(llmClient, never()).post();
+    }
+
+    @Test
+    void validateIssueDiff_blankDescription_returnsSkipped() {
+        AiValidationResult result = service.validateIssueDiff(
+                "   ",
+                List.of(new GithubFileDiffDto("Foo.java", "@@ -1,1 +1,2 @@\n+new line")));
+
+        assertThat(result).isEqualTo(AiValidationResult.SKIPPED);
+        verify(llmClient, never()).post();
+    }
+
+    @Test
+    void validateIssueDiff_nullDescription_returnsSkipped() {
+        AiValidationResult result = service.validateIssueDiff(
+                null,
+                List.of(new GithubFileDiffDto("Foo.java", "@@ -1,1 +1,2 @@\n+new line")));
+
+        assertThat(result).isEqualTo(AiValidationResult.SKIPPED);
+        verify(llmClient, never()).post();
+    }
+
+    // ── All-null patches (binary/oversized files) → SKIPPED, no DB lookup ────
+
+    @Test
+    void validateIssueDiff_allNullPatches_returnsSkipped() {
+        AiValidationResult result = service.validateIssueDiff(
+                "Add payment support",
+                List.of(new GithubFileDiffDto("binary.png", null)));
+
+        assertThat(result).isEqualTo(AiValidationResult.SKIPPED);
+        // Patch filtering happens before DB lookup — no repository call expected
+        verify(systemConfigRepository, never()).findById("llm_api_key");
+        verify(llmClient, never()).post();
+    }
+
+    @Test
+    void validateIssueDiff_emptyDiffs_doesNotQueryRepository() {
+        service.validateIssueDiff("some description", List.of());
+
+        verify(systemConfigRepository, never()).findById("llm_api_key");
+        verify(llmClient, never()).post();
+    }
+
+    // ── Missing llm_api_key with valid inputs → WARN, zero HTTP calls ────────
+
+    @Test
+    void validateIssueDiff_missingLlmKey_returnsWarn_noHttpCall() {
+        when(systemConfigRepository.findById("llm_api_key")).thenReturn(Optional.empty());
+
+        AiValidationResult result = service.validateIssueDiff(
+                "Fix null pointer in service",
+                List.of(new GithubFileDiffDto("Service.java", "@@ -5,1 +5,2 @@\n+null check")));
+
+        assertThat(result).isEqualTo(AiValidationResult.WARN);
         verify(llmClient, never()).post();
     }
 

--- a/backend/src/test/java/com/senior/spm/service/AiValidationWireMockTest.java
+++ b/backend/src/test/java/com/senior/spm/service/AiValidationWireMockTest.java
@@ -5,6 +5,7 @@ import com.github.tomakehurst.wiremock.client.WireMock;
 import com.senior.spm.entity.SystemConfig;
 import com.senior.spm.entity.SprintTrackingLog.AiValidationResult;
 import com.senior.spm.repository.SystemConfigRepository;
+import com.senior.spm.service.dto.GithubFileDiffDto;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
@@ -27,7 +28,7 @@ import static org.mockito.Mockito.when;
 /**
  * WireMock integration tests for AiValidationService — covers all HTTP-response branches.
  * Non-HTTP branches (SKIPPED, missing key) are covered in AiValidationServiceTest.
- * Issue: #151
+ * Issue: #151, #152
  */
 class AiValidationWireMockTest {
 
@@ -198,6 +199,169 @@ class AiValidationWireMockTest {
         stubGemini(200, geminiBody("PASS"));
 
         service.validatePRReview(List.of("Some review"));
+
+        wireMockServer.verify(1,
+                WireMock.postRequestedFor(urlPathEqualTo(GEMINI_PATH))
+                        .withHeader("Content-Type", WireMock.containing(MediaType.APPLICATION_JSON_VALUE)));
+    }
+
+    // ── validateIssueDiff — LLM returns PASS / WARN / FAIL ───────────────────
+
+    @Test
+    void validateIssueDiff_geminiReturnsPass_returnsPass() {
+        stubGemini(200, geminiBody("PASS"));
+
+        AiValidationResult result = service.validateIssueDiff(
+                "Implement login endpoint with JWT",
+                List.of(new GithubFileDiffDto("LoginController.java", "@@ -0,0 +1,10 @@\n+public void login() {}")));
+
+        assertThat(result).isEqualTo(AiValidationResult.PASS);
+    }
+
+    @Test
+    void validateIssueDiff_geminiReturnsWarn_returnsWarn() {
+        stubGemini(200, geminiBody("WARN"));
+
+        AiValidationResult result = service.validateIssueDiff(
+                "Add full user registration flow",
+                List.of(new GithubFileDiffDto("UserService.java", "@@ -5,1 +5,3 @@\n+// partial impl")));
+
+        assertThat(result).isEqualTo(AiValidationResult.WARN);
+    }
+
+    @Test
+    void validateIssueDiff_geminiReturnsFail_returnsFail() {
+        stubGemini(200, geminiBody("FAIL"));
+
+        AiValidationResult result = service.validateIssueDiff(
+                "Fix payment processing bug",
+                List.of(new GithubFileDiffDto("README.md", "@@ -1,1 +1,1 @@\n-typo\n+typo fix")));
+
+        assertThat(result).isEqualTo(AiValidationResult.FAIL);
+    }
+
+    // ── validateIssueDiff — request body contains both description and diff ──
+
+    @Test
+    void validateIssueDiff_requestBodyContainsDescriptionAndPatch() {
+        stubGemini(200, geminiBody("PASS"));
+
+        service.validateIssueDiff(
+                "Implement login endpoint with JWT",
+                List.of(new GithubFileDiffDto("LoginController.java", "@@ -0,0 +1,10 @@\n+public void login() {}")));
+
+        wireMockServer.verify(1,
+                WireMock.postRequestedFor(urlPathEqualTo(GEMINI_PATH))
+                        .withRequestBody(WireMock.containing("Implement login endpoint with JWT"))
+                        .withRequestBody(WireMock.containing("public void login()")));
+    }
+
+    // ── validateIssueDiff — unrecognised / lowercase LLM output ─────────────
+
+    @Test
+    void validateIssueDiff_geminiReturnsGarbledOutput_returnsWarn() {
+        stubGemini(200, geminiBody("The changes look related to me."));
+
+        AiValidationResult result = service.validateIssueDiff(
+                "Fix NPE in service",
+                List.of(new GithubFileDiffDto("Service.java", "@@ -10,1 +10,2 @@\n+null check")));
+
+        assertThat(result).isEqualTo(AiValidationResult.WARN);
+    }
+
+    @Test
+    void validateIssueDiff_geminiReturnsLowercasePass_returnsPass() {
+        stubGemini(200, geminiBody("pass"));
+
+        AiValidationResult result = service.validateIssueDiff(
+                "Add null check to service layer",
+                List.of(new GithubFileDiffDto("Service.java", "@@ -10,1 +10,2 @@\n+null check")));
+
+        assertThat(result).isEqualTo(AiValidationResult.PASS);
+    }
+
+    // ── validateIssueDiff — HTTP error branches → WARN ───────────────────────
+
+    @Test
+    void validateIssueDiff_gemini500_returnsWarn_noException() {
+        stubGemini(500, "{\"error\":{\"message\":\"Internal server error\"}}");
+
+        assertThatCode(() -> {
+            AiValidationResult result = service.validateIssueDiff(
+                    "Fix NPE in service layer",
+                    List.of(new GithubFileDiffDto("Service.java", "@@ -10,1 +10,2 @@\n+null check")));
+            assertThat(result).isEqualTo(AiValidationResult.WARN);
+        }).doesNotThrowAnyException();
+    }
+
+    @Test
+    void validateIssueDiff_gemini503_returnsWarn_noException() {
+        stubGemini(503, "{\"error\":{\"message\":\"Service unavailable\"}}");
+
+        assertThatCode(() -> {
+            AiValidationResult result = service.validateIssueDiff(
+                    "Fix NPE in service layer",
+                    List.of(new GithubFileDiffDto("Service.java", "@@ -10,1 +10,2 @@\n+null check")));
+            assertThat(result).isEqualTo(AiValidationResult.WARN);
+        }).doesNotThrowAnyException();
+    }
+
+    // ── validateIssueDiff — timeout → WARN, no exception propagated ──────────
+
+    @Test
+    void validateIssueDiff_geminiTimeout_returnsWarn_noException() {
+        // 2s delay exceeds the 1s timeout configured in setUp()
+        wireMockServer.stubFor(post(urlPathEqualTo(GEMINI_PATH))
+                .willReturn(aResponse()
+                        .withStatus(200)
+                        .withFixedDelay(2000)
+                        .withBody(geminiBody("PASS"))));
+
+        assertThatCode(() -> {
+            AiValidationResult result = service.validateIssueDiff(
+                    "Fix NPE in service layer",
+                    List.of(new GithubFileDiffDto("Service.java", "@@ -10,1 +10,2 @@\n+null check")));
+            assertThat(result).isEqualTo(AiValidationResult.WARN);
+        }).doesNotThrowAnyException();
+    }
+
+    // ── validateIssueDiff — empty candidates list in response → WARN ─────────
+
+    @Test
+    void validateIssueDiff_emptyCandidates_returnsWarn() {
+        stubGemini(200, "{\"candidates\":[]}");
+
+        AiValidationResult result = service.validateIssueDiff(
+                "Fix NPE in service layer",
+                List.of(new GithubFileDiffDto("Service.java", "@@ -10,1 +10,2 @@\n+null check")));
+
+        assertThat(result).isEqualTo(AiValidationResult.WARN);
+    }
+
+    // ── validateIssueDiff — API key is passed as query parameter ─────────────
+
+    @Test
+    void validateIssueDiff_sendsApiKeyAsQueryParam() {
+        stubGemini(200, geminiBody("PASS"));
+
+        service.validateIssueDiff(
+                "Fix NPE in service layer",
+                List.of(new GithubFileDiffDto("Service.java", "@@ -10,1 +10,2 @@\n+null check")));
+
+        wireMockServer.verify(1,
+                WireMock.postRequestedFor(urlPathEqualTo(GEMINI_PATH))
+                        .withQueryParam("key", WireMock.equalTo(FAKE_PLAIN_KEY)));
+    }
+
+    // ── validateIssueDiff — Content-Type header is set to application/json ───
+
+    @Test
+    void validateIssueDiff_setsJsonContentType() {
+        stubGemini(200, geminiBody("PASS"));
+
+        service.validateIssueDiff(
+                "Fix NPE in service layer",
+                List.of(new GithubFileDiffDto("Service.java", "@@ -10,1 +10,2 @@\n+null check")));
 
         wireMockServer.verify(1,
                 WireMock.postRequestedFor(urlPathEqualTo(GEMINI_PATH))


### PR DESCRIPTION
## Summary

Implements `validateIssueDiff()` in `AiValidationService` — the second half of the AI
validation pipeline (sub-process 5.4). This method validates whether the code changes
in a merged PR actually address the linked JIRA issue by sending both the issue
description and the file diffs to the Gemini Flash Lite LLM and returning a
`PASS`, `WARN`, `FAIL`, or `SKIPPED` result.

Resolves #152

Depends on: #151 (AiValidationService infrastructure), #150 (GithubFileDiffDto), #148 (AiValidationResult enum)

---

## What Was Implemented

### `AiValidationService.java`

Replaced the development stub (`return AiValidationResult.PENDING`) with the full implementation.

**Guard logic (evaluated before any DB or HTTP call):**
- `fileDiffs` is null or empty → returns `SKIPPED` immediately
- `issueDescription` is null or blank → returns `SKIPPED` immediately
- All patches in the list are null (binary files or diffs exceeding GitHub's size limit,
  as documented in `GithubFileDiffDto`) → returns `SKIPPED` without hitting the database

**LLM request construction:**
- Non-null patches are filtered and joined with `\n`
- The prompt is assembled with explicit section labels:
  `DIFF_VALIDATION_PROMPT + "Issue description:\n" + issueDescription + "\n\nCode diff:\n" + patches`
- Section labels (`Issue description:` / `Code diff:`) were added to make the
  structure unambiguous for the LLM regardless of content length

**`DIFF_VALIDATION_PROMPT` constant:**
```
Compare the following issue description and code diff, then respond with only one word:
PASS if the changes clearly implement the issue,
WARN if the match is partial or unclear,
FAIL if the changes are unrelated to the issue.
```
Defined as a separate constant from `PR_REVIEW_PROMPT` — both are independently readable.

**Zero infrastructure duplication:**
`callWithRetry()`, `resolveApiKey()`, and `parseResult()` are reused directly from
the existing class. No new HTTP client, no copy-pasted retry logic, no duplicate
timeout or error handling.

**Error handling (unchanged contract):**
- `ResourceAccessException` (timeout / connection failure) → `WARN`, never throws
- Any unexpected exception → `WARN`, never throws
- Missing `llm_api_key` in `system_config` → `WARN`, no HTTP call

---

## How It Works

```
SprintTrackingOrchestrator
  └─► validateIssueDiff(issueDescription, fileDiffs)
        │
        ├─ fileDiffs empty / null          → SKIPPED
        ├─ issueDescription blank / null   → SKIPPED
        ├─ all patches null (binary files) → SKIPPED
        │
        ├─ resolveApiKey() → null          → WARN
        │
        └─ callWithRetry(GeminiRequest)
              │
              ├─ LLM responds "PASS"       → PASS
              ├─ LLM responds "WARN"       → WARN
              ├─ LLM responds "FAIL"       → FAIL
              ├─ unrecognised output       → WARN
              ├─ HTTP 5xx                  → WARN
              ├─ HTTP 429 (rate limit)     → retry up to 3x with backoff
              └─ timeout / network error  → WARN
```

---

## Tests

### `AiValidationServiceTest` — Mockito (non-HTTP branches)

| Test | Verifies |
|------|----------|
| `validateIssueDiff_emptyFileDiffs_returnsSkipped` | Empty list → SKIPPED, no HTTP call |
| `validateIssueDiff_nullFileDiffs_returnsSkipped` | Null list → SKIPPED, no HTTP call |
| `validateIssueDiff_blankDescription_returnsSkipped` | Whitespace-only description → SKIPPED |
| `validateIssueDiff_nullDescription_returnsSkipped` | Null description → SKIPPED |
| `validateIssueDiff_allNullPatches_returnsSkipped` | Binary-only PR → SKIPPED, no DB hit |
| `validateIssueDiff_emptyDiffs_doesNotQueryRepository` | Empty list guard fires before DB lookup |
| `validateIssueDiff_missingLlmKey_returnsWarn_noHttpCall` | Missing key → WARN, no HTTP call |

### `AiValidationWireMockTest` — WireMock (HTTP branches)

| Test | Verifies |
|------|----------|
| `validateIssueDiff_geminiReturnsPass_returnsPass` | LLM "PASS" → PASS |
| `validateIssueDiff_geminiReturnsWarn_returnsWarn` | LLM "WARN" → WARN |
| `validateIssueDiff_geminiReturnsFail_returnsFail` | LLM "FAIL" → FAIL |
| `validateIssueDiff_requestBodyContainsDescriptionAndPatch` | Request body includes both description text and diff patch |
| `validateIssueDiff_geminiReturnsGarbledOutput_returnsWarn` | Non-keyword output → WARN (default branch in `parseResult`) |
| `validateIssueDiff_geminiReturnsLowercasePass_returnsPass` | `.trim().toUpperCase()` normalisation |
| `validateIssueDiff_gemini500_returnsWarn_noException` | HTTP 500 → WARN, no exception propagated |
| `validateIssueDiff_gemini503_returnsWarn_noException` | HTTP 503 → WARN, no exception propagated |
| `validateIssueDiff_geminiTimeout_returnsWarn_noException` | `ResourceAccessException` catch branch |
| `validateIssueDiff_emptyCandidates_returnsWarn` | Empty candidates list → `parseResult` exception → WARN |
| `validateIssueDiff_sendsApiKeyAsQueryParam` | API key sent as `?key=` query parameter |
| `validateIssueDiff_setsJsonContentType` | `Content-Type: application/json` header present |

**Total: 34 tests — 0 failures**

---

## Acceptance Criteria

| Criterion | Status |
|-----------|--------|
| Empty `fileDiffs` → `SKIPPED`, no HTTP call | ✅ |
| Blank `issueDescription` → `SKIPPED`, no HTTP call | ✅ |
| Reuses HTTP client and error handler — no duplicate logic | ✅ |
| `DIFF_VALIDATION_PROMPT` is a separate constant from `PR_REVIEW_PROMPT` | ✅ |
| Unit tests: PASS, WARN, FAIL, empty diffs → SKIPPED, blank description → SKIPPED | ✅ |

**Extra (not in spec, added defensively):**
- All-null patches (binary-only PRs) → `SKIPPED` — documented in `GithubFileDiffDto`
  as an expected caller responsibility
- Null `issueDescription` guard in addition to blank check
- Full Javadoc on `validateIssueDiff` documenting all SKIPPED paths and WARN-on-error contract
- Class Javadoc updated in both test files to reference `Issue: #151, #152`
