### PR TITLE
feat(observability): add trace logging for user events (issue #255)

### DIFF
--- a/backend/src/main/java/com/senior/spm/service/AdvisorService.java
+++ b/backend/src/main/java/com/senior/spm/service/AdvisorService.java
@@ -36,7 +36,9 @@ import com.senior.spm.service.dto.AdvisorRequestSummary;
 import com.senior.spm.service.dto.AdvisorRespondResponse;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class AdvisorService {
@@ -175,6 +177,8 @@ public class AdvisorService {
         request.setSentAt(now);
         AdvisorRequest saved = advisorRequestRepository.save(request);
 
+        log.trace("[EVENT] userId={} action={} entityId={} detail={}",
+                requesterUUID, "ADVISOR_REQUEST_SENT", advisorId, groupId);
         return AdvisorRequestResponse.builder()
                 .requestId(saved.getId())
                 .groupId(group.getId())
@@ -420,6 +424,8 @@ public class AdvisorService {
             request.setRespondedAt(now);
             advisorRequestRepository.save(request);
 
+            log.trace("[EVENT] userId={} action={} entityId={} detail={}",
+                    professorId, "ADVISOR_REQUEST_RESPONDED", request.getGroup().getId(), "REJECTED");
             return AdvisorRespondResponse.builder()
                 .requestId(request.getId())
                 .status(AdvisorRequest.RequestStatus.REJECTED)
@@ -456,6 +462,8 @@ public class AdvisorService {
         // Auto-reject all other PENDING requests for this group (same group, different advisors)
         advisorRequestRepository.bulkUpdateStatusForGroup(AdvisorRequest.RequestStatus.AUTO_REJECTED, group.getId(), request.getId());
 
+        log.trace("[EVENT] userId={} action={} entityId={} detail={}",
+                professorId, "ADVISOR_REQUEST_RESPONDED", group.getId(), "ACCEPTED");
         return AdvisorRespondResponse.builder()
             .requestId(request.getId())
             .status(AdvisorRequest.RequestStatus.ACCEPTED)

--- a/backend/src/main/java/com/senior/spm/service/AuthService.java
+++ b/backend/src/main/java/com/senior/spm/service/AuthService.java
@@ -62,7 +62,7 @@ public class AuthService {
                     staffUser.get().isFirstLogin());
 
             log.trace("[EVENT] userId={} action={} entityId={} detail={}",
-                    staffUser.get().getId(), "STAFF_LOGIN", staffUser.get().getId(), staffUser.get().getMail());
+                    staffUser.get().getId(), "STAFF_LOGIN", staffUser.get().getId(), "staff-password-auth");
             return new LoginResponse(token, userInfo);
         }
 
@@ -130,7 +130,7 @@ public class AuthService {
                 "STUDENT");
 
         log.trace("[EVENT] userId={} action={} entityId={} detail={}",
-                studentOpt.get().getId(), "STUDENT_LOGIN", studentOpt.get().getId(), githubUser.login());
+                studentOpt.get().getId(), "STUDENT_LOGIN", studentOpt.get().getId(), "github-oauth");
         return new GithubLoginResponse(token, userInfo);
     }
 }

--- a/backend/src/main/java/com/senior/spm/service/AuthService.java
+++ b/backend/src/main/java/com/senior/spm/service/AuthService.java
@@ -15,6 +15,9 @@ import com.senior.spm.repository.PasswordResetTokenRepository;
 import com.senior.spm.repository.StaffUserRepository;
 import com.senior.spm.repository.StudentRepository;
 
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
 @Service
 public class AuthService {
 
@@ -58,6 +61,8 @@ public class AuthService {
                     staffUser.get().getRole(),
                     staffUser.get().isFirstLogin());
 
+            log.trace("[EVENT] userId={} action={} entityId={} detail={}",
+                    staffUser.get().getId(), "STAFF_LOGIN", staffUser.get().getId(), staffUser.get().getMail());
             return new LoginResponse(token, userInfo);
         }
 
@@ -124,6 +129,8 @@ public class AuthService {
                 studentOpt.get().getGithubUsername(),
                 "STUDENT");
 
+        log.trace("[EVENT] userId={} action={} entityId={} detail={}",
+                studentOpt.get().getId(), "STUDENT_LOGIN", studentOpt.get().getId(), githubUser.login());
         return new GithubLoginResponse(token, userInfo);
     }
 }

--- a/backend/src/main/java/com/senior/spm/service/GroupService.java
+++ b/backend/src/main/java/com/senior/spm/service/GroupService.java
@@ -35,7 +35,9 @@ import com.senior.spm.repository.ScheduleWindowRepository;
 import com.senior.spm.repository.StudentRepository;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class GroupService {
@@ -107,6 +109,8 @@ public class GroupService {
 
         groupMembershipRepository.save(membership);
 
+        log.trace("[EVENT] userId={} action={} entityId={} detail={}",
+                studentUUID, "GROUP_CREATED", savedGroup.getId(), groupName);
         // 8. Return GroupDetailResponse
         return toGroupDetailResponse(savedGroup, studentUUID);
     }

--- a/backend/src/main/java/com/senior/spm/service/InvitationService.java
+++ b/backend/src/main/java/com/senior/spm/service/InvitationService.java
@@ -30,6 +30,7 @@ import com.senior.spm.repository.ProjectGroupRepository;
 import com.senior.spm.repository.StudentRepository;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
 /**
  * Coordinates the group invitation lifecycle for Process 2.
@@ -39,6 +40,7 @@ import lombok.RequiredArgsConstructor;
  * lock enforcement on accept, and the transactional accept flow that creates
  * group membership while auto-denying competing pending invitations.
  */
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class InvitationService {
@@ -104,6 +106,8 @@ public class InvitationService {
         invitation.setStatus(InvitationStatus.PENDING);
         invitation.setSentAt(nowUtc());
 
+        log.trace("[EVENT] userId={} action={} entityId={} detail={}",
+                requesterUUID, "INVITATION_SENT", targetStudent.getId(), targetStudentId);
         return toSendInvitationResponse(groupInvitationRepository.save(invitation));
     }
 
@@ -200,6 +204,8 @@ public class InvitationService {
         if (!accept) {
             invitation.setStatus(InvitationStatus.DECLINED);
             invitation.setRespondedAt(nowUtc());
+            log.trace("[EVENT] userId={} action={} entityId={} detail={}",
+                    studentUUID, "INVITATION_RESPONDED", invitationId, "DECLINED");
             return toStatusOnlyResponse(groupInvitationRepository.save(invitation));
         }
 
@@ -239,6 +245,8 @@ public class InvitationService {
         // Bulk update excludes the accepted invitation id so the final state is deterministic.
         groupInvitationRepository.autoDenyOtherPendingInvitationsExcept(studentUUID, invitationId);
 
+        log.trace("[EVENT] userId={} action={} entityId={} detail={}",
+                studentUUID, "INVITATION_RESPONDED", invitationId, "ACCEPTED");
         return groupService.getGroupDetail(group.getId());
     }
 

--- a/backend/src/main/java/com/senior/spm/service/InvitationService.java
+++ b/backend/src/main/java/com/senior/spm/service/InvitationService.java
@@ -106,9 +106,10 @@ public class InvitationService {
         invitation.setStatus(InvitationStatus.PENDING);
         invitation.setSentAt(nowUtc());
 
+        GroupInvitation saved = groupInvitationRepository.save(invitation);
         log.trace("[EVENT] userId={} action={} entityId={} detail={}",
-                requesterUUID, "INVITATION_SENT", targetStudent.getId(), targetStudentId);
-        return toSendInvitationResponse(groupInvitationRepository.save(invitation));
+                requesterUUID, "INVITATION_SENT", saved.getId(), targetStudentId);
+        return toSendInvitationResponse(saved);
     }
 
     /**
@@ -204,9 +205,10 @@ public class InvitationService {
         if (!accept) {
             invitation.setStatus(InvitationStatus.DECLINED);
             invitation.setRespondedAt(nowUtc());
+            InvitationActionResponse response = toStatusOnlyResponse(groupInvitationRepository.save(invitation));
             log.trace("[EVENT] userId={} action={} entityId={} detail={}",
                     studentUUID, "INVITATION_RESPONDED", invitationId, "DECLINED");
-            return toStatusOnlyResponse(groupInvitationRepository.save(invitation));
+            return response;
         }
 
         ProjectGroup group = projectGroupRepository.findById(invitation.getGroup().getId())

--- a/backend/src/main/java/com/senior/spm/service/ScrumGradingService.java
+++ b/backend/src/main/java/com/senior/spm/service/ScrumGradingService.java
@@ -84,26 +84,26 @@ public class ScrumGradingService {
         Sprint sprint = findSprintOrThrow(sprintId);
 
         Optional<ScrumGrade> existing = scrumGradeRepository.findByGroupIdAndSprintId(groupId, sprintId);
+        ScrumGrade grade;
         if (existing.isEmpty()) {
-            ScrumGrade grade = new ScrumGrade();
-            grade.setGroup(group);
-            grade.setSprint(sprint);
-            grade.setAdvisor(group.getAdvisor());
+            ScrumGrade newGrade = new ScrumGrade();
+            newGrade.setGroup(group);
+            newGrade.setSprint(sprint);
+            newGrade.setAdvisor(group.getAdvisor());
+            newGrade.setPointAGrade(request.getPointAGrade());
+            newGrade.setPointBGrade(request.getPointBGrade());
+            newGrade.setGradedAt(LocalDateTime.now());
+            grade = scrumGradeRepository.save(newGrade);
+        } else {
+            grade = existing.get();
             grade.setPointAGrade(request.getPointAGrade());
             grade.setPointBGrade(request.getPointBGrade());
-            grade.setGradedAt(LocalDateTime.now());
-            log.trace("[EVENT] userId={} action={} entityId={} detail={}",
-                    advisorId, "SCRUM_GRADE_SUBMITTED", groupId, sprintId);
-            return scrumGradeRepository.save(grade);
+            grade.setUpdatedAt(LocalDateTime.now());
+            grade = scrumGradeRepository.save(grade);
         }
-
-        ScrumGrade grade = existing.get();
-        grade.setPointAGrade(request.getPointAGrade());
-        grade.setPointBGrade(request.getPointBGrade());
-        grade.setUpdatedAt(LocalDateTime.now());
         log.trace("[EVENT] userId={} action={} entityId={} detail={}",
                 advisorId, "SCRUM_GRADE_SUBMITTED", groupId, sprintId);
-        return scrumGradeRepository.save(grade);
+        return grade;
     }
 
     // -------------------------------------------------------------------------

--- a/backend/src/main/java/com/senior/spm/service/ScrumGradingService.java
+++ b/backend/src/main/java/com/senior/spm/service/ScrumGradingService.java
@@ -37,7 +37,9 @@ import com.senior.spm.repository.SprintRepository;
 import com.senior.spm.repository.SprintTrackingLogRepository;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class ScrumGradingService {
@@ -90,6 +92,8 @@ public class ScrumGradingService {
             grade.setPointAGrade(request.getPointAGrade());
             grade.setPointBGrade(request.getPointBGrade());
             grade.setGradedAt(LocalDateTime.now());
+            log.trace("[EVENT] userId={} action={} entityId={} detail={}",
+                    advisorId, "SCRUM_GRADE_SUBMITTED", groupId, sprintId);
             return scrumGradeRepository.save(grade);
         }
 
@@ -97,6 +101,8 @@ public class ScrumGradingService {
         grade.setPointAGrade(request.getPointAGrade());
         grade.setPointBGrade(request.getPointBGrade());
         grade.setUpdatedAt(LocalDateTime.now());
+        log.trace("[EVENT] userId={} action={} entityId={} detail={}",
+                advisorId, "SCRUM_GRADE_SUBMITTED", groupId, sprintId);
         return scrumGradeRepository.save(grade);
     }
 

--- a/backend/src/main/resources/application.properties.example
+++ b/backend/src/main/resources/application.properties.example
@@ -24,3 +24,6 @@ llm.api.timeout-seconds=15
 
 # The actual API key is NOT stored here — it is stored encrypted in the
 # system_config table under the key 'llm_api_key', use admin ui .
+
+# Dev-only: activate trace event logging (do not set in production)
+logging.level.com.senior.spm=TRACE

--- a/backend/src/test/resources/test.properties
+++ b/backend/src/test/resources/test.properties
@@ -23,3 +23,6 @@ GITHUB_CLIENT_SECRET=
 # LLM placeholders — overridden per-test in WireMock tests via constructor injection
 llm.api.base-url=http://localhost
 llm.api.timeout-seconds=1
+
+# Suppress trace event logging during tests — application.properties sets TRACE for dev
+logging.level.com.senior.spm=INFO


### PR DESCRIPTION
## Summary

Implements issue #255 — trace-level logging of user-triggered events across the service layer (NFR-6: Audit Logging).

Adds `@Slf4j` and `log.trace(...)` calls to all existing service methods that handle user actions. All logs follow the uniform format:
[EVENT] userId={} action={} entityId={} detail={}


---

## Changes

### Service Layer — Trace Logs Added

| Service | Method | Action |
|---------|--------|--------|
| `AuthService` | `login()` | `STAFF_LOGIN` |
| `AuthService` | `githubLogin()` | `STUDENT_LOGIN` |
| `GroupService` | `createGroup()` | `GROUP_CREATED` |
| `InvitationService` | `sendInvitation()` | `INVITATION_SENT` |
| `InvitationService` | `respondToInvitation()` | `INVITATION_RESPONDED` (both ACCEPTED and DECLINED paths) |
| `AdvisorService` | `sendAdvisorRequest()` | `ADVISOR_REQUEST_SENT` |
| `AdvisorService` | `respondToRequest()` | `ADVISOR_REQUEST_RESPONDED` (both ACCEPTED and REJECTED paths) |
| `ScrumGradingService` | `submitGrade()` | `SCRUM_GRADE_SUBMITTED` (both new-insert and update branches) |

### Configuration

- `application.properties` — added `logging.level.com.senior.spm=TRACE` (dev only)
- `application.properties.example` — same line added so team members get it on fresh setup
- `test.properties` — added `logging.level.com.senior.spm=INFO` to suppress trace noise during test runs (without this fix, `@SpringBootTest` would inherit TRACE from `application.properties` and flood the test output)

---

## Note on Issue Table vs. Implementation

The issue table lists invitation events under `GroupService`. In the actual codebase, invitation logic lives in `InvitationService` — that is the correct location and where the logs are placed.

---

## Out of Scope (not yet implementable)

Two events listed in the issue cannot be implemented in this PR because their service classes do not exist yet:

| Event | Service | Blocked by |
|-------|---------|------------|
| `RUBRIC_GRADE_SUBMITTED` | `RubricGradingService` | P7-04 (depends on Blue Team P6 `DeliverableSubmission`) |
| `FINAL_GRADE_CALCULATED` | `FinalGradeCalculationService` | P7-05 |

These trace calls must be added inside those services when they are implemented in their respective issues.

---

## Acceptance Criteria

- [x] All existing events listed in the issue emit a `log.trace(...)` line when triggered
- [x] Log includes at minimum: calling user's ID, action name, primary entity ID
- [x] `logging.level.com.senior.spm=TRACE` in dev properties activates the output
- [x] No trace logging in production properties (kept at INFO)
- [x] 609 tests — 0 failures, 0 errors on macOS
