### PR TITLE
feat: implement submission comments and deliverable submission notifications

### DIFF
--- a/backend/src/main/java/com/senior/spm/config/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/senior/spm/config/GlobalExceptionHandler.java
@@ -14,7 +14,6 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 import com.senior.spm.controller.response.ErrorMessage;
 import com.senior.spm.exception.AdvisorAtCapacityException;
-import com.senior.spm.exception.RepositoryException;
 import com.senior.spm.exception.AdvisorNotFoundException;
 import com.senior.spm.exception.AlreadyInGroupException;
 import com.senior.spm.exception.BusinessRuleException;
@@ -28,6 +27,7 @@ import com.senior.spm.exception.InvitationNotFoundException;
 import com.senior.spm.exception.InvitationNotPendingException;
 import com.senior.spm.exception.NotFoundException;
 import com.senior.spm.exception.NotInGroupException;
+import com.senior.spm.exception.RepositoryException;
 import com.senior.spm.exception.RequestNotFoundException;
 import com.senior.spm.exception.RequestNotPendingException;
 import com.senior.spm.exception.ScheduleWindowClosedException;
@@ -64,12 +64,6 @@ public class GlobalExceptionHandler {
                 .body(new ErrorMessage("Invalid request body: " + ex.getMessage()));
     }
 
-    @ExceptionHandler(RuntimeException.class)
-    public ResponseEntity<ErrorMessage> handleRuntimeException(RuntimeException ex) {
-        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
-                .body(new ErrorMessage("An unexpected error occurred: " + ex.getMessage()));
-    }
-
     @ExceptionHandler(ScheduleWindowClosedException.class)
     public ResponseEntity<ErrorMessage> handleScheduleWindowClosed(ScheduleWindowClosedException ex) {
         return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(new ErrorMessage(ex.getMessage()));
@@ -85,12 +79,6 @@ public class GlobalExceptionHandler {
         return ResponseEntity.status(HttpStatus.CONFLICT).body(new ErrorMessage(ex.getMessage()));
     }
 
-    /**
-     * Map duplicate pending invitations to HTTP 409 Conflict.
-     *
-     * @param ex duplicate invitation domain exception
-     * @return conflict response with a user-facing error message
-     */
     @ExceptionHandler(DuplicateInvitationException.class)
     public ResponseEntity<ErrorMessage> handleDuplicateInvitation(DuplicateInvitationException ex) {
         return ResponseEntity.status(HttpStatus.CONFLICT).body(new ErrorMessage(ex.getMessage()));
@@ -101,101 +89,75 @@ public class GlobalExceptionHandler {
         return ResponseEntity.status(HttpStatus.NOT_FOUND).body(new ErrorMessage(ex.getMessage()));
     }
 
-    // Maps JiraValidationException and GitHubValidationException (both extend
-    // ExternalToolValidationException) to HTTP 422 Unprocessable Entity.
-    // The exception message is the exact user-facing string defined in the API spec
-    // (e.g. "JIRA validation failed: API token is invalid or expired").
     @ExceptionHandler(ExternalToolValidationException.class)
     public ResponseEntity<ErrorMessage> handleExternalToolValidation(ExternalToolValidationException ex) {
         return ResponseEntity.status(HttpStatus.UNPROCESSABLE_ENTITY).body(new ErrorMessage(ex.getMessage()));
     }
 
-    // Thrown when the authenticated user does not hold the required role or ownership
-    // (e.g., a non-TEAM_LEADER attempting to bind tool integrations or send invitations).
     @ExceptionHandler(ForbiddenException.class)
     public ResponseEntity<ErrorMessage> handleForbidden(ForbiddenException ex) {
         return ResponseEntity.status(HttpStatus.FORBIDDEN).body(new ErrorMessage(ex.getMessage()));
     }
 
-    // Thrown when a request violates a domain business rule (e.g., binding tools on a
-    // DISBANDED group, or responding to a locked roster). Distinct from validation
-    // errors (400 from @Valid) — these are semantic, not structural, rejections.
     @ExceptionHandler(BusinessRuleException.class)
     public ResponseEntity<ErrorMessage> handleBusinessRule(BusinessRuleException ex) {
         return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(new ErrorMessage(ex.getMessage()));
     }
 
-    // Thrown when a group with the given UUID does not exist.
     @ExceptionHandler(GroupNotFoundException.class)
     public ResponseEntity<ErrorMessage> handleGroupNotFound(GroupNotFoundException ex) {
         return ResponseEntity.status(HttpStatus.NOT_FOUND).body(new ErrorMessage(ex.getMessage()));
     }
 
-    /**
-     * Map missing invitations to HTTP 404 Not Found.
-     *
-     * @param ex invitation not found domain exception
-     * @return not found response with a user-facing error message
-     */
     @ExceptionHandler(InvitationNotFoundException.class)
     public ResponseEntity<ErrorMessage> handleInvitationNotFound(InvitationNotFoundException ex) {
         return ResponseEntity.status(HttpStatus.NOT_FOUND).body(new ErrorMessage(ex.getMessage()));
     }
 
-    // Thrown when an advisor has reached their maximum group capacity.
     @ExceptionHandler(AdvisorAtCapacityException.class)
     public ResponseEntity<ErrorMessage> handleAdvisorAtCapacity(AdvisorAtCapacityException ex) {
         return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(new ErrorMessage(ex.getMessage()));
     }
 
-    // Thrown when an advisor request with the given ID does not exist.
     @ExceptionHandler(RequestNotFoundException.class)
     public ResponseEntity<ErrorMessage> handleRequestNotFound(RequestNotFoundException ex) {
         return ResponseEntity.status(HttpStatus.NOT_FOUND).body(new ErrorMessage(ex.getMessage()));
     }
 
-    // Thrown when attempting to cancel/respond to an advisor request that is no longer PENDING.
     @ExceptionHandler(RequestNotPendingException.class)
     public ResponseEntity<ErrorMessage> handleRequestNotPending(RequestNotPendingException ex) {
         return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(new ErrorMessage(ex.getMessage()));
     }
 
-    // Thrown when an advisor (StaffUser with role=Professor) cannot be found by ID,
-    // or the resolved user is not a Professor.
     @ExceptionHandler(AdvisorNotFoundException.class)
     public ResponseEntity<ErrorMessage> handleAdvisorNotFound(AdvisorNotFoundException ex) {
         return ResponseEntity.status(HttpStatus.NOT_FOUND).body(new ErrorMessage(ex.getMessage()));
     }
 
-    // Thrown when a group tries to send a second advisor request while a PENDING one already
-    // exists. Maps to 409 Conflict per the P3 API spec (endpoints_p3.md).
     @ExceptionHandler(DuplicateRequestException.class)
     public ResponseEntity<ErrorMessage> handleDuplicateRequest(DuplicateRequestException ex) {
         return ResponseEntity.status(HttpStatus.CONFLICT).body(new ErrorMessage(ex.getMessage()));
     }
-    /**
-     * Map non-pending invitation lifecycle actions to HTTP 400 Bad Request.
-     *
-     * @param ex invitation state domain exception
-     * @return bad request response with a user-facing error message
-     */
+
     @ExceptionHandler(InvitationNotPendingException.class)
     public ResponseEntity<ErrorMessage> handleInvitationNotPending(InvitationNotPendingException ex) {
         return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(new ErrorMessage(ex.getMessage()));
     }
 
-    // Generic resource-not-found mapped to HTTP 404. Use this when a more specific
-    // *NotFoundException isn't warranted (e.g., looking up a Deliverable by id).
     @ExceptionHandler(NotFoundException.class)
     public ResponseEntity<ErrorMessage> handleNotFound(NotFoundException ex) {
         return ResponseEntity.status(HttpStatus.NOT_FOUND).body(new ErrorMessage(ex.getMessage()));
     }
 
-    // Thrown by stub endpoints (Issue #45) that are not yet implemented.
-    // Prevents UnsupportedOperationException from falling through to the 500 catch-all.
     @ExceptionHandler(UnsupportedOperationException.class)
     public ResponseEntity<ErrorMessage> handleUnsupportedOperation(UnsupportedOperationException ex) {
         return ResponseEntity.status(HttpStatus.NOT_IMPLEMENTED)
                 .body(new ErrorMessage("This endpoint is not yet implemented"));
+    }
+
+    @ExceptionHandler(RuntimeException.class)
+    public ResponseEntity<ErrorMessage> handleRuntimeException(RuntimeException ex) {
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                .body(new ErrorMessage("An unexpected error occurred: " + ex.getMessage()));
     }
 }

--- a/backend/src/main/java/com/senior/spm/config/SecurityConfig.java
+++ b/backend/src/main/java/com/senior/spm/config/SecurityConfig.java
@@ -52,9 +52,7 @@ public class SecurityConfig {
                                 .requestMatchers("/api/professors/**").hasRole("PROFESSOR")
                                 .requestMatchers("/api/committees/*/submissions").hasRole("PROFESSOR")
                                 .requestMatchers("/api/committees/**").hasRole("COORDINATOR")
-                                // P3: Student-facing advisor request endpoints.
                                 .requestMatchers("/api/advisor").hasRole("STUDENT")
-                                // P3: Professor-only endpoints live under /api/advisor/**
                                 .requestMatchers("/api/advisor/**").hasRole("PROFESSOR")
                                 .requestMatchers("/api/groups/*/advisor-request").hasRole("STUDENT")
                                 .requestMatchers("/api/deliverables").hasRole("STUDENT")
@@ -70,11 +68,13 @@ public class SecurityConfig {
                                             .getContext()
                                             .getAuthentication()
                                             .getAuthorities()
-                                            .iterator().next();
-                                    var message = "Role: " + authority.getAuthority() + " does not have permission to access this resource.";
+                                            .iterator()
+                                            .next();
+                                    var message = "Role: " + authority.getAuthority()
+                                            + " does not have permission to access this resource.";
                                     response.getWriter().write(
                                             objectMapper.writeValueAsString(
-                                                    new ErrorMessage(message + "Exception: " + exception.getMessage())
+                                                    new ErrorMessage(message + " Exception: " + exception.getMessage())
                                             ));
                                 }).authenticationEntryPoint((request, response, exception) -> {
                                     response.setStatus(401);

--- a/backend/src/main/java/com/senior/spm/controller/SubmissionCommentController.java
+++ b/backend/src/main/java/com/senior/spm/controller/SubmissionCommentController.java
@@ -1,0 +1,50 @@
+package com.senior.spm.controller;
+
+import java.util.UUID;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.senior.spm.controller.request.CreateSubmissionCommentRequest;
+import com.senior.spm.controller.response.SubmissionCommentResponse;
+import com.senior.spm.service.SubmissionCommentService;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/api/submissions")
+@RequiredArgsConstructor
+public class SubmissionCommentController {
+
+    private final SubmissionCommentService submissionCommentService;
+
+    @PostMapping("/{id}/comments")
+    public ResponseEntity<SubmissionCommentResponse> createComment(
+            @PathVariable UUID id,
+            @Valid @RequestBody CreateSubmissionCommentRequest request) {
+
+        UUID reviewerId = extractReviewerIdFromJwt();
+
+        SubmissionCommentResponse response = submissionCommentService.createComment(
+                id,
+                reviewerId,
+                request.getCommentText(),
+                request.getSectionReference()
+        );
+
+        return ResponseEntity.status(HttpStatus.CREATED).body(response);
+    }
+
+    private UUID extractReviewerIdFromJwt() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        return UUID.fromString((String) authentication.getPrincipal());
+    }
+}

--- a/backend/src/main/java/com/senior/spm/controller/request/CreateSubmissionCommentRequest.java
+++ b/backend/src/main/java/com/senior/spm/controller/request/CreateSubmissionCommentRequest.java
@@ -1,0 +1,15 @@
+package com.senior.spm.controller.request;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class CreateSubmissionCommentRequest {
+
+    @NotBlank(message = "commentText is required")
+    private String commentText;
+
+    private String sectionReference;
+}

--- a/backend/src/main/java/com/senior/spm/controller/response/SubmissionCommentResponse.java
+++ b/backend/src/main/java/com/senior/spm/controller/response/SubmissionCommentResponse.java
@@ -1,0 +1,23 @@
+package com.senior.spm.controller.response;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class SubmissionCommentResponse {
+
+    private UUID id;
+    private UUID submissionId;
+    private UUID reviewerId;
+    private String reviewerEmail;
+    private String commentText;
+    private String sectionReference;
+    private LocalDateTime createdAt;
+}

--- a/backend/src/main/java/com/senior/spm/entity/SubmissionComment.java
+++ b/backend/src/main/java/com/senior/spm/entity/SubmissionComment.java
@@ -5,6 +5,7 @@ import java.util.UUID;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.ForeignKey;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -33,17 +34,20 @@ public class SubmissionComment {
     @GeneratedValue(strategy = GenerationType.UUID)
     private UUID id;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "submission_id", nullable = false, foreignKey = @ForeignKey(name = "fk_sc_submission"))
     private DeliverableSubmission submission;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "commenter_id", nullable = false, foreignKey = @ForeignKey(name = "fk_sc_commenter"))
     private StaffUser commenter;
 
     @Lob
     @Column(nullable = false)
     private String commentText;
+
+    @Column(nullable = true, length = 255)
+    private String sectionReference;
 
     @Column(nullable = false)
     private LocalDateTime createdAt;

--- a/backend/src/main/java/com/senior/spm/repository/CommitteeRepository.java
+++ b/backend/src/main/java/com/senior/spm/repository/CommitteeRepository.java
@@ -9,6 +9,7 @@ import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import com.senior.spm.entity.Committee;
+import com.senior.spm.entity.StaffUser;
 
 @Repository
 public interface CommitteeRepository extends JpaRepository<Committee, UUID> {
@@ -18,14 +19,23 @@ public interface CommitteeRepository extends JpaRepository<Committee, UUID> {
     boolean existsByCommitteeNameAndTermId(String committeeName, String termId);
 
     @Query("SELECT COUNT(c) > 0 FROM Committee c JOIN c.professors cp WHERE cp.professor.id = :professorId AND c.deliverable.id = :deliverableId")
-    boolean existsByProfessorIdAndDeliverableId(@Param("professorId") UUID professorId, @Param("deliverableId") UUID deliverableId);
+    boolean existsByProfessorIdAndDeliverableId(
+            @Param("professorId") UUID professorId,
+            @Param("deliverableId") UUID deliverableId);
 
     @Query("SELECT COUNT(c) > 0 FROM Committee c JOIN c.groups g WHERE g.id = :groupId AND c.deliverable.id = :deliverableId")
-    boolean existsByGroupIdAndDeliverableId(@Param("groupId") UUID groupId, @Param("deliverableId") UUID deliverableId);
+    boolean existsByGroupIdAndDeliverableId(
+            @Param("groupId") UUID groupId,
+            @Param("deliverableId") UUID deliverableId);
 
     @Query("SELECT COUNT(c) > 0 FROM Committee c JOIN c.professors cp JOIN c.groups g WHERE cp.professor.id = :professorId AND g.id = :groupId AND c.deliverable.id = :deliverableId")
     boolean existsByProfessorIdAndGroupIdAndDeliverableId(
             @Param("professorId") UUID professorId,
+            @Param("groupId") UUID groupId,
+            @Param("deliverableId") UUID deliverableId);
+
+    @Query("SELECT DISTINCT cp.professor FROM Committee c JOIN c.professors cp JOIN c.groups g WHERE g.id = :groupId AND c.deliverable.id = :deliverableId")
+    List<StaffUser> findAssignedProfessorsByGroupIdAndDeliverableId(
             @Param("groupId") UUID groupId,
             @Param("deliverableId") UUID deliverableId);
 }

--- a/backend/src/main/java/com/senior/spm/service/DeliverableSubmissionNotificationService.java
+++ b/backend/src/main/java/com/senior/spm/service/DeliverableSubmissionNotificationService.java
@@ -1,0 +1,55 @@
+package com.senior.spm.service;
+
+import java.util.List;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+import com.senior.spm.entity.StaffUser;
+import com.senior.spm.repository.CommitteeRepository;
+import com.senior.spm.service.dto.DeliverableSubmissionNotificationPayload;
+import com.senior.spm.service.event.DeliverableSubmissionCreatedEvent;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class DeliverableSubmissionNotificationService {
+
+    private static final Logger log = LoggerFactory.getLogger(DeliverableSubmissionNotificationService.class);
+
+    private final CommitteeRepository committeeRepository;
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handleDeliverableSubmissionCreated(DeliverableSubmissionCreatedEvent event) {
+        List<StaffUser> assignedProfessors =
+                committeeRepository.findAssignedProfessorsByGroupIdAndDeliverableId(
+                        event.getGroupId(),
+                        event.getDeliverableId()
+                );
+
+        assignedProfessors.stream()
+                .map(professor -> new DeliverableSubmissionNotificationPayload(
+                        event.getSubmissionId(),
+                        event.getGroupId(),
+                        event.getDeliverableId(),
+                        professor.getId(),
+                        professor.getMail()
+                ))
+                .forEach(this::dispatchNotification);
+    }
+
+    private void dispatchNotification(DeliverableSubmissionNotificationPayload payload) {
+        log.info(
+                "Deliverable submission notification dispatched. submissionId={}, groupId={}, deliverableId={}, professorId={}, professorEmail={}",
+                payload.getSubmissionId(),
+                payload.getGroupId(),
+                payload.getDeliverableId(),
+                payload.getProfessorId(),
+                payload.getProfessorEmail()
+        );
+    }
+}

--- a/backend/src/main/java/com/senior/spm/service/DeliverableSubmissionService.java
+++ b/backend/src/main/java/com/senior/spm/service/DeliverableSubmissionService.java
@@ -7,6 +7,7 @@ import java.util.Locale;
 import java.util.Set;
 import java.util.UUID;
 
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -29,6 +30,7 @@ import com.senior.spm.repository.CommitteeRepository;
 import com.senior.spm.repository.DeliverableRepository;
 import com.senior.spm.repository.DeliverableSubmissionRepository;
 import com.senior.spm.repository.GroupMembershipRepository;
+import com.senior.spm.service.event.DeliverableSubmissionCreatedEvent;
 
 import lombok.RequiredArgsConstructor;
 
@@ -47,6 +49,7 @@ public class DeliverableSubmissionService {
     private final DeliverableRepository deliverableRepository;
     private final GroupMembershipRepository groupMembershipRepository;
     private final CommitteeRepository committeeRepository;
+    private final ApplicationEventPublisher applicationEventPublisher;
 
     /**
      * Create the initial (or revision) submission for a deliverable on behalf of the team leader.
@@ -109,6 +112,14 @@ public class DeliverableSubmissionService {
         }
 
         DeliverableSubmission saved = submissionRepository.save(submission);
+
+        applicationEventPublisher.publishEvent(
+                new DeliverableSubmissionCreatedEvent(
+                        saved.getId(),
+                        group.getId(),
+                        deliverable.getId()
+                )
+        );
 
         DeliverableSubmissionResponse response = new DeliverableSubmissionResponse();
         response.setSubmissionId(saved.getId());

--- a/backend/src/main/java/com/senior/spm/service/SubmissionCommentService.java
+++ b/backend/src/main/java/com/senior/spm/service/SubmissionCommentService.java
@@ -1,0 +1,77 @@
+package com.senior.spm.service;
+
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.UUID;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.senior.spm.controller.response.SubmissionCommentResponse;
+import com.senior.spm.entity.DeliverableSubmission;
+import com.senior.spm.entity.StaffUser;
+import com.senior.spm.entity.SubmissionComment;
+import com.senior.spm.exception.ForbiddenException;
+import com.senior.spm.exception.NotFoundException;
+import com.senior.spm.repository.CommitteeRepository;
+import com.senior.spm.repository.DeliverableSubmissionRepository;
+import com.senior.spm.repository.StaffUserRepository;
+import com.senior.spm.repository.SubmissionCommentRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class SubmissionCommentService {
+
+    private final SubmissionCommentRepository submissionCommentRepository;
+    private final DeliverableSubmissionRepository deliverableSubmissionRepository;
+    private final StaffUserRepository staffUserRepository;
+    private final CommitteeRepository committeeRepository;
+
+    @Transactional
+    public SubmissionCommentResponse createComment(
+            UUID submissionId,
+            UUID reviewerId,
+            String commentText,
+            String sectionReference) {
+
+        DeliverableSubmission submission = deliverableSubmissionRepository.findById(submissionId)
+                .orElseThrow(() -> new NotFoundException("Submission not found"));
+
+        StaffUser reviewer = staffUserRepository.findById(reviewerId)
+                .orElseThrow(() -> new NotFoundException("Reviewer not found"));
+
+        UUID groupId = submission.getGroup().getId();
+        UUID deliverableId = submission.getDeliverable().getId();
+
+        boolean assignedCommitteeMember = committeeRepository.existsByProfessorIdAndGroupIdAndDeliverableId(
+                reviewer.getId(),
+                groupId,
+                deliverableId
+        );
+
+        if (!assignedCommitteeMember) {
+            throw new ForbiddenException("Only assigned committee members can comment on this submission");
+        }
+
+        SubmissionComment comment = new SubmissionComment();
+        comment.setSubmission(submission);
+        comment.setCommenter(reviewer);
+        comment.setCommentText(commentText);
+        comment.setSectionReference(sectionReference);
+        comment.setCreatedAt(LocalDateTime.now(ZoneId.of("UTC")));
+
+        SubmissionComment saved = submissionCommentRepository.save(comment);
+
+        return new SubmissionCommentResponse(
+                saved.getId(),
+                submission.getId(),
+                reviewer.getId(),
+                reviewer.getMail(),
+                saved.getCommentText(),
+                saved.getSectionReference(),
+                saved.getCreatedAt()
+        );
+    }
+}

--- a/backend/src/main/java/com/senior/spm/service/dto/DeliverableSubmissionNotificationPayload.java
+++ b/backend/src/main/java/com/senior/spm/service/dto/DeliverableSubmissionNotificationPayload.java
@@ -1,0 +1,17 @@
+package com.senior.spm.service.dto;
+
+import java.util.UUID;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class DeliverableSubmissionNotificationPayload {
+
+    private final UUID submissionId;
+    private final UUID groupId;
+    private final UUID deliverableId;
+    private final UUID professorId;
+    private final String professorEmail;
+}

--- a/backend/src/main/java/com/senior/spm/service/event/DeliverableSubmissionCreatedEvent.java
+++ b/backend/src/main/java/com/senior/spm/service/event/DeliverableSubmissionCreatedEvent.java
@@ -1,0 +1,15 @@
+package com.senior.spm.service.event;
+
+import java.util.UUID;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class DeliverableSubmissionCreatedEvent {
+
+    private final UUID submissionId;
+    private final UUID groupId;
+    private final UUID deliverableId;
+}


### PR DESCRIPTION
## Summary
- Implemented `POST /api/submissions/{id}/comments` endpoint
- Added request/response DTOs for submission comments
- Added `SubmissionCommentService` and `SubmissionCommentRepository`
- Attached comments to the parent submission and logged-in reviewer
- Added optional `sectionReference` support
- Enforced RBAC so only assigned committee members can comment on submissions
- Added deliverable submission created event
- Added notification payload and notification service
- Triggered notification after successful `POST /api/deliverables/{id}/submissions`
- Notification payload includes `submissionId`, `groupId`, `deliverableId`, and assigned professor information

## Test
- Ran `mvn clean compile` successfully
- Tested `POST /api/submissions/{id}/comments` in Postman
- Received `201 Created` for an assigned committee professor

## Related Issues
Closes #195
Closes #197