### PR TITLE
fix(tests): resolve 32 test failures on macOS

### DIFF
--- a/backend/src/test/java/com/senior/spm/AdvisorControllerIntegrationTest.java
+++ b/backend/src/test/java/com/senior/spm/AdvisorControllerIntegrationTest.java
@@ -12,6 +12,7 @@ import com.senior.spm.entity.StaffUser.Role;
 import com.senior.spm.entity.Student;
 import com.senior.spm.entity.SystemConfig;
 import com.senior.spm.repository.AdvisorRequestRepository;
+import com.senior.spm.repository.CommitteeRepository;
 import com.senior.spm.repository.GroupInvitationRepository;
 import com.senior.spm.repository.GroupMembershipRepository;
 import com.senior.spm.repository.ProjectGroupRepository;
@@ -74,6 +75,7 @@ class AdvisorControllerIntegrationTest {
     @Autowired GroupMembershipRepository groupMembershipRepository;
     @Autowired GroupInvitationRepository groupInvitationRepository;
     @Autowired AdvisorRequestRepository advisorRequestRepository;
+    @Autowired CommitteeRepository committeeRepository;
 
     private static final String TERM_ID = "2026-SPRING-TEST";
 
@@ -89,10 +91,13 @@ class AdvisorControllerIntegrationTest {
 
     @BeforeEach
     void setUp() {
-        // FK-safe teardown
+        // FK-safe teardown.
+        // committeeRepository.deleteAll() removes committee_group join rows first (ManyToMany owning side)
+        // so that projectGroupRepository.deleteAll() is not blocked by the FK constraint.
         advisorRequestRepository.deleteAll();
         groupInvitationRepository.deleteAll();
         groupMembershipRepository.deleteAll();
+        committeeRepository.deleteAll();
         projectGroupRepository.deleteAll();
         studentRepository.deleteAll();
         staffUserRepository.deleteAll();

--- a/backend/src/test/java/com/senior/spm/CommitteeControllerIntegrationTest.java
+++ b/backend/src/test/java/com/senior/spm/CommitteeControllerIntegrationTest.java
@@ -9,6 +9,7 @@ import com.senior.spm.entity.StaffUser;
 import com.senior.spm.entity.StaffUser.Role;
 import com.senior.spm.repository.CommitteeRepository;
 import com.senior.spm.repository.DeliverableRepository;
+import com.senior.spm.repository.RubricCriterionRepository;
 import com.senior.spm.repository.StaffUserRepository;
 import com.senior.spm.service.JWTService;
 import org.junit.jupiter.api.BeforeEach;
@@ -60,6 +61,9 @@ class CommitteeControllerIntegrationTest {
     private DeliverableRepository deliverableRepository;
 
     @Autowired
+    private RubricCriterionRepository rubricCriterionRepository;
+
+    @Autowired
     private StaffUserRepository staffUserRepository;
 
     private StaffUser coordinator;
@@ -76,6 +80,8 @@ class CommitteeControllerIntegrationTest {
     void setUp() {
         committeeRepository.deleteAll();
         staffUserRepository.deleteAll();
+        // rubric_criterion.deliverable_id → deliverable.id: delete child before parent
+        rubricCriterionRepository.deleteAll();
         deliverableRepository.deleteAll();
 
         coordinator = staffUserRepository.save(newCoordinator("coord@test.com"));

--- a/backend/src/test/java/com/senior/spm/CommitteeGroupAssignmentIntegrationTest.java
+++ b/backend/src/test/java/com/senior/spm/CommitteeGroupAssignmentIntegrationTest.java
@@ -13,6 +13,7 @@ import com.senior.spm.repository.DeliverableRepository;
 import com.senior.spm.repository.ProjectGroupRepository;
 import com.senior.spm.repository.StaffUserRepository;
 import com.senior.spm.service.JWTService;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -83,6 +84,15 @@ class CommitteeGroupAssignmentIntegrationTest {
         committee.setTermId("2026-SPRING");
         committee.setDeliverable(deliverable);
         committee = committeeRepository.save(committee);
+    }
+
+    @AfterEach
+    void tearDown() {
+        // committee_group join rows are removed when Committee rows are deleted (owning side of @ManyToMany)
+        committeeRepository.deleteAll();
+        projectGroupRepository.deleteAll();
+        staffUserRepository.deleteAll();
+        deliverableRepository.deleteAll();
     }
 
     @Test

--- a/backend/src/test/java/com/senior/spm/GroupCreationIntegrationTest.java
+++ b/backend/src/test/java/com/senior/spm/GroupCreationIntegrationTest.java
@@ -10,6 +10,7 @@ import com.senior.spm.entity.ScheduleWindow.WindowType;
 import com.senior.spm.entity.Student;
 import com.senior.spm.entity.SystemConfig;
 import com.senior.spm.repository.AdvisorRequestRepository;
+import com.senior.spm.repository.CommitteeRepository;
 import com.senior.spm.repository.GroupInvitationRepository;
 import com.senior.spm.repository.GroupMembershipRepository;
 import com.senior.spm.repository.ProjectGroupRepository;
@@ -66,6 +67,7 @@ class GroupCreationIntegrationTest {
     @Autowired GroupMembershipRepository groupMembershipRepository;
     @Autowired GroupInvitationRepository groupInvitationRepository;
     @Autowired AdvisorRequestRepository advisorRequestRepository;
+    @Autowired CommitteeRepository committeeRepository;
 
     private static final String TERM_ID = "2026-SPRING-TEST";
 
@@ -74,10 +76,13 @@ class GroupCreationIntegrationTest {
 
     @BeforeEach
     void setUp() {
-        // Delete in FK-safe order so constraints don't block teardown between tests
+        // Delete in FK-safe order so constraints don't block teardown between tests.
+        // committeeRepository.deleteAll() removes committee_group join rows first (ManyToMany owning side)
+        // before project_group rows can be deleted.
         advisorRequestRepository.deleteAll();
         groupInvitationRepository.deleteAll();
         groupMembershipRepository.deleteAll();
+        committeeRepository.deleteAll();
         projectGroupRepository.deleteAll();
         studentRepository.deleteAll();
         scheduleWindowRepository.deleteAll();

--- a/backend/src/test/java/com/senior/spm/SprintTrackingOrchestratorE2ETest.java
+++ b/backend/src/test/java/com/senior/spm/SprintTrackingOrchestratorE2ETest.java
@@ -87,6 +87,9 @@ class SprintTrackingOrchestratorE2ETest {
     @DynamicPropertySource
     static void overrideProps(DynamicPropertyRegistry reg) {
         reg.add("llm.api.base-url", llmWireMock::baseUrl);
+        // Use an isolated DB so @DirtiesContext teardown (create-drop) doesn't drop
+        // the shared testdb tables used by other integration test classes.
+        reg.add("spring.datasource.url", () -> "jdbc:h2:mem:sprintdb;DB_CLOSE_DELAY=-1;MODE=MySQL");
     }
 
     @AfterAll


### PR DESCRIPTION

## Problem
602 tests pass on Windows, but 32 fail on macOS across 3 classes. All failures happen in `setUp()` before any test logic runs.

Root cause: macOS (APFS) iterates the filesystem in a different order than Windows (NTFS). Tests share a single H2 in-memory database (`testdb`). When a class leaves orphaned FK child rows (`committee_group`, `rubric_criterion`), the next class's `setUp()` fails trying to delete parent rows (`project_group`, `deliverable`).

## Affected Classes
| Class | Failing FK | Fix |
|---|---|---|
| `CommitteeGroupAssignmentIntegrationTest` | `committee_group → project_group` | Added `@AfterEach` cleanup (had none) |
| `GroupCreationIntegrationTest` | `committee_group → project_group` | Delete `committee` before `project_group` in `setUp()` |
| `CommitteeControllerIntegrationTest` | `rubric_criterion → deliverable` | Delete `rubric_criterion` before `deliverable` in `setUp()` |
| `AdvisorControllerIntegrationTest` | `committee_group → project_group` | Delete `committee` before `project_group` in `setUp()` |

## Result
`./mvnw clean test` → 602 tests, 0 failures, 0 errors on Windows.

## Reviewers Needed
At least one reviewer with a  macOS  is required to run `./mvnw clean test` and confirm the 32 failures are resolved.
