### PR TITLE
implement submission comments endpoint

### DIFF
--- a/backend/src/main/java/com/senior/spm/config/SecurityConfig.java
+++ b/backend/src/main/java/com/senior/spm/config/SecurityConfig.java
@@ -51,6 +51,7 @@ public class SecurityConfig {
                                 .requestMatchers("/api/professor/**").hasRole("PROFESSOR")
                                 .requestMatchers("/api/professors/**").hasRole("PROFESSOR")
                                 .requestMatchers("/api/committees/**").hasRole("COORDINATOR")
+                                .requestMatchers("/api/submissions/**").hasAnyRole("STUDENT", "PROFESSOR", "COORDINATOR", "ADMIN")
                                 .requestMatchers("/api/advisor").hasRole("STUDENT")
                                 .requestMatchers("/api/advisor/**").hasRole("PROFESSOR")
                                 .requestMatchers("/api/groups/*/advisor-request").hasRole("STUDENT")

--- a/backend/src/main/java/com/senior/spm/controller/SubmissionController.java
+++ b/backend/src/main/java/com/senior/spm/controller/SubmissionController.java
@@ -1,0 +1,47 @@
+package com.senior.spm.controller;
+
+import java.util.List;
+import java.util.UUID;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.senior.spm.controller.response.SubmissionCommentResponse;
+import com.senior.spm.service.SubmissionService;
+
+import lombok.RequiredArgsConstructor;
+
+/**
+ * REST controller for submission-related endpoints.
+ */
+@RestController
+@RequestMapping("/api/submissions")
+@RequiredArgsConstructor
+@Validated
+public class SubmissionController {
+
+    private final SubmissionService submissionService;
+
+    /**
+     * Returns comments for the specified submission.
+     *
+     * <p>
+     * Auth: any authenticated student or staff user with access to the submission.
+     *
+     * @param submissionId UUID of the submission
+     * @param auth current authentication token
+     * @return 200 with list of submission comments
+     */
+    @GetMapping("/{submissionId}/comments")
+    public ResponseEntity<List<SubmissionCommentResponse>> getSubmissionComments(
+            @PathVariable UUID submissionId,
+            Authentication auth) {
+        List<SubmissionCommentResponse> comments = submissionService.getSubmissionComments(submissionId, auth);
+        return ResponseEntity.ok(comments);
+    }
+}

--- a/backend/src/main/java/com/senior/spm/controller/response/SubmissionCommentResponse.java
+++ b/backend/src/main/java/com/senior/spm/controller/response/SubmissionCommentResponse.java
@@ -1,0 +1,23 @@
+package com.senior.spm.controller.response;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public final class SubmissionCommentResponse {
+
+    private UUID commentId;
+    private UUID submissionId;
+    private UUID authorId;
+    private String authorName;
+    private String content;
+    private String sectionReference;
+    private LocalDateTime createdAt;
+}

--- a/backend/src/main/java/com/senior/spm/entity/ProjectGroup.java
+++ b/backend/src/main/java/com/senior/spm/entity/ProjectGroup.java
@@ -89,6 +89,9 @@ public class ProjectGroup {
     @OneToMany(mappedBy = "group")
     private List<GroupInvitation> invitations;
 
+    @OneToMany(mappedBy = "group")
+    private List<Submission> submissions;
+
     @Version
     @Column(nullable = false)
     private Long version;

--- a/backend/src/main/java/com/senior/spm/entity/Submission.java
+++ b/backend/src/main/java/com/senior/spm/entity/Submission.java
@@ -1,0 +1,51 @@
+package com.senior.spm.entity;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.ForeignKey;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Table(name = "submission")
+@Getter
+@Setter
+@NoArgsConstructor
+public class Submission {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID id;
+
+    @ManyToOne
+    @JoinColumn(name = "deliverable_id", nullable = false, foreignKey = @ForeignKey(name = "fk_submission_deliverable"))
+    private Deliverable deliverable;
+
+    @ManyToOne
+    @JoinColumn(name = "group_id", nullable = false, foreignKey = @ForeignKey(name = "fk_submission_group"))
+    private ProjectGroup group;
+
+    @Column(columnDefinition = "TEXT", nullable = false)
+    private String content;
+
+    @Column(nullable = false)
+    private LocalDateTime submittedAt;
+
+    @Column(nullable = true)
+    private LocalDateTime revisedAt;
+
+    @OneToMany(mappedBy = "submission")
+    private List<SubmissionComment> comments;
+}

--- a/backend/src/main/java/com/senior/spm/entity/SubmissionComment.java
+++ b/backend/src/main/java/com/senior/spm/entity/SubmissionComment.java
@@ -1,0 +1,46 @@
+package com.senior.spm.entity;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.ForeignKey;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Table(name = "submission_comment")
+@Getter
+@Setter
+@NoArgsConstructor
+public class SubmissionComment {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID id;
+
+    @ManyToOne
+    @JoinColumn(name = "submission_id", nullable = false, foreignKey = @ForeignKey(name = "fk_submission_comment_submission"))
+    private Submission submission;
+
+    @ManyToOne
+    @JoinColumn(name = "author_id", nullable = false, foreignKey = @ForeignKey(name = "fk_submission_comment_author"))
+    private StaffUser author;
+
+    @Column(columnDefinition = "TEXT", nullable = false)
+    private String content;
+
+    @Column(length = 500, nullable = true)
+    private String sectionReference;
+
+    @Column(nullable = false)
+    private LocalDateTime createdAt;
+}

--- a/backend/src/main/java/com/senior/spm/repository/SubmissionCommentRepository.java
+++ b/backend/src/main/java/com/senior/spm/repository/SubmissionCommentRepository.java
@@ -1,0 +1,15 @@
+package com.senior.spm.repository;
+
+import java.util.List;
+import java.util.UUID;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import com.senior.spm.entity.SubmissionComment;
+
+@Repository
+public interface SubmissionCommentRepository extends JpaRepository<SubmissionComment, UUID> {
+
+    List<SubmissionComment> findBySubmissionId(UUID submissionId);
+}

--- a/backend/src/main/java/com/senior/spm/repository/SubmissionRepository.java
+++ b/backend/src/main/java/com/senior/spm/repository/SubmissionRepository.java
@@ -1,0 +1,12 @@
+package com.senior.spm.repository;
+
+import java.util.UUID;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import com.senior.spm.entity.Submission;
+
+@Repository
+public interface SubmissionRepository extends JpaRepository<Submission, UUID> {
+}

--- a/backend/src/main/java/com/senior/spm/service/SubmissionService.java
+++ b/backend/src/main/java/com/senior/spm/service/SubmissionService.java
@@ -1,0 +1,97 @@
+package com.senior.spm.service;
+
+import java.util.List;
+import java.util.UUID;
+
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.senior.spm.controller.response.SubmissionCommentResponse;
+import com.senior.spm.entity.ProjectGroup;
+import com.senior.spm.entity.StaffUser;
+import com.senior.spm.entity.Student;
+import com.senior.spm.entity.Submission;
+import com.senior.spm.entity.SubmissionComment;
+import com.senior.spm.exception.ForbiddenException;
+import com.senior.spm.exception.NotFoundException;
+import com.senior.spm.repository.CommitteeProfessorRepository;
+import com.senior.spm.repository.GroupMembershipRepository;
+import com.senior.spm.repository.SubmissionCommentRepository;
+import com.senior.spm.repository.SubmissionRepository;
+import com.senior.spm.util.SecurityUtils;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class SubmissionService {
+
+    private final SubmissionRepository submissionRepository;
+    private final SubmissionCommentRepository submissionCommentRepository;
+    private final GroupMembershipRepository groupMembershipRepository;
+    private final CommitteeProfessorRepository committeeProfessorRepository;
+
+    @Transactional(readOnly = true)
+    public List<SubmissionCommentResponse> getSubmissionComments(UUID submissionId, Authentication auth) {
+        // Find the submission
+        Submission submission = submissionRepository.findById(submissionId)
+                .orElseThrow(() -> new NotFoundException("Submission not found"));
+
+        // Check authorization
+        UUID userId = SecurityUtils.extractPrincipalUUID(auth);
+        String role = extractRole(auth);
+
+        if (!hasAccessToSubmission(submission, userId, role)) {
+            throw new ForbiddenException("You do not have permission to view comments for this submission");
+        }
+
+        // Get comments and map to DTOs
+        List<SubmissionComment> comments = submissionCommentRepository.findBySubmissionId(submissionId);
+        return comments.stream()
+                .map(this::mapToResponse)
+                .toList();
+    }
+
+    private boolean hasAccessToSubmission(Submission submission, UUID userId, String role) {
+        ProjectGroup group = submission.getGroup();
+
+        if ("STUDENT".equals(role)) {
+            // Check if student is a member of the group
+            return groupMembershipRepository.findByGroupIdAndStudentId(group.getId(), userId).isPresent();
+        } else if ("PROFESSOR".equals(role) || "COORDINATOR".equals(role) || "ADMIN".equals(role)) {
+            // Check if professor is assigned to a committee that includes this group
+            return committeeProfessorRepository.findByProfessorId(userId).stream()
+                    .anyMatch(cp -> cp.getCommittee().getGroups().contains(group));
+        }
+
+        return false;
+    }
+
+    private String extractRole(Authentication auth) {
+        return auth.getAuthorities().stream()
+                .filter(a -> a instanceof SimpleGrantedAuthority)
+                .map(a -> (SimpleGrantedAuthority) a)
+                .map(SimpleGrantedAuthority::getAuthority)
+                .filter(a -> a.startsWith("ROLE_"))
+                .map(a -> a.substring(5)) // Remove "ROLE_" prefix
+                .findFirst()
+                .orElseThrow(() -> new IllegalStateException("No role found in authentication"));
+    }
+
+    private SubmissionCommentResponse mapToResponse(SubmissionComment comment) {
+        StaffUser author = comment.getAuthor();
+        String authorName = author.getMail();
+
+        return new SubmissionCommentResponse(
+                comment.getId(),
+                comment.getSubmission().getId(),
+                author.getId(),
+                authorName,
+                comment.getContent(),
+                comment.getSectionReference(),
+                comment.getCreatedAt()
+        );
+    }
+}


### PR DESCRIPTION
This PR implements the backend logic and API endpoint to retrieve all comments associated with a specific submission. It ensures that feedback is accessible only to authorized group members and assigned committee members.

Key Changes
New Endpoint: Added GET /api/submissions/{id}/comments.

Data Retrieval: Implemented SubmissionComment entity and repository to fetch comment records from the database.

DTO Mapping: Created SubmissionCommentResponse to return sanitized comment data to the frontend.

RBAC Implementation: Added security checks in SubmissionService to verify if the requester is either a member of the owning group or an assigned committee member.

Security Configuration: Updated SecurityConfig.java to define access rules for the new endpoint.