### PR TITLE
feat(admin): add Gemini API key management via admin panel (#228)

### DIFF
--- a/backend/src/main/java/com/senior/spm/controller/AdminController.java
+++ b/backend/src/main/java/com/senior/spm/controller/AdminController.java
@@ -15,11 +15,8 @@ import com.senior.spm.controller.request.LlmConfigRequest;
 import com.senior.spm.controller.request.RegisterProfessorRequest;
 import com.senior.spm.controller.response.ErrorMessage;
 import com.senior.spm.controller.response.LlmConfigResponse;
-import com.senior.spm.entity.SystemConfig;
 import com.senior.spm.exception.AlreadyExistsException;
-import com.senior.spm.repository.SystemConfigRepository;
-import com.senior.spm.service.AiValidationService;
-import com.senior.spm.service.EncryptionService;
+import com.senior.spm.service.LlmConfigService;
 import com.senior.spm.service.StaffUserService;
 
 import jakarta.validation.Valid;
@@ -28,21 +25,13 @@ import jakarta.validation.Valid;
 @RequestMapping("/api/admin")
 public class AdminController {
 
-    private static final String LLM_KEY_CONFIG = "llm_api_key";
-
     private final StaffUserService staffUserService;
-    private final SystemConfigRepository systemConfigRepository;
-    private final EncryptionService encryptionService;
-    private final AiValidationService aiValidationService;
+    private final LlmConfigService llmConfigService;
 
     public AdminController(StaffUserService staffUserService,
-                           SystemConfigRepository systemConfigRepository,
-                           EncryptionService encryptionService,
-                           AiValidationService aiValidationService) {
+                           LlmConfigService llmConfigService) {
         this.staffUserService = staffUserService;
-        this.systemConfigRepository = systemConfigRepository;
-        this.encryptionService = encryptionService;
-        this.aiValidationService = aiValidationService;
+        this.llmConfigService = llmConfigService;
     }
 
     @PostMapping("/register-professor")
@@ -60,31 +49,12 @@ public class AdminController {
 
     @GetMapping("/llm-config")
     public ResponseEntity<LlmConfigResponse> getLlmConfig() {
-        return systemConfigRepository.findById(LLM_KEY_CONFIG)
-                .map(config -> {
-                    String plain = encryptionService.decrypt(config.getConfigValue());
-                    return ResponseEntity.ok(new LlmConfigResponse(true, maskKey(plain)));
-                })
-                .orElseGet(() -> ResponseEntity.ok(new LlmConfigResponse(false, null)));
+        return ResponseEntity.ok(llmConfigService.getLlmConfig());
     }
 
     @PutMapping("/llm-config")
     public ResponseEntity<Map<String, String>> updateLlmConfig(@Valid @RequestBody LlmConfigRequest request) {
-        String encrypted = encryptionService.encrypt(request.getApiKey());
-
-        SystemConfig config = systemConfigRepository.findById(LLM_KEY_CONFIG)
-                .orElseGet(SystemConfig::new);
-        config.setConfigKey(LLM_KEY_CONFIG);
-        config.setConfigValue(encrypted);
-        systemConfigRepository.save(config);
-
-        aiValidationService.invalidateKeyCache();
-
+        llmConfigService.updateLlmKey(request.getApiKey());
         return ResponseEntity.ok(Map.of("message", "LLM API key updated successfully"));
-    }
-
-    private static String maskKey(String key) {
-        if (key.length() <= 8) return "****";
-        return key.substring(0, 4) + "..." + key.substring(key.length() - 4);
     }
 }

--- a/backend/src/main/java/com/senior/spm/controller/AdminController.java
+++ b/backend/src/main/java/com/senior/spm/controller/AdminController.java
@@ -4,14 +4,22 @@ import java.util.Map;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.senior.spm.controller.request.LlmConfigRequest;
 import com.senior.spm.controller.request.RegisterProfessorRequest;
 import com.senior.spm.controller.response.ErrorMessage;
+import com.senior.spm.controller.response.LlmConfigResponse;
+import com.senior.spm.entity.SystemConfig;
 import com.senior.spm.exception.AlreadyExistsException;
+import com.senior.spm.repository.SystemConfigRepository;
+import com.senior.spm.service.AiValidationService;
+import com.senior.spm.service.EncryptionService;
 import com.senior.spm.service.StaffUserService;
 
 import jakarta.validation.Valid;
@@ -20,10 +28,21 @@ import jakarta.validation.Valid;
 @RequestMapping("/api/admin")
 public class AdminController {
 
-    private final StaffUserService staffUserService;
+    private static final String LLM_KEY_CONFIG = "llm_api_key";
 
-    public AdminController(StaffUserService staffUserService) {
+    private final StaffUserService staffUserService;
+    private final SystemConfigRepository systemConfigRepository;
+    private final EncryptionService encryptionService;
+    private final AiValidationService aiValidationService;
+
+    public AdminController(StaffUserService staffUserService,
+                           SystemConfigRepository systemConfigRepository,
+                           EncryptionService encryptionService,
+                           AiValidationService aiValidationService) {
         this.staffUserService = staffUserService;
+        this.systemConfigRepository = systemConfigRepository;
+        this.encryptionService = encryptionService;
+        this.aiValidationService = aiValidationService;
     }
 
     @PostMapping("/register-professor")
@@ -37,5 +56,35 @@ public class AdminController {
             return ResponseEntity.status(HttpStatus.CONFLICT)
                     .body(new ErrorMessage("Professor with same mail already exists"));
         }
+    }
+
+    @GetMapping("/llm-config")
+    public ResponseEntity<LlmConfigResponse> getLlmConfig() {
+        return systemConfigRepository.findById(LLM_KEY_CONFIG)
+                .map(config -> {
+                    String plain = encryptionService.decrypt(config.getConfigValue());
+                    return ResponseEntity.ok(new LlmConfigResponse(true, maskKey(plain)));
+                })
+                .orElseGet(() -> ResponseEntity.ok(new LlmConfigResponse(false, null)));
+    }
+
+    @PutMapping("/llm-config")
+    public ResponseEntity<Map<String, String>> updateLlmConfig(@Valid @RequestBody LlmConfigRequest request) {
+        String encrypted = encryptionService.encrypt(request.getApiKey());
+
+        SystemConfig config = systemConfigRepository.findById(LLM_KEY_CONFIG)
+                .orElseGet(SystemConfig::new);
+        config.setConfigKey(LLM_KEY_CONFIG);
+        config.setConfigValue(encrypted);
+        systemConfigRepository.save(config);
+
+        aiValidationService.invalidateKeyCache();
+
+        return ResponseEntity.ok(Map.of("message", "LLM API key updated successfully"));
+    }
+
+    private static String maskKey(String key) {
+        if (key.length() <= 8) return "****";
+        return key.substring(0, 4) + "..." + key.substring(key.length() - 4);
     }
 }

--- a/backend/src/main/java/com/senior/spm/controller/request/LlmConfigRequest.java
+++ b/backend/src/main/java/com/senior/spm/controller/request/LlmConfigRequest.java
@@ -1,0 +1,13 @@
+package com.senior.spm.controller.request;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class LlmConfigRequest {
+
+    @NotBlank(message = "apiKey must not be blank")
+    private String apiKey;
+}

--- a/backend/src/main/java/com/senior/spm/controller/response/LlmConfigResponse.java
+++ b/backend/src/main/java/com/senior/spm/controller/response/LlmConfigResponse.java
@@ -1,0 +1,5 @@
+package com.senior.spm.controller.response;
+
+import org.springframework.lang.Nullable;
+
+public record LlmConfigResponse(boolean configured, @Nullable String maskedKey) {}

--- a/backend/src/main/java/com/senior/spm/service/AiValidationService.java
+++ b/backend/src/main/java/com/senior/spm/service/AiValidationService.java
@@ -75,6 +75,10 @@ public class AiValidationService {
                 .build();
     }
 
+    public void invalidateKeyCache() {
+        cachedApiKey.set(null);
+    }
+
     // Package-private constructor for unit tests — accepts a pre-built RestClient mock
     AiValidationService(SystemConfigRepository systemConfigRepository,
                         EncryptionService encryptionService,

--- a/backend/src/main/java/com/senior/spm/service/AiValidationService.java
+++ b/backend/src/main/java/com/senior/spm/service/AiValidationService.java
@@ -5,6 +5,8 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.senior.spm.entity.SprintTrackingLog.AiValidationResult;
 import com.senior.spm.repository.SystemConfigRepository;
 import com.senior.spm.service.dto.GithubFileDiffDto;
+
+import static com.senior.spm.service.LlmConfigService.LLM_KEY_CONFIG;
 import jakarta.annotation.PostConstruct;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -26,7 +28,6 @@ import java.util.stream.Collectors;
 public class AiValidationService {
 
     // ── Static constants ──────────────────────────────────────────────────────
-    private static final String LLM_KEY_CONFIG  = "llm_api_key";
     private static final String PR_REVIEW_PROMPT =
             "Review the following PR review comments and respond with only one word: " +
             "PASS if the review is substantive, " +

--- a/backend/src/main/java/com/senior/spm/service/LlmConfigService.java
+++ b/backend/src/main/java/com/senior/spm/service/LlmConfigService.java
@@ -1,0 +1,53 @@
+package com.senior.spm.service;
+
+import com.senior.spm.controller.response.LlmConfigResponse;
+import com.senior.spm.entity.SystemConfig;
+import com.senior.spm.exception.EncryptionException;
+import com.senior.spm.repository.SystemConfigRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class LlmConfigService {
+
+    public static final String LLM_KEY_CONFIG = "llm_api_key";
+
+    private final SystemConfigRepository systemConfigRepository;
+    private final EncryptionService encryptionService;
+    private final AiValidationService aiValidationService;
+
+    public LlmConfigResponse getLlmConfig() {
+        return systemConfigRepository.findById(LLM_KEY_CONFIG)
+                .map(config -> {
+                    try {
+                        String plain = encryptionService.decrypt(config.getConfigValue());
+                        return new LlmConfigResponse(true, maskKey(plain));
+                    } catch (EncryptionException ex) {
+                        log.warn("Failed to decrypt LLM API key — stored ciphertext may be corrupt: {}",
+                                ex.getMessage());
+                        return new LlmConfigResponse(true, "****");
+                    }
+                })
+                .orElseGet(() -> new LlmConfigResponse(false, null));
+    }
+
+    public void updateLlmKey(String apiKey) {
+        String encrypted = encryptionService.encrypt(apiKey);
+
+        SystemConfig config = systemConfigRepository.findById(LLM_KEY_CONFIG)
+                .orElseGet(SystemConfig::new);
+        config.setConfigKey(LLM_KEY_CONFIG);
+        config.setConfigValue(encrypted);
+        systemConfigRepository.save(config);
+
+        aiValidationService.invalidateKeyCache();
+    }
+
+    static String maskKey(String key) {
+        if (key.length() <= 8) return "****";
+        return key.substring(0, 4) + "..." + key.substring(key.length() - 4);
+    }
+}

--- a/backend/src/test/java/com/senior/spm/controller/AdminLlmConfigControllerTest.java
+++ b/backend/src/test/java/com/senior/spm/controller/AdminLlmConfigControllerTest.java
@@ -1,0 +1,226 @@
+package com.senior.spm.controller;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.util.List;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+
+import com.senior.spm.entity.SystemConfig;
+import com.senior.spm.repository.SystemConfigRepository;
+import com.senior.spm.service.AiValidationService;
+import com.senior.spm.service.EncryptionService;
+
+/**
+ * Integration tests for GET/PUT /api/admin/llm-config.
+ * Issue: #228
+ */
+@SpringBootTest
+@AutoConfigureMockMvc
+@TestPropertySource(locations = "classpath:test.properties")
+class AdminLlmConfigControllerTest {
+
+    @Autowired private MockMvc mockMvc;
+    @Autowired private SystemConfigRepository systemConfigRepository;
+    @Autowired private EncryptionService encryptionService;
+    @Autowired private AiValidationService aiValidationService;
+
+    @BeforeEach
+    void setUp() {
+        systemConfigRepository.deleteById("llm_api_key");
+        aiValidationService.invalidateKeyCache();
+    }
+
+    @AfterEach
+    void tearDown() {
+        systemConfigRepository.deleteById("llm_api_key");
+        aiValidationService.invalidateKeyCache();
+    }
+
+    // ── GET /api/admin/llm-config ─────────────────────────────────────────────
+
+    @Test
+    @DisplayName("GET llm-config with no row returns configured=false and null maskedKey")
+    void getLlmConfig_noRow_returnsNotConfigured() throws Exception {
+        mockMvc.perform(get("/api/admin/llm-config")
+                        .with(authentication(adminAuth())))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.configured").value(false))
+                .andExpect(jsonPath("$.maskedKey").doesNotExist());
+    }
+
+    @Test
+    @DisplayName("GET llm-config with row present returns configured=true and masked key")
+    void getLlmConfig_rowPresent_returnsMaskedKey() throws Exception {
+        saveEncryptedKey("AIzaSyFakeKeyForTests");
+
+        mockMvc.perform(get("/api/admin/llm-config")
+                        .with(authentication(adminAuth())))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.configured").value(true))
+                .andExpect(jsonPath("$.maskedKey").value("AIza...ests"));
+    }
+
+    @Test
+    @DisplayName("GET llm-config with short key (<=8 chars) returns '****'")
+    void getLlmConfig_shortKey_returnsFourStars() throws Exception {
+        saveEncryptedKey("short");
+
+        mockMvc.perform(get("/api/admin/llm-config")
+                        .with(authentication(adminAuth())))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.configured").value(true))
+                .andExpect(jsonPath("$.maskedKey").value("****"));
+    }
+
+    @Test
+    @DisplayName("GET llm-config never returns raw key")
+    void getLlmConfig_neverReturnsRawKey() throws Exception {
+        String rawKey = "AIzaSyFakeKeyForTests";
+        saveEncryptedKey(rawKey);
+
+        String response = mockMvc.perform(get("/api/admin/llm-config")
+                        .with(authentication(adminAuth())))
+                .andExpect(status().isOk())
+                .andReturn()
+                .getResponse()
+                .getContentAsString();
+
+        assertThat(response).doesNotContain(rawKey);
+    }
+
+    // ── PUT /api/admin/llm-config ─────────────────────────────────────────────
+
+    @Test
+    @DisplayName("PUT with valid key saves encrypted row and clears cache")
+    void putLlmConfig_validKey_savesAndClearsCache() throws Exception {
+        mockMvc.perform(put("/api/admin/llm-config")
+                        .with(authentication(adminAuth()))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"apiKey\":\"AIzaSyNewKeyForTests\"}"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.message").value("LLM API key updated successfully"));
+
+        SystemConfig saved = systemConfigRepository.findById("llm_api_key").orElseThrow();
+        String decrypted = encryptionService.decrypt(saved.getConfigValue());
+        assertThat(decrypted).isEqualTo("AIzaSyNewKeyForTests");
+        assertThat(saved.getConfigValue()).isNotEqualTo("AIzaSyNewKeyForTests");
+    }
+
+    @Test
+    @DisplayName("PUT with blank apiKey returns 400")
+    void putLlmConfig_blankKey_returns400() throws Exception {
+        mockMvc.perform(put("/api/admin/llm-config")
+                        .with(authentication(adminAuth()))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"apiKey\":\"\"}"))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("PUT with missing apiKey field returns 400")
+    void putLlmConfig_missingField_returns400() throws Exception {
+        mockMvc.perform(put("/api/admin/llm-config")
+                        .with(authentication(adminAuth()))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{}"))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("PUT updates existing row (upsert)")
+    void putLlmConfig_updatesExistingRow() throws Exception {
+        saveEncryptedKey("AIzaSyOldKey12345678");
+
+        mockMvc.perform(put("/api/admin/llm-config")
+                        .with(authentication(adminAuth()))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"apiKey\":\"AIzaSyNewKey12345678\"}"))
+                .andExpect(status().isOk());
+
+        SystemConfig saved = systemConfigRepository.findById("llm_api_key").orElseThrow();
+        assertThat(encryptionService.decrypt(saved.getConfigValue())).isEqualTo("AIzaSyNewKey12345678");
+    }
+
+    // ── RBAC ─────────────────────────────────────────────────────────────────
+
+    @Test
+    @DisplayName("Professor GET /api/admin/llm-config returns 403")
+    void professor_getLlmConfig_returns403() throws Exception {
+        mockMvc.perform(get("/api/admin/llm-config")
+                        .with(authentication(professorAuth())))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @DisplayName("Coordinator GET /api/admin/llm-config returns 403")
+    void coordinator_getLlmConfig_returns403() throws Exception {
+        mockMvc.perform(get("/api/admin/llm-config")
+                        .with(authentication(coordinatorAuth())))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @DisplayName("Professor PUT /api/admin/llm-config returns 403")
+    void professor_putLlmConfig_returns403() throws Exception {
+        mockMvc.perform(put("/api/admin/llm-config")
+                        .with(authentication(professorAuth()))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"apiKey\":\"AIzaSyFakeKey\"}"))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @DisplayName("Coordinator PUT /api/admin/llm-config returns 403")
+    void coordinator_putLlmConfig_returns403() throws Exception {
+        mockMvc.perform(put("/api/admin/llm-config")
+                        .with(authentication(coordinatorAuth()))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"apiKey\":\"AIzaSyFakeKey\"}"))
+                .andExpect(status().isForbidden());
+    }
+
+    // ── Helpers ───────────────────────────────────────────────────────────────
+
+    private void saveEncryptedKey(String plainKey) {
+        SystemConfig config = new SystemConfig();
+        config.setConfigKey("llm_api_key");
+        config.setConfigValue(encryptionService.encrypt(plainKey));
+        systemConfigRepository.save(config);
+    }
+
+    private Authentication adminAuth() {
+        return new UsernamePasswordAuthenticationToken(
+                java.util.UUID.randomUUID().toString(), null,
+                List.of(new SimpleGrantedAuthority("ROLE_ADMIN")));
+    }
+
+    private Authentication professorAuth() {
+        return new UsernamePasswordAuthenticationToken(
+                java.util.UUID.randomUUID().toString(), null,
+                List.of(new SimpleGrantedAuthority("ROLE_PROFESSOR")));
+    }
+
+    private Authentication coordinatorAuth() {
+        return new UsernamePasswordAuthenticationToken(
+                java.util.UUID.randomUUID().toString(), null,
+                List.of(new SimpleGrantedAuthority("ROLE_COORDINATOR")));
+    }
+}

--- a/backend/src/test/java/com/senior/spm/controller/AdminLlmConfigControllerTest.java
+++ b/backend/src/test/java/com/senior/spm/controller/AdminLlmConfigControllerTest.java
@@ -1,6 +1,7 @@
 package com.senior.spm.controller;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.Matchers.nullValue;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
@@ -63,7 +64,7 @@ class AdminLlmConfigControllerTest {
                         .with(authentication(adminAuth())))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.configured").value(false))
-                .andExpect(jsonPath("$.maskedKey").doesNotExist());
+                .andExpect(jsonPath("$.maskedKey").value(nullValue()));
     }
 
     @Test

--- a/frontend/composables/useApiClient.ts
+++ b/frontend/composables/useApiClient.ts
@@ -1,5 +1,5 @@
 import { useAuthStore } from '~/stores/auth';
-import type { ApiError } from '~/types/api';
+import type { ApiError, LlmConfigResponse } from '~/types/api';
 import type { GithubLoginResponse, LoginResponse } from '~/types/auth';
 import type {
   GroupDetailResponse,
@@ -34,7 +34,7 @@ import type {
   CreateDeliverableRequest,
   UpdateDeliverableRequest,
 } from '~/types/deliverable';
-import type { Sprint, CreateSprintRequest, ActiveSprintResponse, SprintTrackingResponse } from '~/types/sprint';
+import type { Sprint, CreateSprintRequest } from '~/types/sprint';
 import type { GradingCriterion, RubricCriterionResponse } from '~/types/rubric';
 import type {
   GroupInvitation,
@@ -248,6 +248,14 @@ export function useApiClient() {
 
   async function registerProfessor(mail: string, token?: string): Promise<{ resetToken: string }> {
     return apiCall<{ resetToken: string }>("/admin/register-professor", "POST", { mail }, token);
+  }
+
+  async function fetchLlmConfig(token?: string): Promise<LlmConfigResponse> {
+    return apiCall<LlmConfigResponse>("/admin/llm-config", "GET", undefined, token);
+  }
+
+  async function updateLlmKey(apiKey: string, token?: string): Promise<{ message: string }> {
+    return apiCall<{ message: string }>("/admin/llm-config", "PUT", { apiKey }, token);
   }
 
   async function createGroup(data: CreateGroupRequest, token?: string): Promise<GroupDetailResponse> {
@@ -645,6 +653,8 @@ export function useApiClient() {
     searchStudents,
     sendGroupInvitation,
     fetchGroupInvitations,
-    cancelGroupInvitation
+    cancelGroupInvitation,
+    fetchLlmConfig,
+    updateLlmKey,
   };
 }

--- a/frontend/pages/admin/dashboard.vue
+++ b/frontend/pages/admin/dashboard.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-	import { LogOut, UserPlus, Shield } from "lucide-vue-next";
+	import { LogOut, UserPlus, Shield, KeyRound } from "lucide-vue-next";
 	import { useAuthStore } from "~/stores/auth";
 
 	definePageMeta({
@@ -41,7 +41,7 @@
       </header>
 
       <!-- Quick Actions -->
-      <div class="grid gap-4 md:grid-cols-2">
+      <div class="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
         <NuxtLink
           to="/admin/register-professor"
           class="group rounded-2xl border border-slate-200 bg-white p-6 shadow-sm transition-all hover:border-blue-300 hover:shadow-md dark:border-slate-700 dark:bg-slate-800 dark:hover:border-blue-600"
@@ -62,6 +62,19 @@
             System is active and running.
           </p>
         </div>
+
+        <NuxtLink
+          to="/admin/llm-config"
+          class="group rounded-2xl border border-slate-200 bg-white p-6 shadow-sm transition-all hover:border-purple-300 hover:shadow-md dark:border-slate-700 dark:bg-slate-800 dark:hover:border-purple-600"
+        >
+          <KeyRound class="h-8 w-8 text-purple-600 dark:text-purple-400" />
+          <h3 class="mt-3 font-semibold text-slate-900 dark:text-white group-hover:text-purple-600 dark:group-hover:text-purple-400">
+            Configure LLM API Key
+          </h3>
+          <p class="mt-1 text-sm text-slate-600 dark:text-slate-400">
+            Set the Google AI Studio API key for AI-assisted sprint validation.
+          </p>
+        </NuxtLink>
       </div>
     </div>
   </main>

--- a/frontend/pages/admin/llm-config.vue
+++ b/frontend/pages/admin/llm-config.vue
@@ -49,6 +49,7 @@ async function handleSubmit() {
     if (!token) throw new Error("Authentication required");
     await updateLlmKey(apiKeyInput.value.trim(), token);
     apiKeyInput.value = "";
+    showKey.value = false;
     saveSuccess.value = "API key saved successfully.";
     await loadConfig();
   } catch (err: unknown) {

--- a/frontend/pages/admin/llm-config.vue
+++ b/frontend/pages/admin/llm-config.vue
@@ -1,0 +1,180 @@
+<script setup lang="ts">
+import { ref, onMounted } from "vue";
+import { ArrowLeft, Eye, EyeOff, KeyRound, Loader2, Save } from "lucide-vue-next";
+import type { LlmConfigResponse } from "~/types/api";
+
+definePageMeta({
+  middleware: "auth",
+  roles: ["Admin"],
+});
+
+const { getAuthToken, fetchLlmConfig, updateLlmKey } = useApiClient();
+
+const isLoading = ref(true);
+const config = ref<LlmConfigResponse | null>(null);
+const pageError = ref<string | null>(null);
+
+const apiKeyInput = ref("");
+const showKey = ref(false);
+const isSaving = ref(false);
+const saveError = ref<string | null>(null);
+const saveSuccess = ref<string | null>(null);
+
+async function loadConfig() {
+  isLoading.value = true;
+  pageError.value = null;
+  try {
+    const token = getAuthToken();
+    if (!token) throw new Error("Authentication required");
+    config.value = await fetchLlmConfig(token);
+  } catch (err: unknown) {
+    pageError.value =
+      err && typeof err === "object" && "message" in err
+        ? String(err.message)
+        : "Failed to load LLM configuration.";
+  } finally {
+    isLoading.value = false;
+  }
+}
+
+async function handleSubmit() {
+  if (!apiKeyInput.value.trim()) return;
+
+  isSaving.value = true;
+  saveError.value = null;
+  saveSuccess.value = null;
+
+  try {
+    const token = getAuthToken();
+    if (!token) throw new Error("Authentication required");
+    await updateLlmKey(apiKeyInput.value.trim(), token);
+    apiKeyInput.value = "";
+    saveSuccess.value = "API key saved successfully.";
+    await loadConfig();
+  } catch (err: unknown) {
+    saveError.value =
+      err && typeof err === "object" && "message" in err
+        ? String(err.message)
+        : "Failed to save API key.";
+  } finally {
+    isSaving.value = false;
+  }
+}
+
+onMounted(loadConfig);
+</script>
+
+<template>
+  <main
+    class="min-h-screen bg-gradient-to-br from-slate-50 via-white to-slate-100 p-4 transition-colors dark:from-slate-950 dark:via-slate-900 dark:to-slate-950 md:p-8"
+  >
+    <div class="mx-auto w-full max-w-2xl space-y-6">
+      <NuxtLink
+        to="/admin/dashboard"
+        class="inline-flex items-center gap-2 text-sm font-medium text-slate-600 transition hover:text-slate-900 dark:text-slate-400 dark:hover:text-white"
+      >
+        <ArrowLeft class="h-4 w-4" />
+        Back to Dashboard
+      </NuxtLink>
+
+      <header
+        class="rounded-2xl border border-slate-200 bg-white/90 p-6 shadow-sm backdrop-blur transition-colors dark:border-slate-700 dark:bg-slate-800/90"
+      >
+        <div class="flex items-center gap-3">
+          <KeyRound class="h-7 w-7 text-purple-600 dark:text-purple-400" />
+          <div>
+            <h1 class="text-2xl font-semibold tracking-tight text-slate-900 dark:text-white">
+              LLM API Key
+            </h1>
+            <p class="mt-1 text-sm text-slate-600 dark:text-slate-400">
+              Set the Google AI Studio API key used for AI-assisted sprint validation.
+            </p>
+          </div>
+        </div>
+
+        <div class="mt-5">
+          <div v-if="isLoading" class="flex items-center gap-2 text-sm text-slate-500 dark:text-slate-400">
+            <Loader2 class="h-4 w-4 animate-spin" />
+            Loading status...
+          </div>
+          <div v-else-if="pageError" class="text-sm text-red-600 dark:text-red-400">{{ pageError }}</div>
+          <div v-else-if="config" class="flex items-center gap-3">
+            <span
+              v-if="config.configured"
+              class="inline-flex items-center gap-1.5 rounded-full bg-emerald-100 px-3 py-1 text-xs font-medium text-emerald-700 dark:bg-emerald-900/40 dark:text-emerald-300"
+            >
+              Configured
+            </span>
+            <span
+              v-else
+              class="inline-flex items-center gap-1.5 rounded-full bg-amber-100 px-3 py-1 text-xs font-medium text-amber-700 dark:bg-amber-900/40 dark:text-amber-300"
+            >
+              Not configured
+            </span>
+            <span v-if="config.maskedKey" class="font-mono text-sm text-slate-700 dark:text-slate-300">
+              {{ config.maskedKey }}
+            </span>
+          </div>
+        </div>
+      </header>
+
+      <section
+        class="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm dark:border-slate-700 dark:bg-slate-800"
+      >
+        <h2 class="text-base font-semibold text-slate-900 dark:text-white">
+          {{ config?.configured ? "Rotate API Key" : "Set API Key" }}
+        </h2>
+        <p class="mt-1 text-sm text-slate-600 dark:text-slate-400">
+          Obtain your key from
+          <a
+            href="https://aistudio.google.com/apikey"
+            target="_blank"
+            rel="noopener noreferrer"
+            class="text-blue-600 underline hover:text-blue-800 dark:text-blue-400 dark:hover:text-blue-300"
+          >Google AI Studio</a>.
+          Keys start with <code class="rounded bg-slate-100 px-1 dark:bg-slate-700">AIza</code>.
+        </p>
+
+        <form class="mt-4 space-y-4" @submit.prevent="handleSubmit">
+          <div>
+            <label class="block text-sm font-medium text-slate-700 dark:text-slate-300">
+              Google AI Studio API Key
+            </label>
+            <div class="relative mt-1">
+              <input
+                v-model="apiKeyInput"
+                :type="showKey ? 'text' : 'password'"
+                placeholder="AIza..."
+                autocomplete="off"
+                class="w-full rounded-lg border border-slate-300 bg-white px-3 py-2 pr-10 text-sm text-slate-900 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200 dark:border-slate-600 dark:bg-slate-900 dark:text-slate-100 dark:focus:ring-blue-900"
+              />
+              <button
+                type="button"
+                @click="showKey = !showKey"
+                class="absolute right-2 top-1/2 -translate-y-1/2 text-slate-400 hover:text-slate-600 dark:hover:text-slate-300"
+              >
+                <Eye v-if="!showKey" class="h-4 w-4" />
+                <EyeOff v-else class="h-4 w-4" />
+              </button>
+            </div>
+          </div>
+
+          <div>
+            <button
+              type="submit"
+              :disabled="isSaving || !apiKeyInput.trim()"
+              class="inline-flex items-center gap-2 rounded-lg bg-purple-600 px-4 py-2 text-sm font-medium text-white transition hover:bg-purple-700 disabled:cursor-not-allowed disabled:opacity-60"
+            >
+              <Loader2 v-if="isSaving" class="h-4 w-4 animate-spin" />
+              <Save v-else class="h-4 w-4" />
+              Save API Key
+            </button>
+          </div>
+
+          <p v-if="saveError" class="text-sm text-red-600 dark:text-red-400">{{ saveError }}</p>
+          <p v-else-if="saveSuccess" class="text-sm text-emerald-600 dark:text-emerald-400">{{ saveSuccess }}</p>
+        </form>
+      </section>
+    </div>
+  </main>
+</template>

--- a/frontend/types/api.ts
+++ b/frontend/types/api.ts
@@ -2,3 +2,8 @@ export interface ApiError {
   status: number;
   message: string;
 }
+
+export interface LlmConfigResponse {
+  configured: boolean;
+  maskedKey: string | null;
+}


### PR DESCRIPTION
## Summary

Implements [FS] Gemini API key management via admin panel (#228).

Admins can now set and rotate the Gemini API key directly from the UI without direct DB access. The key is encrypted at rest (AES-256-GCM via the existing `EncryptionService`) and the `AiValidationService` cache is invalidated immediately on save so the next validation call picks up the new key.

---

## Changes

### Backend

- **`LlmConfigRequest`** — `@NotBlank`-validated request DTO
- **`LlmConfigResponse`** — record with `configured: boolean` and `maskedKey: String` (never returns the raw key)
- **`AiValidationService`** — added `invalidateKeyCache()` to allow cache reset on key rotation
- **`AdminController`** — two new endpoints:
  - `GET /api/admin/llm-config` — returns configured status and masked key (`AIza...cDef`; `"****"` for keys ≤ 8 chars)
  - `PUT /api/admin/llm-config` — encrypts the new key, upserts the `system_config` row, clears service cache
- Security: already covered by existing `/api/admin/**` → `hasRole("ADMIN")` rule in `SecurityConfig` — no changes needed

### Frontend

- **`/admin/llm-config`** (new page) — amber "Not configured" / green "Configured" status badge, password input with show/hide toggle, save button with loading state and success/error feedback, back link to dashboard
- **`/admin/dashboard`** — added "Configure LLM API Key" card (purple, `KeyRound` icon) linking to the new page; grid changed to 3 columns
- **`useApiClient`** — added `fetchLlmConfig` and `updateLlmKey`
- **`types/api.ts`** — added `LlmConfigResponse` interface

---

## Tests

12 integration tests in `AdminLlmConfigControllerTest`:

| Test | Covers |
|------|--------|
| GET with no DB row | `configured: false`, `maskedKey: null` |
| GET with row present | `configured: true`, correct `AIza...ests` mask |
| GET with short key (≤8 chars) | returns `"****"` |
| GET never returns raw key | asserts raw key absent from response body |
| PUT with valid key | row saved encrypted, decrypts back correctly |
| PUT updates existing row (upsert) | old value replaced |
| PUT with blank `apiKey` | 400 |
| PUT with missing `apiKey` field | 400 |
| Professor GET → 403 | RBAC |
| Coordinator GET → 403 | RBAC |
| Professor PUT → 403 | RBAC |
| Coordinator PUT → 403 | RBAC |

---

## Acceptance Criteria

- [x] Admin dashboard has an "LLM API Key" card linking to `/admin/llm-config`
- [x] Page shows "Not configured" if `llm_api_key` row is absent
- [x] Page shows masked key (`AIza...cDef`) if row is present
- [x] Submitting a valid key saves it encrypted and clears the service cache
- [x] `GET` never returns the raw key
- [x] `PUT` with blank `apiKey` → 400
- [x] Non-admin requests → 403
- [x] `AiValidationService` picks up the new key on the next validation call after save

Closes #228
