### PR TITLE
Fix known bugs in Process 5 sprint tracking pipeline

### DIFF
--- a/backend/src/main/java/com/senior/spm/controller/AdvisorController.java
+++ b/backend/src/main/java/com/senior/spm/controller/AdvisorController.java
@@ -13,6 +13,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.senior.spm.controller.request.AdvisorRespondRequest;
@@ -191,9 +192,10 @@ public class AdvisorController {
     @GetMapping("/sprints/{sprintId}/groups")
     public ResponseEntity<List<AdvisorGroupSprintSummaryResponse>> getAdvisorGroupSummaries(
             @PathVariable UUID sprintId,
+            @RequestParam(required = false, defaultValue = "false") boolean includeDisbanded,
             Authentication auth) {
         UUID advisorId = SecurityUtils.extractPrincipalUUID(auth);
-        return ResponseEntity.ok(scrumGradingService.getAdvisorGroupSummaries(advisorId, sprintId));
+        return ResponseEntity.ok(scrumGradingService.getAdvisorGroupSummaries(advisorId, sprintId, includeDisbanded));
     }
 
     // GET /api/advisor/sprints/{sprintId}/groups/{groupId}/tracking

--- a/backend/src/main/java/com/senior/spm/service/JiraSprintService.java
+++ b/backend/src/main/java/com/senior/spm/service/JiraSprintService.java
@@ -37,6 +37,16 @@ public class JiraSprintService {
      *
      * <p>Board not found or no active sprint → logs WARN and returns empty list. Never throws.
      */
+    private String buildAuthHeader(ProjectGroup group) {
+        String decryptedToken = encryptionService.decrypt(group.getEncryptedJiraToken());
+        String authString = group.getJiraEmail().strip() + ":" + decryptedToken;
+        return "Basic " + Base64.getEncoder().encodeToString(authString.getBytes(StandardCharsets.UTF_8));
+    }
+
+    private String buildBaseUrl(ProjectGroup group) {
+        return group.getJiraSpaceUrl().strip().replaceAll("/+$", "");
+    }
+
     public List<JiraIssueDto> fetchSprintStories(ProjectGroup group) {
         if (group.getJiraSpaceUrl() == null || group.getJiraEmail() == null
                 || group.getEncryptedJiraToken() == null || group.getJiraProjectKey() == null) {
@@ -44,16 +54,14 @@ public class JiraSprintService {
             return Collections.emptyList();
         }
         try {
-            String decryptedToken = encryptionService.decrypt(group.getEncryptedJiraToken());
-            String authString = group.getJiraEmail().strip() + ":" + decryptedToken;
-            String base64Auth = Base64.getEncoder().encodeToString(authString.getBytes(StandardCharsets.UTF_8));
-            String baseUrl = group.getJiraSpaceUrl().strip().replaceAll("/+$", "");
+            String base64Auth = buildAuthHeader(group);
+            String baseUrl = buildBaseUrl(group);
 
             // Step 1: resolve boardId from project key
             String boardUrl = baseUrl + "/rest/agile/1.0/board?projectKeyOrId=" + group.getJiraProjectKey();
             JsonNode boardResp = restClient.get()
                     .uri(boardUrl)
-                    .header(HttpHeaders.AUTHORIZATION, "Basic " + base64Auth)
+                    .header(HttpHeaders.AUTHORIZATION, base64Auth)
                     .header(HttpHeaders.ACCEPT, "application/json")
                     .retrieve()
                     .body(JsonNode.class);
@@ -69,7 +77,7 @@ public class JiraSprintService {
             String sprintUrl = baseUrl + "/rest/agile/1.0/board/" + boardId + "/sprint?state=active";
             JsonNode sprintResp = restClient.get()
                     .uri(sprintUrl)
-                    .header(HttpHeaders.AUTHORIZATION, "Basic " + base64Auth)
+                    .header(HttpHeaders.AUTHORIZATION, base64Auth)
                     .header(HttpHeaders.ACCEPT, "application/json")
                     .retrieve()
                     .body(JsonNode.class);
@@ -108,11 +116,8 @@ public class JiraSprintService {
         }
 
         try {
-            String decryptedToken = encryptionService.decrypt(group.getEncryptedJiraToken());
-            String authString = group.getJiraEmail().strip() + ":" + decryptedToken;
-            String base64Auth = Base64.getEncoder().encodeToString(authString.getBytes(StandardCharsets.UTF_8));
-            
-            String baseUrl = group.getJiraSpaceUrl().strip().replaceAll("/+$", "");
+            String base64Auth = buildAuthHeader(group);
+            String baseUrl = buildBaseUrl(group);
             
             List<JiraIssueDto> dtos = new ArrayList<>();
             int startAt = 0;
@@ -123,7 +128,7 @@ public class JiraSprintService {
 
                 JsonNode response = restClient.get()
                         .uri(url)
-                        .header(HttpHeaders.AUTHORIZATION, "Basic " + base64Auth)
+                        .header(HttpHeaders.AUTHORIZATION, base64Auth)
                         .header(HttpHeaders.ACCEPT, "application/json")
                         .retrieve()
                         .body(JsonNode.class);
@@ -150,9 +155,9 @@ public class JiraSprintService {
                         }
                     }
 
-                    Integer storyPoints = null;
+                    Double storyPoints = null;
                     if (fields.hasNonNull("customfield_10016")) {
-                        storyPoints = fields.get("customfield_10016").asInt();
+                        storyPoints = fields.get("customfield_10016").asDouble();
                     }
 
                     String description = null;

--- a/backend/src/main/java/com/senior/spm/service/ScrumGradingService.java
+++ b/backend/src/main/java/com/senior/spm/service/ScrumGradingService.java
@@ -21,6 +21,7 @@ import com.senior.spm.controller.response.SprintTrackingResponse;
 import com.senior.spm.controller.response.TrackingIssueResponse;
 import com.senior.spm.controller.request.ScrumGradeRequest;
 import com.senior.spm.entity.ProjectGroup;
+import com.senior.spm.entity.ProjectGroup.GroupStatus;
 import com.senior.spm.entity.ScrumGrade;
 import com.senior.spm.entity.ScrumGrade.ScrumGradeValue;
 import com.senior.spm.entity.Sprint;
@@ -118,14 +119,30 @@ public class ScrumGradingService {
     // -------------------------------------------------------------------------
 
     @Transactional(readOnly = true)
-    public List<AdvisorGroupSprintSummaryResponse> getAdvisorGroupSummaries(UUID advisorId, UUID sprintId) {
+    public List<AdvisorGroupSprintSummaryResponse> getAdvisorGroupSummaries(UUID advisorId, UUID sprintId, boolean includeDisbanded) {
         findSprintOrThrow(sprintId);
 
         String termId = termConfigService.getActiveTermId();
-        List<ProjectGroup> groups = projectGroupRepository.findByAdvisor_IdAndTermId(advisorId, termId);
+        List<ProjectGroup> groups = projectGroupRepository.findByAdvisor_IdAndTermId(advisorId, termId)
+                .stream()
+                .filter(g -> includeDisbanded || g.getStatus() != GroupStatus.DISBANDED)
+                .toList();
+
+        // Batch-fetch all tracking logs and grades for the sprint in 2 queries (avoids N+1)
+        Map<UUID, List<SprintTrackingLog>> logsByGroup = sprintTrackingLogRepository
+                .findBySprintId(sprintId)
+                .stream()
+                .collect(Collectors.groupingBy(l -> l.getGroup().getId()));
+
+        Map<UUID, ScrumGrade> gradeByGroup = scrumGradeRepository
+                .findBySprintId(sprintId)
+                .stream()
+                .collect(Collectors.toMap(g -> g.getGroup().getId(), g -> g));
 
         return groups.stream()
-                .map(group -> buildGroupSummary(group, sprintId))
+                .map(group -> buildGroupSummary(group,
+                        logsByGroup.getOrDefault(group.getId(), List.of()),
+                        gradeByGroup.get(group.getId())))
                 .toList();
     }
 
@@ -219,11 +236,22 @@ public class ScrumGradingService {
         }
     }
 
+    /** Pre-fetched variant — used by getAdvisorGroupSummaries to avoid N+1. */
+    private AdvisorGroupSprintSummaryResponse buildGroupSummary(
+            ProjectGroup group, List<SprintTrackingLog> logs, ScrumGrade grade) {
+        return buildGroupSummaryFromData(group, logs, Optional.ofNullable(grade));
+    }
+
     private AdvisorGroupSprintSummaryResponse buildGroupSummary(ProjectGroup group, UUID sprintId) {
         List<SprintTrackingLog> logs = sprintTrackingLogRepository
                 .findByGroupIdAndSprintId(group.getId(), sprintId);
         Optional<ScrumGrade> grade = scrumGradeRepository
                 .findByGroupIdAndSprintId(group.getId(), sprintId);
+        return buildGroupSummaryFromData(group, logs, grade);
+    }
+
+    private AdvisorGroupSprintSummaryResponse buildGroupSummaryFromData(
+            ProjectGroup group, List<SprintTrackingLog> logs, Optional<ScrumGrade> grade) {
 
         long mergedPRs = logs.stream().filter(l -> Boolean.TRUE.equals(l.getPrMerged())).count();
 

--- a/backend/src/main/java/com/senior/spm/service/SprintTrackingOrchestrator.java
+++ b/backend/src/main/java/com/senior/spm/service/SprintTrackingOrchestrator.java
@@ -176,13 +176,15 @@ public class SprintTrackingOrchestrator {
         // 5.1 — fetch JIRA stories (resolves active sprint internally)
         List<JiraIssueDto> issues = jiraSprintService.fetchSprintStories(group);
 
-        // Wipe any pre-existing rows for this group+sprint (handles per-group re-runs)
-        sprintTrackingLogRepository.deleteByGroupIdAndSprintId(group.getId(), sprint.getId());
-
+        // Guard: on empty result (JIRA outage / no stories) do NOT wipe existing good rows
         if (issues.isEmpty()) {
-            log.info("No JIRA issues found for group {} sprint {}", group.getId(), sprint.getId());
+            log.info("No JIRA issues found for group {} sprint {} — skipping delete to preserve existing rows",
+                    group.getId(), sprint.getId());
             return new int[]{0, 0};
         }
+
+        // Wipe any pre-existing rows for this group+sprint only after we have fresh data
+        sprintTrackingLogRepository.deleteByGroupIdAndSprintId(group.getId(), sprint.getId());
 
         LocalDateTime fetchedAt = LocalDateTime.now(ZoneId.of("UTC"));
         List<SprintTrackingLog> logs = new ArrayList<>(issues.size());
@@ -194,7 +196,7 @@ public class SprintTrackingOrchestrator {
             entry.setIssueKey(issue.issueKey());
             // assigneeGithubUsername is set later from pr.authorLogin() (GitHub PR author)
             // because JIRA assigneeEmail does not match Student.githubUsername
-            entry.setStoryPoints(issue.storyPoints());
+            entry.setStoryPoints(issue.storyPoints() != null ? (int) Math.round(issue.storyPoints()) : null);
             entry.setFetchedAt(fetchedAt);
             entry.setAiPrResult(AiValidationResult.PENDING);
             entry.setAiDiffResult(AiValidationResult.PENDING);
@@ -207,47 +209,51 @@ public class SprintTrackingOrchestrator {
         int aiValidationsRun = 0;
 
         for (int i = 0; i < savedLogs.size(); i++) {
-            SprintTrackingLog log = savedLogs.get(i);
+            SprintTrackingLog entry = savedLogs.get(i);
             JiraIssueDto issue = issues.get(i);
 
             // 5.2 — GitHub branch + PR match
             Optional<String> branchOpt = githubSprintService.findBranchByIssueKey(group, issue.issueKey());
             if (branchOpt.isEmpty()) {
                 // No branch found — skip AI, leave prMerged=null, set AI to SKIPPED
-                log.setAiPrResult(AiValidationResult.SKIPPED);
-                log.setAiDiffResult(AiValidationResult.SKIPPED);
+                entry.setAiPrResult(AiValidationResult.SKIPPED);
+                entry.setAiDiffResult(AiValidationResult.SKIPPED);
                 continue;
             }
 
             Optional<GithubPrDto> prOpt = githubSprintService.findMergedPR(group, branchOpt.get());
             if (prOpt.isEmpty()) {
                 // Branch found but no closed PR
-                log.setPrMerged(false);
-                log.setAiPrResult(AiValidationResult.SKIPPED);
-                log.setAiDiffResult(AiValidationResult.SKIPPED);
+                entry.setPrMerged(false);
+                entry.setAiPrResult(AiValidationResult.SKIPPED);
+                entry.setAiDiffResult(AiValidationResult.SKIPPED);
                 continue;
             }
 
             GithubPrDto pr = prOpt.get();
-            log.setPrNumber(pr.prNumber());
-            log.setPrMerged(pr.merged());
+            entry.setPrNumber(pr.prNumber());
+            entry.setPrMerged(pr.merged());
             // PR author (user.login) is the authoritative GitHub username — overrides JIRA email
-            log.setAssigneeGithubUsername(pr.authorLogin());
+            if (pr.authorLogin() == null) {
+                log.warn("No authorLogin from GitHub for PR {} group {} — assigneeGithubUsername will be null",
+                        pr.prNumber(), group.getId());
+            }
+            entry.setAssigneeGithubUsername(pr.authorLogin());
 
             if (!pr.merged()) {
-                log.setAiPrResult(AiValidationResult.SKIPPED);
-                log.setAiDiffResult(AiValidationResult.SKIPPED);
+                entry.setAiPrResult(AiValidationResult.SKIPPED);
+                entry.setAiDiffResult(AiValidationResult.SKIPPED);
                 continue;
             }
 
             // 5.3 — AI PR review validation
             List<String> comments = githubSprintService.fetchPRReviewComments(group, pr.prNumber());
-            log.setAiPrResult(aiValidationService.validatePRReview(comments));
+            entry.setAiPrResult(aiValidationService.validatePRReview(comments));
             aiValidationsRun++;
 
             // 5.4 — AI diff semantics validation
             List<GithubFileDiffDto> diffs = githubSprintService.fetchFileDiffs(group, pr.prNumber());
-            log.setAiDiffResult(aiValidationService.validateIssueDiff(issue.description(), diffs));
+            entry.setAiDiffResult(aiValidationService.validateIssueDiff(issue.description(), diffs));
             aiValidationsRun++;
         }
 

--- a/backend/src/main/java/com/senior/spm/service/dto/JiraIssueDto.java
+++ b/backend/src/main/java/com/senior/spm/service/dto/JiraIssueDto.java
@@ -3,7 +3,7 @@ package com.senior.spm.service.dto;
 public record JiraIssueDto(
         String issueKey,
         String assigneeEmail,
-        Integer storyPoints,
+        Double storyPoints,
         String description
 ) {
 }

--- a/backend/src/test/java/com/senior/spm/controller/P3RbacSecurityTest.java
+++ b/backend/src/test/java/com/senior/spm/controller/P3RbacSecurityTest.java
@@ -41,17 +41,17 @@ class P3RbacSecurityTest {
     // ── Staff/Admin hitting student-only endpoints ───────────────────────────
 
     @Test
-    @DisplayName("Professor JWT on GET /api/advisors returns 403")
+    @DisplayName("Professor JWT on GET /api/advisor returns 403")
     void professor_getAvailableAdvisors_returns403() throws Exception {
-        mockMvc.perform(get("/api/advisors")
+        mockMvc.perform(get("/api/advisor")
                 .with(authentication(professorAuth())))
                 .andExpect(status().isForbidden());
     }
 
     @Test
-    @DisplayName("Coordinator JWT on GET /api/advisors returns 403")
+    @DisplayName("Coordinator JWT on GET /api/advisor returns 403")
     void coordinator_getAvailableAdvisors_returns403() throws Exception {
-        mockMvc.perform(get("/api/advisors")
+        mockMvc.perform(get("/api/advisor")
                 .with(authentication(coordinatorAuth())))
                 .andExpect(status().isForbidden());
     }

--- a/backend/src/test/java/com/senior/spm/service/JiraSprintWireMockTest.java
+++ b/backend/src/test/java/com/senior/spm/service/JiraSprintWireMockTest.java
@@ -76,18 +76,18 @@ class JiraSprintWireMockTest {
         JiraIssueDto issue1 = result.get(0);
         assertThat(issue1.issueKey()).isEqualTo("SPM-42");
         assertThat(issue1.assigneeEmail()).isEqualTo("student@example.com");
-        assertThat(issue1.storyPoints()).isEqualTo(3);
+        assertThat(issue1.storyPoints()).isEqualTo(3.0);
         assertThat(issue1.description()).isEqualTo("Implemented group creation");
 
         JiraIssueDto issue2 = result.get(1);
         assertThat(issue2.issueKey()).isEqualTo("SPM-43");
         assertThat(issue2.assigneeEmail()).isNull();
-        assertThat(issue2.storyPoints()).isEqualTo(5);
+        assertThat(issue2.storyPoints()).isEqualTo(5.0);
         assertThat(issue2.description()).isNull();
 
         JiraIssueDto issue3 = result.get(2);
         assertThat(issue3.issueKey()).isEqualTo("SPM-44");
-        assertThat(issue3.storyPoints()).isEqualTo(8);
+        assertThat(issue3.storyPoints()).isEqualTo(8.0);
         assertThat(issue3.description()).contains("\"type\":\"doc\"");
     }
 

--- a/backend/src/test/java/com/senior/spm/service/ScrumGradingServiceTest.java
+++ b/backend/src/test/java/com/senior/spm/service/ScrumGradingServiceTest.java
@@ -254,7 +254,7 @@ class ScrumGradingServiceTest {
         when(projectGroupRepository.findByAdvisor_IdAndTermId(ADVISOR_ID, TERM_ID))
                 .thenReturn(List.of());
 
-        var result = service.getAdvisorGroupSummaries(ADVISOR_ID, SPRINT_ID);
+        var result = service.getAdvisorGroupSummaries(ADVISOR_ID, SPRINT_ID, false);
 
         assertThat(result).isEmpty();
     }
@@ -269,21 +269,18 @@ class ScrumGradingServiceTest {
         group2.setVersion(0L);
 
         SprintTrackingLog log = makeLog("SPM-1", "alice", AiValidationResult.FAIL, AiValidationResult.PASS, true);
+        log.setGroup(group); // required for batch-fetch groupingBy
 
         when(sprintRepository.findById(SPRINT_ID)).thenReturn(Optional.of(sprint));
         when(termConfigService.getActiveTermId()).thenReturn(TERM_ID);
         when(projectGroupRepository.findByAdvisor_IdAndTermId(ADVISOR_ID, TERM_ID))
                 .thenReturn(List.of(group, group2));
-        when(sprintTrackingLogRepository.findByGroupIdAndSprintId(GROUP_ID, SPRINT_ID))
+        when(sprintTrackingLogRepository.findBySprintId(SPRINT_ID))
                 .thenReturn(List.of(log));
-        when(sprintTrackingLogRepository.findByGroupIdAndSprintId(group2.getId(), SPRINT_ID))
+        when(scrumGradeRepository.findBySprintId(SPRINT_ID))
                 .thenReturn(List.of());
-        when(scrumGradeRepository.findByGroupIdAndSprintId(GROUP_ID, SPRINT_ID))
-                .thenReturn(Optional.empty());
-        when(scrumGradeRepository.findByGroupIdAndSprintId(group2.getId(), SPRINT_ID))
-                .thenReturn(Optional.empty());
 
-        var result = service.getAdvisorGroupSummaries(ADVISOR_ID, SPRINT_ID);
+        var result = service.getAdvisorGroupSummaries(ADVISOR_ID, SPRINT_ID, false);
 
         assertThat(result).hasSize(2);
         var summary = result.stream().filter(s -> s.getGroupId().equals(GROUP_ID)).findFirst().orElseThrow();
@@ -297,7 +294,7 @@ class ScrumGradingServiceTest {
     void getAdvisorGroupSummaries_sprintNotFound_throwsNotFoundException() {
         when(sprintRepository.findById(SPRINT_ID)).thenReturn(Optional.empty());
 
-        assertThatThrownBy(() -> service.getAdvisorGroupSummaries(ADVISOR_ID, SPRINT_ID))
+        assertThatThrownBy(() -> service.getAdvisorGroupSummaries(ADVISOR_ID, SPRINT_ID, false))
                 .isInstanceOf(NotFoundException.class);
     }
 

--- a/backend/src/test/java/com/senior/spm/service/SprintTrackingOrchestratorTest.java
+++ b/backend/src/test/java/com/senior/spm/service/SprintTrackingOrchestratorTest.java
@@ -96,7 +96,7 @@ class SprintTrackingOrchestratorTest {
     }
 
     private JiraIssueDto issue(String key) {
-        return new JiraIssueDto(key, "dev@example.com", 3, "description");
+        return new JiraIssueDto(key, "dev@example.com", 3.0, "description");
     }
 
     // ── triggerForSprint guard tests ──────────────────────────────────────────

--- a/frontend/composables/useApiClient.ts
+++ b/frontend/composables/useApiClient.ts
@@ -421,10 +421,12 @@ export function useApiClient() {
 
   async function fetchAdvisorSprintGroups(
     sprintId: string,
-    token?: string
+    token?: string,
+    includeDisbanded?: boolean
   ): Promise<AdvisorGroupSprintSummaryResponse[]> {
+    const query = includeDisbanded ? "?includeDisbanded=true" : "";
     return apiCall<AdvisorGroupSprintSummaryResponse[]>(
-      `/advisor/sprints/${encodeURIComponent(sprintId)}/groups`,
+      `/advisor/sprints/${encodeURIComponent(sprintId)}/groups${query}`,
       "GET",
       undefined,
       token

--- a/frontend/pages/professor/sprint.vue
+++ b/frontend/pages/professor/sprint.vue
@@ -6,6 +6,8 @@ import {
   CalendarDays,
   ChevronDown,
   ChevronUp,
+  Eye,
+  EyeOff,
   Loader2,
   Save,
   Trophy,
@@ -37,6 +39,7 @@ const pageError = ref<string | null>(null);
 const noActiveSprint = ref(false);
 const activeSprint = ref<ActiveSprintResponse | null>(null);
 const groups = ref<AdvisorGroupSprintSummaryResponse[]>([]);
+const showDisbanded = ref(false);
 
 const expandedGroupIds = ref<Set<string>>(new Set());
 const trackingByGroup = reactive<Record<string, SprintTrackingResponse | null>>({});
@@ -81,7 +84,7 @@ async function loadPageData() {
     const sprint = await fetchAdvisorActiveSprint(token);
     activeSprint.value = sprint;
 
-    const sprintGroups = await fetchAdvisorSprintGroups(sprint.sprintId, token);
+    const sprintGroups = await fetchAdvisorSprintGroups(sprint.sprintId, token, showDisbanded.value);
     groups.value = sprintGroups;
 
     for (const group of sprintGroups) {
@@ -213,12 +216,28 @@ onMounted(loadPageData);
       <header
         class="rounded-2xl border border-slate-200 bg-white/90 p-6 shadow-sm backdrop-blur transition-colors dark:border-slate-700 dark:bg-slate-800/90 dark:shadow-lg"
       >
-        <h1 class="text-2xl font-semibold tracking-tight text-slate-900 dark:text-white md:text-3xl">
-          Sprint Tracking & Grading
-        </h1>
-        <p class="mt-2 text-sm text-slate-600 dark:text-slate-400">
-          Review per-group tracking, AI validation results, and submit Point A / Point B grades.
-        </p>
+        <div class="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+          <div>
+            <h1 class="text-2xl font-semibold tracking-tight text-slate-900 dark:text-white md:text-3xl">
+              Sprint Tracking & Grading
+            </h1>
+            <p class="mt-2 text-sm text-slate-600 dark:text-slate-400">
+              Review per-group tracking, AI validation results, and submit Point A / Point B grades.
+            </p>
+          </div>
+          <button
+            type="button"
+            class="inline-flex shrink-0 items-center gap-2 rounded-lg border px-3 py-2 text-sm font-medium transition"
+            :class="showDisbanded
+              ? 'border-amber-400 bg-amber-50 text-amber-700 hover:bg-amber-100 dark:border-amber-600 dark:bg-amber-900/30 dark:text-amber-300 dark:hover:bg-amber-900/50'
+              : 'border-slate-300 bg-white text-slate-600 hover:bg-slate-50 dark:border-slate-600 dark:bg-slate-700 dark:text-slate-300 dark:hover:bg-slate-600'"
+            @click="showDisbanded = !showDisbanded; loadPageData()"
+          >
+            <Eye v-if="!showDisbanded" class="h-4 w-4" />
+            <EyeOff v-else class="h-4 w-4" />
+            {{ showDisbanded ? "Hide disbanded" : "Show disbanded" }}
+          </button>
+        </div>
 
         <div
           v-if="activeSprint"


### PR DESCRIPTION
## Bug fix  Summary

Fixes 7 correctness and reliability bugs identified during P5 code review and E2E testing. Covers the sprint tracking pipeline (5.1–5.4), the professor sprint grading panel, and two pre-existing failing security tests.

---

## Changes

### 1. Disbanded groups hidden from professor sprint panel
- **`AdvisorController`** — added `?includeDisbanded=false` query param (default hidden)
- **`ScrumGradingService.getAdvisorGroupSummaries`** — filters out `DISBANDED` groups unless flag is set
- **`professor/sprint.vue`** — "Show disbanded" toggle button (amber, Eye/EyeOff icon); fires a re-fetch when toggled
- **`useApiClient.ts`** — `fetchAdvisorSprintGroups` appends `?includeDisbanded=true` when flag is true

### 2. Data safety on JIRA outage during re-run
- **`SprintTrackingOrchestrator.processGroup`** — `deleteByGroupIdAndSprintId` moved to **after** the `issues.isEmpty()` guard; a transient JIRA error or empty response no longer wipes existing valid rows

### 3. Null `authorLogin` warning
- **`SprintTrackingOrchestrator.processGroup`** — added `log.warn(...)` when `pr.authorLogin()` is `null`; previously stored silently

### 4. Auth credential helpers in `JiraSprintService`
- Extracted `buildAuthHeader(ProjectGroup)` and `buildBaseUrl(ProjectGroup)` private helpers
- Both `fetchSprintStories` overloads now use them — eliminates duplicated Base64 encoding and URL stripping

### 5. N+1 query eliminated in `ScrumGradingService`
- Old: 2 queries per group inside a stream → 20 queries for 10 groups
- New: `findBySprintId(sprintId)` + `findBySprintId(sprintId)` (grades) batch-fetched once, grouped in-memory with `Collectors.groupingBy` → always 2 queries regardless of group count

### 6. Story points decimal truncation fixed
- **`JiraIssueDto`** — `storyPoints` field changed from `Integer` to `Double`
- **`JiraSprintService`** — `asDouble()` instead of `asInt()`; JIRA Cloud returns `0.5` as a JSON double
- **`SprintTrackingOrchestrator`** — `Math.round(issue.storyPoints())` stores rounded int; `0.5 → 1`, not `0`

### 7. `P3RbacSecurityTest` URL typo fixed
- Two tests hit `/api/advisors` (plural → 404) instead of `/api/advisor` (singular → 403)
- Corrected to `/api/advisor`; both tests now pass

---

## Test changes

| File | Change |
|------|--------|
| `ScrumGradingServiceTest` | Updated 3 call sites to new 3-arg signature; mocks changed from `findByGroupIdAndSprintId` to `findBySprintId` |
| `JiraSprintWireMockTest` | Story point assertions updated to `double` values (`3.0`, `5.0`, `8.0`) |
| `SprintTrackingOrchestratorTest` | `JiraIssueDto` constructor updated to `3.0` |
| `P3RbacSecurityTest` | `/api/advisors` → `/api/advisor` in two test methods |

All 589 tests pass.

---

## Acceptance criteria

- [x] Disbanded groups hidden by default from professor sprint view; toggle to show them
- [x] Sprint re-run does not delete existing rows when JIRA returns empty
- [x] Null `authorLogin` from GitHub produces a warning log
- [x] Auth header construction deduplicated in `JiraSprintService`
- [x] `getAdvisorGroupSummaries` uses 2 batch queries regardless of group count
- [x] `0.5` story points stored as `1` (rounded), not `0` (truncated)
- [x] All 589 tests pass

---

Resolves #226
