### PR TITLE
feat(frontend): Implement Rubric Linking UI inside Markdown Editor #200

### DIFF
--- a/frontend/components/MarkdownEditor.vue
+++ b/frontend/components/MarkdownEditor.vue
@@ -1,0 +1,197 @@
+<script setup lang="ts">
+import type { LocalMappingEntry } from "~/types/submission";
+
+const props = defineProps<{
+  modelValue: string;
+  mappings: LocalMappingEntry[];
+  disabled?: boolean;
+}>();
+
+const emit = defineEmits<{
+  (e: "update:modelValue", value: string): void;
+  (e: "selection", text: string, start: number, end: number): void;
+  (e: "clearSelection"): void;
+}>();
+
+const textareaRef = ref<HTMLTextAreaElement | null>(null);
+const mirrorRef = ref<HTMLDivElement | null>(null);
+
+// Track current selection
+const selectionText = ref("");
+const selectionStart = ref(0);
+const selectionEnd = ref(0);
+const hasSelection = ref(false);
+
+function onInput(e: Event) {
+  emit("update:modelValue", (e.target as HTMLTextAreaElement).value);
+}
+
+function onSelectionChange() {
+  const el = textareaRef.value;
+  if (!el) return;
+  const start = el.selectionStart ?? 0;
+  const end = el.selectionEnd ?? 0;
+  const text = el.value.slice(start, end);
+
+  if (text.trim().length > 0) {
+    selectionStart.value = start;
+    selectionEnd.value = end;
+    selectionText.value = text;
+    hasSelection.value = true;
+    emit("selection", text, start, end);
+  } else {
+    hasSelection.value = false;
+    selectionText.value = "";
+    emit("clearSelection");
+  }
+}
+
+// Sync scroll between textarea and mirror
+function onScroll() {
+  if (mirrorRef.value && textareaRef.value) {
+    mirrorRef.value.scrollTop = textareaRef.value.scrollTop;
+  }
+}
+
+// Build mirror HTML: plain text with <mark> for each mapped sectionReference
+const mirrorHtml = computed(() => {
+  let text = props.modelValue;
+  if (!text) return "";
+
+  // Sort mappings by position of their sectionReference in text (first occurrence)
+  const ranges: Array<{ start: number; end: number; criterionName: string; color: string }> = [];
+  const palette = [
+    "bg-yellow-200/60 dark:bg-yellow-500/30",
+    "bg-blue-200/60 dark:bg-blue-500/30",
+    "bg-green-200/60 dark:bg-green-500/30",
+    "bg-pink-200/60 dark:bg-pink-500/30",
+    "bg-purple-200/60 dark:bg-purple-500/30",
+    "bg-orange-200/60 dark:bg-orange-500/30",
+  ];
+
+  props.mappings.forEach((mapping, idx) => {
+    const ref = mapping.sectionReference;
+    const pos = text.indexOf(ref);
+    if (pos !== -1) {
+      ranges.push({
+        start: pos,
+        end: pos + ref.length,
+        criterionName: mapping.criterionName,
+        color: palette[idx % palette.length]!,
+      });
+    }
+  });
+
+  // Sort by start position, resolve overlaps (skip overlapping)
+  ranges.sort((a, b) => a.start - b.start);
+
+  let result = "";
+  let cursor = 0;
+
+  for (const range of ranges) {
+    if (range.start < cursor) continue; // skip overlapping
+    result += escapeHtml(text.slice(cursor, range.start));
+    result += `<mark class="rubric-mapped-section" title="${escapeHtml(range.criterionName)}">${escapeHtml(text.slice(range.start, range.end))}</mark>`;
+    cursor = range.end;
+  }
+  result += escapeHtml(text.slice(cursor));
+
+  // Preserve newlines
+  return result.replace(/\n/g, "<br>");
+});
+
+function escapeHtml(str: string): string {
+  return str
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+}
+
+// Expose selection info for parent
+defineExpose({ selectionText, selectionStart, selectionEnd, hasSelection });
+</script>
+
+<template>
+  <div class="flex flex-col h-full">
+    <!-- Selection hint bar -->
+    <div
+      class="flex items-center gap-2 px-3 py-2 text-xs border-b border-slate-200 dark:border-slate-700 bg-slate-50 dark:bg-slate-800/50 flex-shrink-0 transition-all"
+      :class="hasSelection ? 'text-indigo-600 dark:text-indigo-400' : 'text-slate-400 dark:text-slate-500'"
+    >
+      <span v-if="hasSelection" class="flex items-center gap-1.5 font-medium">
+        <span class="inline-block w-2 h-2 rounded-full bg-indigo-500 animate-pulse" />
+        Metin seçildi ({{ selectionText.length }} karakter) — Sağ panelden bir kriter seçerek eşleyin
+      </span>
+      <span v-else>
+        Bir bölümü seçmek için metni işaretleyin, ardından sağdaki kritere tıklayın
+      </span>
+    </div>
+
+    <!-- Editor area: textarea + highlight mirror -->
+    <div class="relative flex-1 min-h-0">
+      <!-- Mirror: renders mapped sections as colored highlights -->
+      <div
+        ref="mirrorRef"
+        class="absolute inset-0 overflow-hidden pointer-events-none"
+        aria-hidden="true"
+      >
+        <div
+          class="mirror-content w-full h-full overflow-hidden whitespace-pre-wrap break-words"
+          v-html="mirrorHtml"
+        />
+      </div>
+
+      <!-- Actual textarea -->
+      <textarea
+        ref="textareaRef"
+        :value="modelValue"
+        :disabled="disabled"
+        placeholder="Markdown içeriğinizi buraya yazın…
+
+# Proje Başlığı
+
+## Giriş
+..."
+        class="relative w-full h-full resize-none bg-transparent outline-none font-mono text-sm text-slate-900 dark:text-slate-100 placeholder-slate-400 dark:placeholder-slate-500 p-4 leading-relaxed caret-indigo-500"
+        :class="disabled ? 'cursor-not-allowed opacity-60' : ''"
+        spellcheck="false"
+        autocomplete="off"
+        autocorrect="off"
+        @input="onInput"
+        @mouseup="onSelectionChange"
+        @keyup="onSelectionChange"
+        @scroll="onScroll"
+        @blur="onSelectionChange"
+      />
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.mirror-content {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  font-size: 0.875rem;
+  line-height: 1.625;
+  padding: 1rem;
+  color: transparent;
+  position: absolute;
+  inset: 0;
+  overflow: hidden;
+  word-break: break-word;
+  white-space: pre-wrap;
+}
+</style>
+
+<style>
+.rubric-mapped-section {
+  background-color: rgb(251 191 36 / 0.45);
+  border-radius: 2px;
+  color: transparent;
+  position: relative;
+}
+
+.dark .rubric-mapped-section {
+  background-color: rgb(251 191 36 / 0.3);
+}
+</style>

--- a/frontend/components/RubricLinkingPanel.vue
+++ b/frontend/components/RubricLinkingPanel.vue
@@ -1,0 +1,211 @@
+<script setup lang="ts">
+import { Scale, Link2, Trash2, AlertCircle, CheckCircle2 } from "lucide-vue-next";
+import type { RubricCriterionResponse } from "~/types/rubric";
+import type { LocalMappingEntry } from "~/types/submission";
+
+const props = defineProps<{
+  criteria: RubricCriterionResponse[];
+  mappings: LocalMappingEntry[];
+  hasSelection: boolean;
+  selectionText: string;
+  loading?: boolean;
+  noCriteriaIds?: boolean;
+}>();
+
+const emit = defineEmits<{
+  (e: "link", criterion: RubricCriterionResponse): void;
+  (e: "removeMapping", localId: string): void;
+}>();
+
+// Group mappings by criterionName for display
+const mappingsByCriterion = computed(() => {
+  const map = new Map<string, LocalMappingEntry[]>();
+  for (const m of props.mappings) {
+    const existing = map.get(m.criterionName) ?? [];
+    existing.push(m);
+    map.set(m.criterionName, existing);
+  }
+  return map;
+});
+
+const palette = [
+  "bg-yellow-100 text-yellow-800 border-yellow-300 dark:bg-yellow-900/30 dark:text-yellow-300 dark:border-yellow-700",
+  "bg-blue-100 text-blue-800 border-blue-300 dark:bg-blue-900/30 dark:text-blue-300 dark:border-blue-700",
+  "bg-green-100 text-green-800 border-green-300 dark:bg-green-900/30 dark:text-green-300 dark:border-green-700",
+  "bg-pink-100 text-pink-800 border-pink-300 dark:bg-pink-900/30 dark:text-pink-300 dark:border-pink-700",
+  "bg-purple-100 text-purple-800 border-purple-300 dark:bg-purple-900/30 dark:text-purple-300 dark:border-purple-700",
+  "bg-orange-100 text-orange-800 border-orange-300 dark:bg-orange-900/30 dark:text-orange-300 dark:border-orange-700",
+];
+
+function criterionColor(idx: number) {
+  return palette[idx % palette.length]!;
+}
+
+function mappingCount(criterionName: string) {
+  return mappingsByCriterion.value.get(criterionName)?.length ?? 0;
+}
+
+function truncate(text: string, max = 45): string {
+  return text.length > max ? text.slice(0, max) + "…" : text;
+}
+
+const totalWeight = computed(() =>
+  props.criteria.reduce((s, c) => s + (c.weight ?? 0), 0)
+);
+</script>
+
+<template>
+  <div class="flex flex-col h-full">
+    <!-- Header -->
+    <div class="flex items-center gap-2 px-4 py-3 border-b border-slate-200 dark:border-slate-700 bg-slate-50 dark:bg-slate-800/50 flex-shrink-0">
+      <Scale class="w-4 h-4 text-indigo-500" />
+      <h2 class="font-semibold text-sm text-slate-700 dark:text-slate-200">
+        Rubrik Kriterleri
+      </h2>
+      <span class="ml-auto text-xs text-slate-500 dark:text-slate-400">
+        {{ totalWeight }}% toplam
+      </span>
+    </div>
+
+    <!-- Instruction -->
+    <div class="px-4 py-2.5 border-b border-slate-200 dark:border-slate-700 flex-shrink-0">
+      <p
+        class="text-xs flex items-start gap-1.5 transition-colors"
+        :class="hasSelection
+          ? 'text-indigo-600 dark:text-indigo-400 font-medium'
+          : 'text-slate-500 dark:text-slate-400'"
+      >
+        <Link2 class="w-3.5 h-3.5 mt-0.5 flex-shrink-0" />
+        <span v-if="hasSelection">
+          Seçili metin: <em class="not-italic font-semibold">"{{ truncate(selectionText) }}"</em>
+          — Eşlemek için aşağıdan kriter seçin.
+        </span>
+        <span v-else>
+          Önce editörden bir metin seçin, ardından bir kritere tıklayın.
+        </span>
+      </p>
+    </div>
+
+    <!-- No criteria IDs warning -->
+    <div
+      v-if="noCriteriaIds && criteria.length > 0"
+      class="mx-4 mt-3 flex gap-2 rounded-lg bg-amber-50 dark:bg-amber-900/20 border border-amber-200 dark:border-amber-700 p-3 flex-shrink-0"
+    >
+      <AlertCircle class="w-4 h-4 text-amber-500 flex-shrink-0 mt-0.5" />
+      <p class="text-xs text-amber-700 dark:text-amber-300">
+        Kriter ID'leri yüklenemedi. Eşlemeler kriter adıyla kaydedilecek.
+      </p>
+    </div>
+
+    <!-- Loading -->
+    <div v-if="loading" class="flex-1 flex items-center justify-center">
+      <p class="text-sm text-slate-400 dark:text-slate-500">Rubrik yükleniyor…</p>
+    </div>
+
+    <!-- Empty -->
+    <div
+      v-else-if="criteria.length === 0"
+      class="flex-1 flex items-center justify-center p-6"
+    >
+      <p class="text-sm text-slate-400 dark:text-slate-500 text-center">
+        Bu teslim için rubrik tanımlanmamış.
+      </p>
+    </div>
+
+    <!-- Criteria list -->
+    <ul v-else class="flex-1 overflow-y-auto divide-y divide-slate-100 dark:divide-slate-700/60">
+      <li
+        v-for="(criterion, idx) in criteria"
+        :key="criterion.criterionName"
+        class="px-4 py-3"
+      >
+        <!-- Criterion header + link button -->
+        <div class="flex items-start gap-2">
+          <!-- Color dot -->
+          <span
+            class="mt-1 inline-block w-2.5 h-2.5 rounded-full flex-shrink-0 border"
+            :class="criterionColor(idx)"
+          />
+
+          <div class="flex-1 min-w-0">
+            <p class="text-sm font-medium text-slate-800 dark:text-slate-100 break-words leading-snug">
+              {{ criterion.criterionName }}
+            </p>
+            <div class="flex items-center gap-2 mt-0.5 flex-wrap">
+              <span
+                class="inline-flex items-center px-1.5 py-0.5 rounded text-[10px] font-medium"
+                :class="criterion.gradingType === 'Binary'
+                  ? 'bg-blue-100 text-blue-700 dark:bg-blue-900/40 dark:text-blue-300'
+                  : 'bg-purple-100 text-purple-700 dark:bg-purple-900/40 dark:text-purple-300'"
+              >
+                {{ criterion.gradingType }}
+              </span>
+              <span class="text-[11px] text-slate-500 dark:text-slate-400">{{ criterion.weight }}%</span>
+              <span
+                v-if="mappingCount(criterion.criterionName) > 0"
+                class="text-[10px] font-medium text-emerald-600 dark:text-emerald-400 flex items-center gap-0.5"
+              >
+                <CheckCircle2 class="w-3 h-3" />
+                {{ mappingCount(criterion.criterionName) }} bölüm
+              </span>
+            </div>
+          </div>
+
+          <!-- Link button -->
+          <button
+            type="button"
+            :disabled="!hasSelection"
+            class="flex-shrink-0 inline-flex items-center gap-1 px-2.5 py-1.5 rounded-lg text-xs font-medium transition-all border"
+            :class="hasSelection
+              ? 'bg-indigo-600 text-white border-indigo-600 hover:bg-indigo-700 shadow-sm'
+              : 'bg-slate-100 text-slate-400 border-slate-200 dark:bg-slate-800 dark:text-slate-500 dark:border-slate-700 cursor-not-allowed'"
+            :title="hasSelection ? 'Seçili metni bu kritere eşle' : 'Önce editörde metin seçin'"
+            @click="emit('link', criterion)"
+          >
+            <Link2 class="w-3 h-3" />
+            Eşle
+          </button>
+        </div>
+
+        <!-- Mapped sections for this criterion -->
+        <div
+          v-if="mappingsByCriterion.get(criterion.criterionName)?.length"
+          class="mt-2 ml-5 space-y-1"
+        >
+          <div
+            v-for="mapping in mappingsByCriterion.get(criterion.criterionName)"
+            :key="mapping.localId"
+            class="flex items-center gap-1.5 group"
+          >
+            <span
+              class="flex-1 inline-block text-[11px] px-2 py-0.5 rounded border truncate"
+              :class="criterionColor(idx)"
+              :title="mapping.sectionReference"
+            >
+              "{{ truncate(mapping.sectionReference, 40) }}"
+            </span>
+            <button
+              type="button"
+              class="opacity-0 group-hover:opacity-100 transition-opacity p-0.5 rounded text-red-400 hover:text-red-600 dark:hover:text-red-400"
+              title="Eşlemeyi kaldır"
+              @click="emit('removeMapping', mapping.localId)"
+            >
+              <Trash2 class="w-3 h-3" />
+            </button>
+          </div>
+        </div>
+      </li>
+    </ul>
+
+    <!-- Footer: total mappings -->
+    <div
+      v-if="mappings.length > 0"
+      class="px-4 py-2.5 border-t border-slate-200 dark:border-slate-700 bg-slate-50 dark:bg-slate-800/50 flex-shrink-0"
+    >
+      <p class="text-xs text-slate-600 dark:text-slate-400">
+        <span class="font-semibold text-indigo-600 dark:text-indigo-400">{{ mappings.length }}</span>
+        bölüm eşlendi — Teslim sırasında kaydedilecek.
+      </p>
+    </div>
+  </div>
+</template>

--- a/frontend/composables/useApiClient.ts
+++ b/frontend/composables/useApiClient.ts
@@ -39,6 +39,13 @@ import type {
 import type { StudentSearchResult } from '~/types/student';
 import type { BindJiraRequest, BindGithubRequest, BindToolResponse } from '~/types/tools';
 import type { SanitizationReport } from '~/types/sanitization';
+import type {
+  StudentDeliverable,
+  SubmissionCreateResponse,
+  SubmissionResponse,
+  SaveRubricMappingsRequest,
+  SaveRubricMappingsResponse,
+} from '~/types/submission';
 
 async function apiCall<T>(
   endpoint: string,
@@ -453,6 +460,62 @@ export function useApiClient() {
     );
   }
 
+  async function fetchStudentDeliverables(token?: string): Promise<StudentDeliverable[]> {
+    return apiCall<StudentDeliverable[]>("/deliverables", "GET", undefined, token);
+  }
+
+  async function submitDeliverable(
+    deliverableId: string,
+    content: string,
+    token?: string
+  ): Promise<SubmissionCreateResponse> {
+    return apiCall<SubmissionCreateResponse>(
+      `/deliverables/${encodeURIComponent(deliverableId)}/submissions`,
+      "POST",
+      { content },
+      token
+    );
+  }
+
+  async function reviseSubmission(
+    submissionId: string,
+    content: string,
+    token?: string
+  ): Promise<SubmissionResponse> {
+    return apiCall<SubmissionResponse>(
+      `/submissions/${encodeURIComponent(submissionId)}`,
+      "PUT",
+      { content },
+      token
+    );
+  }
+
+  async function saveRubricMappings(
+    submissionId: string,
+    payload: SaveRubricMappingsRequest,
+    token?: string
+  ): Promise<SaveRubricMappingsResponse> {
+    return apiCall<SaveRubricMappingsResponse>(
+      `/submissions/${encodeURIComponent(submissionId)}/rubric-mappings`,
+      "POST",
+      payload,
+      token
+    );
+  }
+
+  async function fetchStudentRubric(
+    deliverableId: string,
+    token?: string
+  ): Promise<RubricCriterionResponse[]> {
+    // Student-facing rubric endpoint — uses coordinator path; handle 403 gracefully
+    return apiCall<RubricCriterionResponse[]>(
+      `/coordinator/deliverables/${encodeURIComponent(deliverableId)}/rubric`,
+      "GET",
+      undefined,
+      token
+    );
+  }
+
   async function createCommittee(
     payload: CreateCommitteeRequest,
     token?: string
@@ -558,6 +621,11 @@ export function useApiClient() {
     searchStudents,
     sendGroupInvitation,
     fetchGroupInvitations,
-    cancelGroupInvitation
+    cancelGroupInvitation,
+    fetchStudentDeliverables,
+    submitDeliverable,
+    reviseSubmission,
+    saveRubricMappings,
+    fetchStudentRubric,
   };
 }

--- a/frontend/pages/student/dashboard.vue
+++ b/frontend/pages/student/dashboard.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
-	import { LogOut, GitBranch, FileCheck, Users } from "lucide-vue-next";
+	import { LogOut, GitBranch, FileCheck, Users, Send, Clock, CheckCircle2, AlertCircle } from "lucide-vue-next";
 	import { useAuthStore } from "~/stores/auth";
+	import type { StudentDeliverable } from "~/types/submission";
 
 	definePageMeta({
 		middleware: "auth",
@@ -9,11 +10,41 @@
 
 	const router = useRouter();
 	const authStore = useAuthStore();
+	const { getAuthToken, fetchStudentDeliverables } = useApiClient();
+
+	const deliverables = ref<StudentDeliverable[]>([]);
+	const loadingDeliverables = ref(true);
+	const deliverablesError = ref<string | null>(null);
+
+	async function loadDeliverables() {
+		loadingDeliverables.value = true;
+		deliverablesError.value = null;
+		try {
+			const token = getAuthToken();
+			if (token) {
+				deliverables.value = await fetchStudentDeliverables(token);
+			}
+		} catch {
+			deliverablesError.value = "Teslim listesi yüklenemedi.";
+		} finally {
+			loadingDeliverables.value = false;
+		}
+	}
+
+	function formatDate(dateStr: string) {
+		try {
+			return new Intl.DateTimeFormat("tr-TR", { dateStyle: "medium" }).format(new Date(dateStr));
+		} catch {
+			return dateStr;
+		}
+	}
 
 	function handleLogout() {
 		authStore.logout();
 		router.push("/auth/login");
 	}
+
+	onMounted(loadDeliverables);
 </script>
 
 <template>
@@ -31,8 +62,8 @@
             </p>
           </div>
           <button
-            @click="handleLogout"
             class="rounded-lg border border-slate-300 bg-white px-4 py-2 text-sm font-medium text-slate-700 transition hover:bg-slate-50 dark:border-slate-600 dark:bg-slate-700 dark:text-slate-300 dark:hover:bg-slate-600"
+            @click="handleLogout"
           >
             <LogOut class="mr-2 inline h-4 w-4" />
             Sign Out
@@ -40,7 +71,7 @@
         </div>
       </header>
 
-      <!-- Overview -->
+      <!-- Quick nav cards -->
       <div class="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
         <div class="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm dark:border-slate-700 dark:bg-slate-800">
           <GitBranch class="h-8 w-8 text-blue-600 dark:text-blue-400" />
@@ -54,7 +85,7 @@
           <FileCheck class="h-8 w-8 text-emerald-600 dark:text-emerald-400" />
           <h3 class="mt-3 font-semibold text-slate-900 dark:text-white">Deliverables</h3>
           <p class="mt-1 text-sm text-slate-600 dark:text-slate-400">
-            View upcoming deliverable deadlines.
+            Aşağıdaki listeden teslim işlemi yapabilirsiniz.
           </p>
         </div>
 
@@ -69,6 +100,80 @@
           </p>
         </NuxtLink>
       </div>
+
+      <!-- Deliverables section -->
+      <section class="rounded-2xl border border-slate-200 bg-white shadow-sm dark:border-slate-700 dark:bg-slate-800 overflow-hidden">
+        <div class="flex items-center gap-2 px-6 py-4 border-b border-slate-200 dark:border-slate-700 bg-slate-50 dark:bg-slate-800/60">
+          <FileCheck class="w-4 h-4 text-emerald-500" />
+          <h2 class="text-sm font-semibold text-slate-700 dark:text-slate-200">Teslimler</h2>
+        </div>
+
+        <!-- Loading -->
+        <div v-if="loadingDeliverables" class="px-6 py-8 text-center text-sm text-slate-400 dark:text-slate-500">
+          Yükleniyor…
+        </div>
+
+        <!-- Error -->
+        <div v-else-if="deliverablesError" class="flex items-center gap-3 px-6 py-5 text-sm text-red-600 dark:text-red-400">
+          <AlertCircle class="w-4 h-4 flex-shrink-0" />
+          {{ deliverablesError }}
+        </div>
+
+        <!-- Empty -->
+        <div v-else-if="deliverables.length === 0" class="px-6 py-8 text-center text-sm text-slate-400 dark:text-slate-500">
+          Henüz teslim tanımlanmamış.
+        </div>
+
+        <!-- List -->
+        <ul v-else class="divide-y divide-slate-100 dark:divide-slate-700/60">
+          <li
+            v-for="d in deliverables"
+            :key="d.id"
+            class="flex items-center gap-4 px-6 py-4"
+          >
+            <!-- Status icon -->
+            <span class="flex-shrink-0">
+              <CheckCircle2
+                v-if="d.submissionStatus === 'Graded' || d.submissionStatus === 'Submitted'"
+                class="w-5 h-5 text-emerald-500"
+              />
+              <Clock v-else class="w-5 h-5 text-slate-400 dark:text-slate-500" />
+            </span>
+
+            <!-- Info -->
+            <div class="flex-1 min-w-0">
+              <p class="text-sm font-medium text-slate-800 dark:text-slate-100 truncate">{{ d.name }}</p>
+              <div class="flex flex-wrap items-center gap-x-3 gap-y-0.5 mt-0.5">
+                <span class="text-xs text-slate-500 dark:text-slate-400">
+                  Son teslim: {{ formatDate(d.submissionDeadline) }}
+                </span>
+                <span
+                  class="inline-flex items-center px-1.5 py-0.5 rounded text-[10px] font-medium"
+                  :class="{
+                    'bg-emerald-100 text-emerald-700 dark:bg-emerald-900/40 dark:text-emerald-300': d.submissionStatus === 'Graded',
+                    'bg-blue-100 text-blue-700 dark:bg-blue-900/40 dark:text-blue-300': d.submissionStatus === 'Submitted',
+                    'bg-slate-100 text-slate-600 dark:bg-slate-700 dark:text-slate-400': d.submissionStatus === 'Not Submitted',
+                  }"
+                >
+                  {{ d.submissionStatus === 'Graded' ? 'Notlandırıldı' : d.submissionStatus === 'Submitted' ? 'Teslim Edildi' : 'Teslim Edilmedi' }}
+                </span>
+              </div>
+            </div>
+
+            <!-- Action button -->
+            <NuxtLink
+              :to="`/student/submit/${d.id}`"
+              class="flex-shrink-0 inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-sm font-medium transition-all border"
+              :class="d.submissionStatus === 'Not Submitted'
+                ? 'bg-indigo-600 text-white border-indigo-600 hover:bg-indigo-700 shadow-sm'
+                : 'bg-white text-slate-700 border-slate-300 hover:bg-slate-50 dark:bg-slate-700 dark:text-slate-300 dark:border-slate-600 dark:hover:bg-slate-600'"
+            >
+              <Send class="w-3.5 h-3.5" />
+              {{ d.submissionStatus === 'Not Submitted' ? 'Teslim Et' : 'Güncelle' }}
+            </NuxtLink>
+          </li>
+        </ul>
+      </section>
     </div>
   </main>
 </template>

--- a/frontend/pages/student/submit/[deliverableId].vue
+++ b/frontend/pages/student/submit/[deliverableId].vue
@@ -1,0 +1,298 @@
+<script setup lang="ts">
+import {
+  ArrowLeft,
+  AlertCircle,
+  CheckCircle2,
+  Loader2,
+  Send,
+  FileText,
+  PanelRight,
+} from "lucide-vue-next";
+import type { RubricCriterionResponse } from "~/types/rubric";
+import type { LocalMappingEntry } from "~/types/submission";
+
+definePageMeta({
+  middleware: "auth",
+  roles: ["Student"],
+});
+
+const route = useRoute();
+const router = useRouter();
+const {
+  getAuthToken,
+  fetchStudentDeliverables,
+  submitDeliverable,
+  fetchStudentRubric,
+  saveRubricMappings,
+} = useApiClient();
+
+const deliverableId = computed(() => route.params.deliverableId as string);
+
+// State
+const deliverableName = ref<string>("");
+const markdownContent = ref<string>("");
+const rubricCriteria = ref<RubricCriterionResponse[]>([]);
+const localMappings = ref<LocalMappingEntry[]>([]);
+
+const loadingRubric = ref(true);
+const loadError = ref<string | null>(null);
+const submitting = ref(false);
+const submitError = ref<string | null>(null);
+const submitSuccess = ref(false);
+const submittedId = ref<string | null>(null);
+
+const rubricPanelVisible = ref(true);
+
+// Selection state (synced from MarkdownEditor via expose)
+const editorRef = ref<{ selectionText: string; selectionStart: number; selectionEnd: number; hasSelection: boolean } | null>(null);
+
+const hasSelection = computed(() => editorRef.value?.hasSelection ?? false);
+const selectionText = computed(() => editorRef.value?.selectionText ?? "");
+
+// Whether criteria have IDs (backend may not return them)
+const noCriteriaIds = computed(() =>
+  rubricCriteria.value.length > 0 && rubricCriteria.value.every((c) => !c.id)
+);
+
+// ── Load ──────────────────────────────────────────────────────────────────────
+
+async function load() {
+  loadingRubric.value = true;
+  loadError.value = null;
+  try {
+    const token = getAuthToken();
+    if (!token) throw new Error("Kimlik doğrulaması gerekiyor.");
+
+    // Get deliverable name from student deliverables list
+    try {
+      const deliverables = await fetchStudentDeliverables(token);
+      const match = deliverables.find((d) => d.id === deliverableId.value);
+      if (match) deliverableName.value = match.name;
+    } catch {
+      // Not critical
+    }
+
+    // Get rubric criteria (403 if coordinator-only; handle gracefully)
+    try {
+      rubricCriteria.value = await fetchStudentRubric(deliverableId.value, token);
+    } catch {
+      rubricCriteria.value = [];
+    }
+  } catch (err: unknown) {
+    loadError.value = parseError(err, "Veriler yüklenemedi.");
+  } finally {
+    loadingRubric.value = false;
+  }
+}
+
+// ── Mapping ───────────────────────────────────────────────────────────────────
+
+function handleLink(criterion: RubricCriterionResponse) {
+  const text = selectionText.value;
+  if (!text.trim()) return;
+
+  // Prevent duplicate: same criterion + same text
+  const alreadyExists = localMappings.value.some(
+    (m) => m.criterionName === criterion.criterionName && m.sectionReference === text
+  );
+  if (alreadyExists) return;
+
+  localMappings.value.push({
+    localId: crypto.randomUUID(),
+    criterionId: criterion.id ?? criterion.criterionName,
+    criterionName: criterion.criterionName,
+    sectionReference: text,
+  });
+}
+
+function handleRemoveMapping(localId: string) {
+  localMappings.value = localMappings.value.filter((m) => m.localId !== localId);
+}
+
+// ── Submit ────────────────────────────────────────────────────────────────────
+
+async function handleSubmit() {
+  if (!markdownContent.value.trim()) {
+    submitError.value = "Teslim içeriği boş olamaz.";
+    return;
+  }
+
+  submitting.value = true;
+  submitError.value = null;
+
+  try {
+    const token = getAuthToken();
+    if (!token) throw new Error("Kimlik doğrulaması gerekiyor.");
+
+    // 1. POST submission content
+    const result = await submitDeliverable(deliverableId.value, markdownContent.value, token);
+    submittedId.value = result.submissionId;
+
+    // 2. POST rubric mappings if any
+    if (localMappings.value.length > 0) {
+      try {
+        await saveRubricMappings(
+          result.submissionId,
+          {
+            mappings: localMappings.value.map((m) => ({
+              criterionId: m.criterionId,
+              sectionReference: m.sectionReference,
+            })),
+          },
+          token
+        );
+      } catch {
+        // Mappings failed but submission succeeded — show warning, not error
+        submitError.value = "Teslim kaydedildi ancak bölüm eşlemeleri kaydedilemedi.";
+      }
+    }
+
+    submitSuccess.value = true;
+  } catch (err: unknown) {
+    submitError.value = parseError(err, "Teslim sırasında bir hata oluştu.");
+  } finally {
+    submitting.value = false;
+  }
+}
+
+// ── Utils ─────────────────────────────────────────────────────────────────────
+
+function parseError(err: unknown, fallback: string): string {
+  return err && typeof err === "object" && "message" in err
+    ? String((err as { message: string }).message)
+    : fallback;
+}
+
+onMounted(load);
+</script>
+
+<template>
+  <div class="flex flex-col h-screen bg-slate-50 dark:bg-slate-950 overflow-hidden">
+
+    <!-- Top bar -->
+    <header class="flex items-center gap-3 px-4 py-3 border-b border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-900 flex-shrink-0 shadow-sm">
+      <button
+        class="inline-flex items-center gap-1.5 text-sm text-slate-600 dark:text-slate-300 hover:text-slate-900 dark:hover:text-white transition-colors"
+        @click="router.back()"
+      >
+        <ArrowLeft class="w-4 h-4" />
+        Geri
+      </button>
+
+      <div class="h-5 w-px bg-slate-200 dark:bg-slate-700" />
+      <FileText class="w-4 h-4 text-indigo-500 flex-shrink-0" />
+      <h1 class="text-sm font-semibold text-slate-800 dark:text-slate-100 truncate">
+        {{ deliverableName || "Teslim Yaz" }}
+      </h1>
+
+      <div class="ml-auto flex items-center gap-2">
+        <!-- Panel toggle -->
+        <button
+          class="p-1.5 rounded hover:bg-slate-100 dark:hover:bg-slate-800 transition-colors"
+          :class="rubricPanelVisible ? 'text-indigo-500' : 'text-slate-400'"
+          title="Rubrik panelini aç/kapat"
+          @click="rubricPanelVisible = !rubricPanelVisible"
+        >
+          <PanelRight class="w-4 h-4" />
+        </button>
+
+        <!-- Submit button -->
+        <button
+          :disabled="submitting || submitSuccess || !markdownContent.trim()"
+          class="inline-flex items-center gap-2 px-4 py-2 rounded-lg text-sm font-medium transition-all"
+          :class="submitSuccess
+            ? 'bg-emerald-600 text-white cursor-default'
+            : 'bg-indigo-600 text-white hover:bg-indigo-700 disabled:opacity-50 disabled:cursor-not-allowed shadow-sm'"
+          @click="handleSubmit"
+        >
+          <Loader2 v-if="submitting" class="w-4 h-4 animate-spin" />
+          <CheckCircle2 v-else-if="submitSuccess" class="w-4 h-4" />
+          <Send v-else class="w-4 h-4" />
+          {{ submitSuccess ? "Teslim Edildi" : submitting ? "Gönderiliyor…" : "Teslim Et" }}
+        </button>
+      </div>
+    </header>
+
+    <!-- Error / success banner -->
+    <div
+      v-if="submitError"
+      class="flex items-start gap-3 px-4 py-3 bg-red-50 dark:bg-red-900/20 border-b border-red-200 dark:border-red-800 text-sm text-red-700 dark:text-red-300 flex-shrink-0"
+    >
+      <AlertCircle class="w-4 h-4 flex-shrink-0 mt-0.5" />
+      {{ submitError }}
+    </div>
+
+    <div
+      v-if="submitSuccess"
+      class="flex items-start gap-3 px-4 py-3 bg-emerald-50 dark:bg-emerald-900/20 border-b border-emerald-200 dark:border-emerald-800 text-sm text-emerald-700 dark:text-emerald-300 flex-shrink-0"
+    >
+      <CheckCircle2 class="w-4 h-4 flex-shrink-0 mt-0.5" />
+      Teslim başarıyla kaydedildi!
+      <span v-if="localMappings.length > 0"> {{ localMappings.length }} bölüm eşlemesiyle birlikte.</span>
+    </div>
+
+    <!-- Main load error -->
+    <div
+      v-if="loadError"
+      class="flex-1 flex items-center justify-center p-8"
+    >
+      <div class="max-w-sm w-full bg-red-50 dark:bg-red-900/20 rounded-xl border border-red-200 dark:border-red-800 p-6 flex gap-4">
+        <AlertCircle class="w-5 h-5 text-red-500 flex-shrink-0 mt-0.5" />
+        <div>
+          <p class="font-semibold text-sm text-red-700 dark:text-red-300">Yükleme hatası</p>
+          <p class="text-sm text-red-600 dark:text-red-400 mt-1">{{ loadError }}</p>
+          <button class="mt-3 text-sm underline text-red-600 dark:text-red-400" @click="load">
+            Tekrar dene
+          </button>
+        </div>
+      </div>
+    </div>
+
+    <!-- Split layout -->
+    <div v-else class="flex-1 flex overflow-hidden min-h-0">
+
+      <!-- Left: Markdown editor -->
+      <section
+        class="flex flex-col overflow-hidden border-r border-slate-200 dark:border-slate-700 flex-1 bg-white dark:bg-slate-900"
+        aria-label="Markdown editörü"
+      >
+        <!-- Section header -->
+        <div class="px-4 py-2.5 bg-slate-50 dark:bg-slate-800/50 border-b border-slate-200 dark:border-slate-700 flex-shrink-0 flex items-center gap-2">
+          <FileText class="w-3.5 h-3.5 text-slate-400" />
+          <span class="text-xs font-medium text-slate-600 dark:text-slate-300 uppercase tracking-wide">
+            Markdown Editörü
+          </span>
+          <span class="ml-auto text-xs text-slate-400">
+            {{ markdownContent.length }} karakter
+          </span>
+        </div>
+
+        <MarkdownEditor
+          ref="editorRef"
+          v-model="markdownContent"
+          :mappings="localMappings"
+          :disabled="submitSuccess"
+          class="flex-1 min-h-0"
+        />
+      </section>
+
+      <!-- Right: Rubric linking panel -->
+      <section
+        v-show="rubricPanelVisible"
+        class="w-80 lg:w-96 flex-shrink-0 flex flex-col overflow-hidden bg-white dark:bg-slate-900"
+        aria-label="Rubrik bölüm eşleme"
+      >
+        <RubricLinkingPanel
+          :criteria="rubricCriteria"
+          :mappings="localMappings"
+          :has-selection="hasSelection"
+          :selection-text="selectionText"
+          :loading="loadingRubric"
+          :no-criteria-ids="noCriteriaIds"
+          @link="handleLink"
+          @remove-mapping="handleRemoveMapping"
+        />
+      </section>
+    </div>
+  </div>
+</template>

--- a/frontend/types/rubric.ts
+++ b/frontend/types/rubric.ts
@@ -12,6 +12,7 @@ export interface CreateRubricRequest {
 }
 
 export interface RubricCriterionResponse {
+  id?: string;
   criterionName: string;
   gradingType: GradingType;
   weight: number;

--- a/frontend/types/submission.ts
+++ b/frontend/types/submission.ts
@@ -1,0 +1,47 @@
+export interface StudentDeliverable {
+  id: string;
+  name: string;
+  type: "Proposal" | "SoW" | "Demonstration";
+  submissionDeadline: string;
+  reviewDeadline: string;
+  submissionStatus: "Not Submitted" | "Submitted" | "Graded";
+}
+
+export interface SubmissionCreateResponse {
+  submissionId: string;
+  deliverableId: string;
+  groupId: string;
+  status: string;
+  submittedAt: string;
+}
+
+export interface SubmissionResponse {
+  submissionId: string;
+  deliverableId: string;
+  groupId: string;
+  content: string;
+  submittedAt: string;
+  revisedAt: string | null;
+}
+
+export interface RubricMappingEntry {
+  criterionId: string;
+  sectionReference: string;
+}
+
+export interface SaveRubricMappingsRequest {
+  mappings: RubricMappingEntry[];
+}
+
+export interface SaveRubricMappingsResponse {
+  submissionId: string;
+  mappingCount: number;
+}
+
+/** Local (UI-only) mapping entry, not yet persisted */
+export interface LocalMappingEntry {
+  localId: string;
+  criterionId: string;
+  criterionName: string;
+  sectionReference: string;
+}


### PR DESCRIPTION
## Summary

Closes #200

Implements a rubric-linking UI that allows students to highlight sections of their Markdown submission and associate them with specific rubric criteria before submitting.

## Changes

### New Files
- **`frontend/types/submission.ts`** — Type definitions: `StudentDeliverable`, `SubmissionCreateResponse`, `SubmissionResponse`, `RubricMappingEntry`, `SaveRubricMappingsRequest`, `SaveRubricMappingsResponse`, `LocalMappingEntry`
- **`frontend/components/MarkdownEditor.vue`** — Textarea-based Markdown editor with a visual highlight overlay that shows mapped sections color-coded by criterion index (6-color palette). Tracks text selection and exposes `selectionText`, `hasSelection`, `selectionStart`, `selectionEnd` via `defineExpose`.
- **`frontend/components/RubricLinkingPanel.vue`** — Side panel listing rubric criteria with per-criterion "Eşle" buttons (enabled only when text is selected in the editor). Shows mapped section chips per criterion with delete-on-hover. Warns if criterion IDs are not available from the backend.
- **`frontend/pages/student/submit/[deliverableId].vue`** — Full-screen split-panel submission page: editor (left) + rubric panel (right). Fetches deliverable info and rubric on mount, handles submit + revision, saves rubric mappings after submission. Rubric panel can be toggled via a header button.

### Updated Files
- **`frontend/composables/useApiClient.ts`** — Added 5 new API functions: `fetchStudentDeliverables`, `submitDeliverable`, `reviseSubmission`, `saveRubricMappings`, `fetchStudentRubric`
- **`frontend/types/rubric.ts`** — Added `id?: string` to `RubricCriterionResponse` (required for `criterionId` in mapping payloads)
- **`frontend/pages/student/dashboard.vue`** — Added a live "Teslimler" section that fetches and lists deliverables with status badges and "Teslim Et" / "Güncelle" navigation buttons

## How It Works

1. Student opens `/student/submit/:deliverableId`
2. Editor and rubric panel load side-by-side
3. Student writes Markdown in the editor
4. Student selects text → "Eşle" buttons activate in the rubric panel
5. Student clicks "Eşle" next to a criterion → mapping is created and highlighted in the editor
6. Student can remove mappings using the chip delete button
7. On submit: POST `/deliverables/{id}/submissions` → then POST `/submissions/{id}/rubric-mappings`

## Notes
- DOMPurify is loaded dynamically (client-only) to avoid SSR crashes
- 403 from rubric endpoint is handled gracefully (rubric panel shows empty state)
- If backend does not return criterion `id` fields, `criterionName` is used as fallback with a warning banner