### PR TITLE
feat(frontend): Committee Read-Only Submission Review & Rubric Split-Panel #201

### DIFF
--- a/frontend/components/MarkdownViewer.vue
+++ b/frontend/components/MarkdownViewer.vue
@@ -1,0 +1,167 @@
+<script setup lang="ts">
+import { marked } from "marked";
+
+const props = defineProps<{
+  content: string;
+  highlightRef: string | null;
+}>();
+
+const viewerRef = ref<HTMLDivElement | null>(null);
+const activeHighlightIds = ref<string[]>([]);
+
+// DOMPurify is browser-only; use a ref so computed re-runs after it loads
+type PurifyFn = (html: string, config?: object) => string;
+const purify = ref<PurifyFn | null>(null);
+if (import.meta.client) {
+  import("dompurify").then((mod) => {
+    purify.value = mod.default.sanitize.bind(mod.default) as PurifyFn;
+  });
+}
+
+const sanitizedHtml = computed(() => {
+  if (!props.content) return "";
+  const raw = marked.parse(props.content) as string;
+  if (purify.value) {
+    return purify.value(raw, {
+      ALLOWED_TAGS: [
+        "h1","h2","h3","h4","h5","h6",
+        "p","ul","ol","li","blockquote","pre","code","strong","em",
+        "a","img","table","thead","tbody","tr","th","td",
+        "hr","br","span","del","sup","sub",
+      ],
+      ALLOWED_ATTR: ["href","src","alt","title","class","id"],
+      ALLOW_DATA_ATTR: false,
+    });
+  }
+  return raw;
+});
+
+function clearHighlights() {
+  if (!viewerRef.value) return;
+  const marks = viewerRef.value.querySelectorAll("mark.rubric-highlight");
+  marks.forEach((mark) => {
+    const parent = mark.parentNode;
+    if (parent) {
+      parent.replaceChild(document.createTextNode(mark.textContent ?? ""), mark);
+      parent.normalize();
+    }
+  });
+  activeHighlightIds.value = [];
+}
+
+function applyHighlight(searchText: string) {
+  if (!viewerRef.value || !searchText.trim()) return;
+
+  clearHighlights();
+
+  const walker = document.createTreeWalker(
+    viewerRef.value,
+    NodeFilter.SHOW_TEXT,
+    null
+  );
+
+  const textNodes: Text[] = [];
+  let node: Node | null;
+  while ((node = walker.nextNode())) {
+    textNodes.push(node as Text);
+  }
+
+  const lowerSearch = searchText.toLowerCase();
+  let foundAny = false;
+
+  textNodes.forEach((textNode) => {
+    const text = textNode.textContent ?? "";
+    const lowerText = text.toLowerCase();
+    const idx = lowerText.indexOf(lowerSearch);
+    if (idx === -1) return;
+
+    foundAny = true;
+    const id = `highlight-${Math.random().toString(36).slice(2)}`;
+    activeHighlightIds.value.push(id);
+
+    const before = text.slice(0, idx);
+    const match = text.slice(idx, idx + searchText.length);
+    const after = text.slice(idx + searchText.length);
+
+    const mark = document.createElement("mark");
+    mark.className = "rubric-highlight";
+    mark.id = id;
+    mark.textContent = match;
+
+    const frag = document.createDocumentFragment();
+    if (before) frag.appendChild(document.createTextNode(before));
+    frag.appendChild(mark);
+    if (after) frag.appendChild(document.createTextNode(after));
+
+    textNode.parentNode?.replaceChild(frag, textNode);
+  });
+
+  if (foundAny && activeHighlightIds.value.length > 0) {
+    const first = document.getElementById(activeHighlightIds.value[0]!);
+    first?.scrollIntoView({ behavior: "smooth", block: "center" });
+  }
+}
+
+watch(
+  () => props.highlightRef,
+  (val) => {
+    nextTick(() => {
+      if (val) {
+        applyHighlight(val);
+      } else {
+        clearHighlights();
+      }
+    });
+  }
+);
+
+watch(sanitizedHtml, () => {
+  nextTick(() => {
+    if (props.highlightRef) {
+      applyHighlight(props.highlightRef);
+    }
+  });
+});
+</script>
+
+<template>
+  <div
+    ref="viewerRef"
+    class="markdown-viewer prose prose-slate dark:prose-invert max-w-none w-full select-text"
+    aria-readonly="true"
+    v-html="sanitizedHtml"
+  />
+</template>
+
+<style scoped>
+.markdown-viewer {
+  pointer-events: auto;
+  user-select: text;
+  -webkit-user-select: text;
+}
+
+/* Prevent any kind of editing */
+.markdown-viewer :deep(*) {
+  pointer-events: auto;
+  outline: none;
+}
+
+.markdown-viewer :deep([contenteditable]) {
+  contenteditable: false;
+}
+</style>
+
+<style>
+/* Global styles for highlight marks */
+.rubric-highlight {
+  background-color: rgb(251 191 36 / 0.45);
+  border-radius: 2px;
+  padding: 1px 2px;
+  transition: background-color 0.2s ease;
+}
+
+.dark .rubric-highlight {
+  background-color: rgb(251 191 36 / 0.35);
+  color: inherit;
+}
+</style>

--- a/frontend/components/RubricPanel.vue
+++ b/frontend/components/RubricPanel.vue
@@ -1,0 +1,153 @@
+<script setup lang="ts">
+import { Scale, CheckSquare2, MousePointerClick } from "lucide-vue-next";
+import type { RubricCriterionResponse } from "~/types/rubric";
+import type { RubricMappingItem } from "~/types/submission";
+
+const props = defineProps<{
+  criteria: RubricCriterionResponse[];
+  mappings: RubricMappingItem[];
+  selectedCriterionName: string | null;
+}>();
+
+const emit = defineEmits<{
+  (e: "select", criterionName: string, sectionRef: string | null): void;
+  (e: "deselect"): void;
+}>();
+
+function getMappingForCriterion(criterionName: string): RubricMappingItem | undefined {
+  return props.mappings.find(
+    (m) => m.sectionReference?.toLowerCase().includes(criterionName.toLowerCase()) ||
+           criterionName.toLowerCase().includes(m.sectionReference?.toLowerCase() ?? "")
+  );
+}
+
+function handleCriterionClick(criterion: RubricCriterionResponse) {
+  if (props.selectedCriterionName === criterion.criterionName) {
+    emit("deselect");
+    return;
+  }
+  const mapping = getMappingForCriterion(criterion.criterionName);
+  const sectionRef = mapping?.sectionReference ?? criterion.criterionName;
+  emit("select", criterion.criterionName, sectionRef);
+}
+
+function isSelected(name: string): boolean {
+  return props.selectedCriterionName === name;
+}
+
+function hasMappedSection(name: string): boolean {
+  return !!getMappingForCriterion(name);
+}
+
+const totalWeight = computed(() =>
+  props.criteria.reduce((sum, c) => sum + (c.weight ?? 0), 0)
+);
+</script>
+
+<template>
+  <div class="flex flex-col h-full">
+    <!-- Header -->
+    <div class="flex items-center gap-2 px-4 py-3 border-b border-slate-200 dark:border-slate-700 bg-slate-50 dark:bg-slate-800/50 flex-shrink-0">
+      <Scale class="w-4 h-4 text-indigo-500" />
+      <h2 class="font-semibold text-sm text-slate-700 dark:text-slate-200">
+        Değerlendirme Rubriği
+      </h2>
+      <span class="ml-auto text-xs text-slate-500 dark:text-slate-400">
+        Toplam Ağırlık: {{ totalWeight }}%
+      </span>
+    </div>
+
+    <!-- Hint -->
+    <div class="px-4 py-2 border-b border-slate-200 dark:border-slate-700 flex-shrink-0">
+      <p class="text-xs text-slate-500 dark:text-slate-400 flex items-center gap-1">
+        <MousePointerClick class="w-3 h-3" />
+        Bir kritere tıklayarak belgede ilgili bölümü vurgulayabilirsiniz.
+      </p>
+    </div>
+
+    <!-- Empty state -->
+    <div
+      v-if="criteria.length === 0"
+      class="flex-1 flex items-center justify-center p-6"
+    >
+      <p class="text-sm text-slate-400 dark:text-slate-500 text-center">
+        Bu teslim için rubrik tanımlanmamış.
+      </p>
+    </div>
+
+    <!-- Criteria list -->
+    <ul v-else class="flex-1 overflow-y-auto divide-y divide-slate-100 dark:divide-slate-700/60">
+      <li
+        v-for="criterion in criteria"
+        :key="criterion.criterionName"
+        class="group cursor-pointer select-none"
+        :class="[
+          isSelected(criterion.criterionName)
+            ? 'bg-indigo-50 dark:bg-indigo-900/25 border-l-4 border-indigo-500'
+            : 'border-l-4 border-transparent hover:bg-slate-50 dark:hover:bg-slate-800/40',
+        ]"
+        role="button"
+        tabindex="0"
+        :aria-pressed="isSelected(criterion.criterionName)"
+        :aria-label="`Kriter: ${criterion.criterionName}`"
+        @click="handleCriterionClick(criterion)"
+        @keydown.enter.prevent="handleCriterionClick(criterion)"
+        @keydown.space.prevent="handleCriterionClick(criterion)"
+      >
+        <div class="px-4 py-3 flex items-start gap-3">
+          <!-- Icon -->
+          <CheckSquare2
+            class="w-4 h-4 mt-0.5 flex-shrink-0 transition-colors"
+            :class="isSelected(criterion.criterionName)
+              ? 'text-indigo-500'
+              : 'text-slate-300 dark:text-slate-600 group-hover:text-slate-400'"
+          />
+
+          <!-- Content -->
+          <div class="flex-1 min-w-0">
+            <p
+              class="text-sm font-medium leading-tight break-words"
+              :class="isSelected(criterion.criterionName)
+                ? 'text-indigo-700 dark:text-indigo-300'
+                : 'text-slate-700 dark:text-slate-200'"
+            >
+              {{ criterion.criterionName }}
+            </p>
+            <div class="flex items-center gap-2 mt-1 flex-wrap">
+              <!-- Grading type badge -->
+              <span
+                class="inline-flex items-center px-1.5 py-0.5 rounded text-[10px] font-medium"
+                :class="criterion.gradingType === 'Binary'
+                  ? 'bg-blue-100 text-blue-700 dark:bg-blue-900/40 dark:text-blue-300'
+                  : 'bg-purple-100 text-purple-700 dark:bg-purple-900/40 dark:text-purple-300'"
+              >
+                {{ criterion.gradingType }}
+              </span>
+              <!-- Weight -->
+              <span class="text-[11px] text-slate-500 dark:text-slate-400">
+                Ağırlık: {{ criterion.weight }}%
+              </span>
+              <!-- Mapping indicator -->
+              <span
+                v-if="hasMappedSection(criterion.criterionName)"
+                class="text-[10px] text-emerald-600 dark:text-emerald-400 font-medium"
+              >
+                ✓ Bölüm eşlenmiş
+              </span>
+            </div>
+          </div>
+        </div>
+      </li>
+    </ul>
+
+    <!-- Footer: selected criterion label -->
+    <div
+      v-if="selectedCriterionName"
+      class="px-4 py-2 border-t border-slate-200 dark:border-slate-700 bg-indigo-50 dark:bg-indigo-900/20 flex-shrink-0"
+    >
+      <p class="text-xs text-indigo-600 dark:text-indigo-400 truncate">
+        <span class="font-medium">Seçili:</span> {{ selectedCriterionName }}
+      </p>
+    </div>
+  </div>
+</template>

--- a/frontend/composables/useApiClient.ts
+++ b/frontend/composables/useApiClient.ts
@@ -39,6 +39,7 @@ import type {
 import type { StudentSearchResult } from '~/types/student';
 import type { BindJiraRequest, BindGithubRequest, BindToolResponse } from '~/types/tools';
 import type { SanitizationReport } from '~/types/sanitization';
+import type { SubmissionResponse, RubricMappingsResponse } from '~/types/submission';
 
 async function apiCall<T>(
   endpoint: string,
@@ -507,6 +508,24 @@ export function useApiClient() {
     return apiCall<ProfessorCommittee[]>("/professors/me/committees", "GET", undefined, token);
   }
 
+  async function fetchSubmission(submissionId: string, token?: string): Promise<SubmissionResponse> {
+    return apiCall<SubmissionResponse>(
+      `/submissions/${encodeURIComponent(submissionId)}`,
+      "GET",
+      undefined,
+      token
+    );
+  }
+
+  async function fetchRubricMappings(submissionId: string, token?: string): Promise<RubricMappingsResponse> {
+    return apiCall<RubricMappingsResponse>(
+      `/submissions/${encodeURIComponent(submissionId)}/rubric-mappings`,
+      "GET",
+      undefined,
+      token
+    );
+  }
+
   return {
     getAuthToken,
     loginFaculty,
@@ -558,6 +577,8 @@ export function useApiClient() {
     searchStudents,
     sendGroupInvitation,
     fetchGroupInvitations,
-    cancelGroupInvitation
+    cancelGroupInvitation,
+    fetchSubmission,
+    fetchRubricMappings,
   };
 }

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -10,7 +10,9 @@
       "dependencies": {
         "@pinia/nuxt": "^0.11.3",
         "@vee-validate/zod": "^4.15.0",
+        "dompurify": "^3.4.2",
         "lucide-vue-next": "^0.475.0",
+        "marked": "^18.0.3",
         "nuxt": "^3.16.0",
         "pinia": "^3.0.4",
         "pinia-plugin-persistedstate": "^4.7.1",
@@ -23,6 +25,8 @@
       "devDependencies": {
         "@nuxtjs/color-mode": "^3.5.2",
         "@nuxtjs/tailwindcss": "^6.13.1",
+        "@tailwindcss/typography": "^0.5.19",
+        "@types/dompurify": "^3.0.5",
         "@types/node": "^25.6.0",
         "@vue/eslint-config-typescript": "^14.7.0",
         "autoprefixer": "^10.4.20",
@@ -3007,7 +3011,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3025,7 +3028,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3043,7 +3045,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3061,7 +3062,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3079,7 +3079,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3097,7 +3096,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3115,7 +3113,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3133,7 +3130,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3151,7 +3147,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3169,7 +3164,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3187,7 +3181,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3205,7 +3198,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3223,7 +3215,6 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3241,7 +3232,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3259,7 +3249,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3277,7 +3266,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3295,7 +3283,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3313,7 +3300,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3331,7 +3317,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4315,6 +4300,33 @@
       "integrity": "sha512-BMq1K3DsElxDWawkX6eLg9+CKJrTVGCBAWVuHXVUV2u0s2711qiChLSId6ikYPfxhdYocLNt3wWwSvDiTvFabw==",
       "license": "CC0-1.0"
     },
+    "node_modules/@tailwindcss/typography": {
+      "version": "0.5.19",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/typography/-/typography-0.5.19.tgz",
+      "integrity": "sha512-w31dd8HOx3k9vPtcQh5QHP9GwKcgbMp87j58qi6xgiBnFFtKEAgCWnDw4qUT8aHwkCp8bKvb/KGKWWHedP0AAg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "postcss-selector-parser": "6.0.10"
+      },
+      "peerDependencies": {
+        "tailwindcss": ">=3.0.0 || insiders || >=4.0.0-alpha.20 || >=4.0.0-beta.1"
+      }
+    },
+    "node_modules/@tailwindcss/typography/node_modules/postcss-selector-parser": {
+      "version": "6.0.10",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.10.tgz",
+      "integrity": "sha512-IQ7TZdoaqbT+LCpShg46jnZVlhWD2w6iQYAcYXfHARZ7X1t/UGhhceQDs5X0cGqKvYlHNOuv7Oa1xmb0oQuA3w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cssesc": "^3.0.0",
+        "util-deprecate": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.1",
       "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
@@ -4323,6 +4335,16 @@
       "optional": true,
       "dependencies": {
         "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@types/dompurify": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@types/dompurify/-/dompurify-3.0.5.tgz",
+      "integrity": "sha512-1Wg0g3BtQF7sSb27fJQAKck1HECM6zV1EB66j8JH9i3LCjYabJa0FSdiSgsD5K/RbrsR0SiraKacLB+T8ZVYAg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/trusted-types": "*"
       }
     },
     "node_modules/@types/esrecurse": {
@@ -4359,6 +4381,13 @@
       "version": "1.20.2",
       "resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-1.20.2.tgz",
       "integrity": "sha512-60BCwRFOZCQhDncwQdxxeOEEkbc5dIMccYLwbxsS4TUNeVECQ/pBJ0j09mrHOl/JJvpRPGwO9SvE4nR2Nb/a4Q==",
+      "license": "MIT"
+    },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
@@ -6622,6 +6651,15 @@
         "url": "https://github.com/fb55/domhandler?sponsor=1"
       }
     },
+    "node_modules/dompurify": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.2.tgz",
+      "integrity": "sha512-lHeS9SA/IKeIFFyYciHBr2n0v1VMPlSj843HdLOwjb2OxNwdq9Xykxqhk+FE42MzAdHvInbAolSE4mhahPpjXA==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
+      }
+    },
     "node_modules/domutils": {
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz",
@@ -8869,6 +8907,18 @@
         "@babel/parser": "^7.29.0",
         "@babel/types": "^7.29.0",
         "source-map-js": "^1.2.1"
+      }
+    },
+    "node_modules/marked": {
+      "version": "18.0.3",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-18.0.3.tgz",
+      "integrity": "sha512-7VT90JOkDeaRWpfjOReRGPEKn0ecdARBkDGL+tT1wZY0efPPqkUxLUSmzy/C7TIylQYJC9STISEsCHrqb/7VIA==",
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 20"
       }
     },
     "node_modules/math-intrinsics": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -13,7 +13,9 @@
   "dependencies": {
     "@pinia/nuxt": "^0.11.3",
     "@vee-validate/zod": "^4.15.0",
+    "dompurify": "^3.4.2",
     "lucide-vue-next": "^0.475.0",
+    "marked": "^18.0.3",
     "nuxt": "^3.16.0",
     "pinia": "^3.0.4",
     "pinia-plugin-persistedstate": "^4.7.1",
@@ -26,6 +28,8 @@
   "devDependencies": {
     "@nuxtjs/color-mode": "^3.5.2",
     "@nuxtjs/tailwindcss": "^6.13.1",
+    "@tailwindcss/typography": "^0.5.19",
+    "@types/dompurify": "^3.0.5",
     "@types/node": "^25.6.0",
     "@vue/eslint-config-typescript": "^14.7.0",
     "autoprefixer": "^10.4.20",

--- a/frontend/pages/professor/committees.vue
+++ b/frontend/pages/professor/committees.vue
@@ -6,6 +6,7 @@
 		ChevronDown,
 		ChevronUp,
 		Clock,
+		Eye,
 		Loader2,
 		Scale,
 		Users,
@@ -334,10 +335,10 @@ interface DeadlineInfo
                       Group Name
                     </th>
                     <th class="px-4 py-2.5 text-left text-xs font-medium uppercase tracking-wider text-slate-500 dark:text-slate-400">
-                      Members
+                      Status
                     </th>
-                    <th class="px-4 py-2.5 text-left text-xs font-medium uppercase tracking-wider text-slate-500 dark:text-slate-400">
-                      Advisor
+                    <th class="px-4 py-2.5 text-right text-xs font-medium uppercase tracking-wider text-slate-500 dark:text-slate-400">
+                      Actions
                     </th>
                   </tr>
                 </thead>
@@ -352,6 +353,22 @@ interface DeadlineInfo
                     </td>
                     <td class="px-4 py-3 text-slate-600 dark:text-slate-400">
                       {{ group.status }}
+                    </td>
+                    <td class="px-4 py-3 text-right">
+                      <NuxtLink
+                        v-if="group.submissionId"
+                        :to="`/professor/submission-review/${group.submissionId}`"
+                        class="inline-flex items-center gap-1.5 rounded-lg bg-indigo-50 px-3 py-1.5 text-xs font-medium text-indigo-700 transition hover:bg-indigo-100 dark:bg-indigo-900/30 dark:text-indigo-300 dark:hover:bg-indigo-900/50"
+                      >
+                        <Eye class="h-3.5 w-3.5" />
+                        Teslimi İncele
+                      </NuxtLink>
+                      <span
+                        v-else
+                        class="text-xs text-slate-400 dark:text-slate-500 italic"
+                      >
+                        Teslim yok
+                      </span>
                     </td>
                   </tr>
                 </tbody>

--- a/frontend/pages/professor/submission-review/[id].vue
+++ b/frontend/pages/professor/submission-review/[id].vue
@@ -1,0 +1,251 @@
+<script setup lang="ts">
+import {
+  ArrowLeft,
+  AlertCircle,
+  Loader2,
+  FileText,
+  Calendar,
+  Users,
+  PanelLeft,
+  PanelRight,
+} from "lucide-vue-next";
+import type { SubmissionResponse, RubricMappingItem } from "~/types/submission";
+import type { RubricCriterionResponse } from "~/types/rubric";
+
+definePageMeta({
+  middleware: "auth",
+  roles: ["Professor"],
+});
+
+const route = useRoute();
+const router = useRouter();
+const { getAuthToken, fetchSubmission, fetchRubricMappings, fetchRubric } =
+  useApiClient();
+
+const submissionId = computed(() => route.params.id as string);
+
+// Data
+const submission = ref<SubmissionResponse | null>(null);
+const rubricCriteria = ref<RubricCriterionResponse[]>([]);
+const rubricMappings = ref<RubricMappingItem[]>([]);
+const loading = ref(true);
+const loadError = ref<string | null>(null);
+
+// Highlight / selection state
+const selectedCriterionName = ref<string | null>(null);
+const highlightRef = ref<string | null>(null);
+
+// Panel visibility toggles (for small screens or manual collapse)
+const leftPanelVisible = ref(true);
+const rightPanelVisible = ref(true);
+
+function handleCriterionSelect(criterionName: string, sectionRef: string | null) {
+  selectedCriterionName.value = criterionName;
+  highlightRef.value = sectionRef ?? criterionName;
+}
+
+function handleCriterionDeselect() {
+  selectedCriterionName.value = null;
+  highlightRef.value = null;
+}
+
+function formatDate(dateStr: string): string {
+  return new Intl.DateTimeFormat("tr-TR", {
+    dateStyle: "medium",
+    timeStyle: "short",
+  }).format(new Date(dateStr));
+}
+
+async function load() {
+  loading.value = true;
+  loadError.value = null;
+
+  try {
+    const token = getAuthToken();
+    if (!token) throw new Error("Kimlik doğrulaması gerekiyor.");
+
+    // Fetch submission content
+    const sub = await fetchSubmission(submissionId.value, token);
+    submission.value = sub;
+
+    // Fetch rubric mappings (student-defined section references)
+    // The endpoint may not exist yet (backend #193); handle gracefully.
+    try {
+      const mappingsResp = await fetchRubricMappings(submissionId.value, token);
+      rubricMappings.value = mappingsResp.mappings ?? [];
+    } catch {
+      rubricMappings.value = [];
+    }
+
+    // Fetch rubric criteria directly via deliverableId from the submission
+    if (sub.deliverableId) {
+      try {
+        rubricCriteria.value = await fetchRubric(sub.deliverableId, token);
+      } catch {
+        rubricCriteria.value = [];
+      }
+    }
+  } catch (err: unknown) {
+    const msg =
+      err && typeof err === "object" && "message" in err
+        ? String((err as { message: string }).message)
+        : "Teslim yüklenirken hata oluştu.";
+    loadError.value = msg;
+  } finally {
+    loading.value = false;
+  }
+}
+
+onMounted(load);
+</script>
+
+<template>
+  <div class="flex flex-col h-screen bg-slate-50 dark:bg-slate-950 overflow-hidden">
+    <!-- Top bar -->
+    <header class="flex items-center gap-3 px-4 py-3 border-b border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-900 flex-shrink-0 shadow-sm">
+      <button
+        class="inline-flex items-center gap-1.5 text-sm text-slate-600 dark:text-slate-300 hover:text-slate-900 dark:hover:text-white transition-colors"
+        @click="router.back()"
+      >
+        <ArrowLeft class="w-4 h-4" />
+        Geri
+      </button>
+
+      <div class="h-5 w-px bg-slate-200 dark:bg-slate-700" />
+
+      <FileText class="w-4 h-4 text-indigo-500 flex-shrink-0" />
+      <h1 class="text-sm font-semibold text-slate-800 dark:text-slate-100 truncate">
+        Teslim İnceleme
+        <span
+          v-if="submission"
+          class="ml-2 text-xs font-normal text-slate-500 dark:text-slate-400"
+        >
+          — {{ submission.submissionId.slice(0, 8) }}…
+        </span>
+      </h1>
+
+      <!-- Submission meta -->
+      <div
+        v-if="submission && !loading"
+        class="ml-auto flex items-center gap-4 text-xs text-slate-500 dark:text-slate-400"
+      >
+        <span class="flex items-center gap-1">
+          <Calendar class="w-3 h-3" />
+          {{ formatDate(submission.revisedAt ?? submission.submittedAt) }}
+          <span v-if="submission.revisedAt" class="text-amber-500">(revize)</span>
+        </span>
+        <span class="flex items-center gap-1">
+          <Users class="w-3 h-3" />
+          {{ submission.groupId.slice(0, 8) }}…
+        </span>
+      </div>
+
+      <!-- Panel toggles -->
+      <div class="flex items-center gap-1 ml-4">
+        <button
+          class="p-1.5 rounded hover:bg-slate-100 dark:hover:bg-slate-800 transition-colors"
+          :class="leftPanelVisible ? 'text-indigo-500' : 'text-slate-400'"
+          :title="leftPanelVisible ? 'Doküman panelini gizle' : 'Doküman panelini göster'"
+          @click="leftPanelVisible = !leftPanelVisible"
+        >
+          <PanelLeft class="w-4 h-4" />
+        </button>
+        <button
+          class="p-1.5 rounded hover:bg-slate-100 dark:hover:bg-slate-800 transition-colors"
+          :class="rightPanelVisible ? 'text-indigo-500' : 'text-slate-400'"
+          :title="rightPanelVisible ? 'Rubrik panelini gizle' : 'Rubrik panelini göster'"
+          @click="rightPanelVisible = !rightPanelVisible"
+        >
+          <PanelRight class="w-4 h-4" />
+        </button>
+      </div>
+    </header>
+
+    <!-- Loading -->
+    <div
+      v-if="loading"
+      class="flex-1 flex items-center justify-center"
+    >
+      <div class="flex flex-col items-center gap-3">
+        <Loader2 class="w-8 h-8 text-indigo-500 animate-spin" />
+        <p class="text-sm text-slate-500 dark:text-slate-400">Teslim yükleniyor…</p>
+      </div>
+    </div>
+
+    <!-- Error -->
+    <div
+      v-else-if="loadError"
+      class="flex-1 flex items-center justify-center p-8"
+    >
+      <div class="max-w-md w-full bg-red-50 dark:bg-red-900/20 rounded-xl border border-red-200 dark:border-red-800 p-6 flex gap-4">
+        <AlertCircle class="w-5 h-5 text-red-500 flex-shrink-0 mt-0.5" />
+        <div>
+          <p class="font-semibold text-sm text-red-700 dark:text-red-300">Yükleme hatası</p>
+          <p class="text-sm text-red-600 dark:text-red-400 mt-1">{{ loadError }}</p>
+          <button
+            class="mt-3 text-sm text-red-600 dark:text-red-400 underline hover:no-underline"
+            @click="load"
+          >
+            Tekrar dene
+          </button>
+        </div>
+      </div>
+    </div>
+
+    <!-- Split panel layout -->
+    <div
+      v-else-if="submission"
+      class="flex-1 flex overflow-hidden min-h-0"
+    >
+      <!-- Left: Markdown document -->
+      <section
+        v-show="leftPanelVisible"
+        class="flex flex-col overflow-hidden border-r border-slate-200 dark:border-slate-700 transition-all duration-200"
+        :class="rightPanelVisible ? 'flex-1' : 'flex-1'"
+        aria-label="Teslim dokümanı"
+      >
+        <!-- Section header -->
+        <div class="px-4 py-2.5 bg-slate-50 dark:bg-slate-800/50 border-b border-slate-200 dark:border-slate-700 flex-shrink-0 flex items-center gap-2">
+          <FileText class="w-3.5 h-3.5 text-slate-400" />
+          <span class="text-xs font-medium text-slate-600 dark:text-slate-300 uppercase tracking-wide">
+            Doküman
+          </span>
+          <span class="ml-auto text-xs text-slate-400 dark:text-slate-500 bg-slate-100 dark:bg-slate-800 px-2 py-0.5 rounded-full">
+            Salt Okunur
+          </span>
+        </div>
+
+        <!-- Markdown content -->
+        <div class="flex-1 overflow-y-auto px-6 py-6">
+          <div
+            v-if="!submission.content"
+            class="flex items-center justify-center h-full"
+          >
+            <p class="text-sm text-slate-400 dark:text-slate-500">Bu teslimde içerik bulunamadı.</p>
+          </div>
+          <MarkdownViewer
+            v-else
+            :content="submission.content"
+            :highlight-ref="highlightRef"
+          />
+        </div>
+      </section>
+
+      <!-- Right: Rubric panel -->
+      <section
+        v-show="rightPanelVisible"
+        class="flex flex-col overflow-hidden bg-white dark:bg-slate-900 transition-all duration-200"
+        :class="leftPanelVisible ? 'w-80 flex-shrink-0 lg:w-96' : 'flex-1'"
+        aria-label="Değerlendirme rubriği"
+      >
+        <RubricPanel
+          :criteria="rubricCriteria"
+          :mappings="rubricMappings"
+          :selected-criterion-name="selectedCriterionName"
+          @select="handleCriterionSelect"
+          @deselect="handleCriterionDeselect"
+        />
+      </section>
+    </div>
+  </div>
+</template>

--- a/frontend/tailwind.config.ts
+++ b/frontend/tailwind.config.ts
@@ -1,4 +1,5 @@
 import type { Config } from "tailwindcss";
+import typography from "@tailwindcss/typography";
 
 const config: Config = {
   darkMode: "class",
@@ -12,7 +13,7 @@ const config: Config = {
   theme: {
     extend: {},
   },
-  plugins: [],
+  plugins: [typography],
 };
 
 export default config;

--- a/frontend/types/committee.ts
+++ b/frontend/types/committee.ts
@@ -58,6 +58,7 @@ export interface ProfessorCommitteeGroup {
   groupId: string;
   groupName: string;
   status: GroupStatus;
+  submissionId?: string | null;
 }
 
 export interface ProfessorCommitteeRubricCriterion {

--- a/frontend/types/submission.ts
+++ b/frontend/types/submission.ts
@@ -1,0 +1,18 @@
+export interface SubmissionResponse {
+  submissionId: string;
+  deliverableId: string;
+  groupId: string;
+  content: string;
+  submittedAt: string;
+  revisedAt: string | null;
+}
+
+export interface RubricMappingItem {
+  criterionId: string;
+  sectionReference: string;
+}
+
+export interface RubricMappingsResponse {
+  submissionId: string;
+  mappings: RubricMappingItem[];
+}


### PR DESCRIPTION
## Summary
Closes #201

Implements the split-panel view for committee members to read submitted markdown documents alongside the evaluation rubric.

---

## Changes

### New Files
- `frontend/components/MarkdownViewer.vue` — Read-only markdown renderer with DOMPurify XSS sanitization (client-only, reactive ref). Clicking a rubric criterion highlights matching text and scrolls to it.
- `frontend/components/RubricPanel.vue` — Rubric criteria list with click-to-highlight interaction, grading type badges, weight display, and section mapping indicators.
- `frontend/pages/professor/submission-review/[id].vue` — Split-panel page: left side renders the markdown submission, right side shows the rubric. Panel toggle buttons included.
- `frontend/types/submission.ts` — `SubmissionResponse`, `RubricMappingItem`, `RubricMappingsResponse` types.

### Modified Files
- `frontend/composables/useApiClient.ts` — Added `fetchSubmission` (`GET /submissions/{id}`) and `fetchRubricMappings` (`GET /submissions/{id}/rubric-mappings`).
- `frontend/types/committee.ts` — Added optional `submissionId` field to `ProfessorCommitteeGroup`.
- `frontend/pages/professor/committees.vue` — Added "Teslimi İncele" (Review Submission) button per group row; navigates to the split-panel review page when `submissionId` is present.
- `frontend/tailwind.config.ts` — Enabled `@tailwindcss/typography` plugin for markdown prose styling.
- `frontend/package.json` — Added `marked`, `dompurify`, `@types/dompurify`, `@tailwindcss/typography`.

---

## Acceptance Criteria

| Criterion | Status |
|-----------|--------|
| Submitted markdown and embedded images render in read-only mode | ✅ |
| Clicking a criterion highlights the student-mapped section | ✅ (fallback: matches criterion name in text) |
| Panel strictly blocks any text editing | ✅ |
| Integrates with `GET /api/submissions/{id}` | ✅ |

---

## Notes
- `GET /submissions/{id}/rubric-mappings` is not in the OpenAPI spec (only POST exists). The call is made gracefully — 404 is caught silently. When backend exposes this endpoint, mappings will work automatically.
- Rubric criteria are fetched directly via `GET /coordinator/deliverables/{id}/rubric` using the `deliverableId` from the submission response.