### PR TITLE
WAIT UNTIL BLUE MERGE - Add submission integration tests and QA seed data (Issues #203, #204)

### DIFF
--- a/backend/src/main/resources/data.sql
+++ b/backend/src/main/resources/data.sql
@@ -66,7 +66,7 @@ VALUES (
     UUID_TO_BIN('00000000-0000-0000-0000-000000000004'),
     'TEST_RESET_TOKEN_123',
     NOW(),
-    DATE_ADD(NOW(), INTERVAL 1 DAY)
+    '2099-12-31 23:59:59'
 );
 
 INSERT IGNORE INTO password_reset_token (
@@ -96,7 +96,7 @@ VALUES (
     UUID_TO_BIN('00000000-0000-0000-0000-000000000004'),
     'USED_TOKEN_123',
     NOW(),
-    DATE_ADD(NOW(), INTERVAL 1 DAY)
+    '2099-12-31 23:59:59'
 );
 
 -- Issue 55: Red Team system_config seed data
@@ -149,3 +149,131 @@ VALUES (
     5
 );
 
+-- ============================================================
+-- BLUE TEAM QA SEED DATA
+-- Issues: #203, #204
+-- ============================================================
+
+-- Deliverable: valid deadline + committee assignment exists
+INSERT IGNORE INTO deliverable (
+    id, name, type, submission_deadline, review_deadline, weight
+)
+VALUES (
+    UUID_TO_BIN('aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa'),
+    'QA Valid Proposal',
+    'Proposal',
+    '2099-12-31 23:59:59',
+    '2099-12-31 23:59:59',
+    20.00
+);
+
+-- Deliverable: expired deadline + committee assignment exists
+INSERT IGNORE INTO deliverable (
+    id, name, type, submission_deadline, review_deadline, weight
+)
+VALUES (
+    UUID_TO_BIN('aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaab'),
+    'QA Expired Proposal',
+    'Proposal',
+    '2000-01-01 00:00:00',
+    '2099-12-31 23:59:59',
+    20.00
+);
+
+-- Deliverable: valid deadline but NO committee assignment
+INSERT IGNORE INTO deliverable (
+    id, name, type, submission_deadline, review_deadline, weight
+)
+VALUES (
+    UUID_TO_BIN('aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaac'),
+    'QA No Committee Proposal',
+    'Proposal',
+    '2099-12-31 23:59:59',
+    '2099-12-31 23:59:59',
+    20.00
+);
+
+-- QA group
+INSERT IGNORE INTO project_group (
+    id, group_name, status, term_id, created_at, version
+)
+VALUES (
+    UUID_TO_BIN('bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb'),
+    'QA Test Group',
+    'TOOLS_BOUND',
+    '2026-SPRING',
+    NOW(),
+    0
+);
+
+-- Team Leader
+INSERT IGNORE INTO group_membership (
+    id, group_id, student_id, role, joined_at
+)
+VALUES (
+    UUID_TO_BIN('cccccccc-cccc-cccc-cccc-cccccccccccc'),
+    UUID_TO_BIN('bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb'),
+    UUID_TO_BIN('00000000-0000-0000-0000-000000000002'),
+    'TEAM_LEADER',
+    NOW()
+);
+
+-- Standard Member
+INSERT IGNORE INTO group_membership (
+    id, group_id, student_id, role, joined_at
+)
+VALUES (
+    UUID_TO_BIN('dddddddd-dddd-dddd-dddd-dddddddddddd'),
+    UUID_TO_BIN('bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb'),
+    UUID_TO_BIN('00000000-0000-0000-0000-000000000010'),
+    'MEMBER',
+    NOW()
+);
+
+-- Committee for valid deliverable
+INSERT IGNORE INTO committee (
+    id, committee_name, term_id, deliverable_id, assignment_notification_sent_at
+)
+VALUES (
+    UUID_TO_BIN('eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee'),
+    'QA Committee A',
+    '2026-SPRING',
+    UUID_TO_BIN('aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa'),
+    NULL
+);
+
+INSERT IGNORE INTO committee_group (
+    committee_id, group_id
+)
+VALUES (
+    UUID_TO_BIN('eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee'),
+    UUID_TO_BIN('bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb')
+);
+
+INSERT IGNORE INTO committee_professor (
+    committee_id, professor_id
+)
+VALUES (
+    UUID_TO_BIN('eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee'),
+    UUID_TO_BIN('00000000-0000-0000-0000-000000000004')
+);
+
+-- Committee for expired deliverable
+INSERT IGNORE INTO committee (
+    id, committee_name, term_id, deliverable_id, assignment_notification_sent_at
+)
+VALUES (
+    UUID_TO_BIN('eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeef'),
+    'QA Committee Expired',
+    '2026-SPRING',
+    UUID_TO_BIN('aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaab'),
+    NULL
+);
+
+INSERT IGNORE INTO committee_group (
+    committee_id, group_id
+)
+VALUES (
+    UUID_TO_BIN('eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeef'),
+    UUID_TO_BIN('bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb')
+);

--- a/backend/src/test/java/com/senior/spm/README.md
+++ b/backend/src/test/java/com/senior/spm/README.md
@@ -35,6 +35,35 @@ These integration tests were added because the student upload endpoint does not 
 
 ---
 
+## Submission Integration Tests
+
+### Description
+
+This integration test class verifies submission rules and role-based access control at both API and database level.
+
+### Implemented Test Cases
+
+1. Valid submission → 201 Created  
+2. Expired deadline → 400 Bad Request  
+3. Missing committee assignment → 400 Bad Request  
+4. Admin submission attempt → 403 Forbidden  
+5. Member submission/update attempt → 403 Forbidden  
+6. Unauthorized professor access/comment → 403 Forbidden  
+7. Assigned professor access → 200 OK  
+
+### Technical Notes
+
+* Tests are implemented using `SpringBootTest` and `MockMvc`.
+* `JWTService` is used to generate role-based tokens (student, admin, professor).
+* Seed data is provided via `data.sql` to ensure deterministic test scenarios.
+* Submission records are cleaned before each test to ensure isolation.
+
+### Purpose
+
+These tests ensure that submission validation rules (deadline and committee assignment) and RBAC constraints are correctly enforced according to system requirements.
+
+---
+
 ## Other Test Classes
 
 ### Config
@@ -90,8 +119,12 @@ These integration tests were added because the student upload endpoint does not 
 | `CapacityGuardSanitizationIntegrationTest` | Capacity guard and sanitization race conditions |
 | `P3AdvisorLifecycleIntegrationTest` | Full P3 advisor request lifecycle via API |
 | `P3RbacSecurityTest` | Role-based access control for all P3 endpoints |
+<<<<<<< HEAD
 | `ScrumGradingControllerTest` | Grade submit (201/200 upsert), wrong-advisor 403, invalid enum 400, GET 404 when no grade |
 | `P5SecurityTest` | URL-pattern guards for `/api/sprints/**`, `/api/advisor/sprints/**`, `/api/groups/*/sprints/**` |
+=======
+| `SubmissionControllerIntegrationTest` | Submission validation (deadline, committee assignment) and RBAC enforcement for Issues #203 and #204 |
+>>>>>>> 5b67318 (Add submission integration tests and QA seed data (Issues #203, #204))
 
 ### DTO
 | Class | Summary |

--- a/backend/src/test/java/com/senior/spm/controller/SubmissionControllerIntegrationTest.java
+++ b/backend/src/test/java/com/senior/spm/controller/SubmissionControllerIntegrationTest.java
@@ -1,0 +1,212 @@
+package com.senior.spm.controller;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.util.UUID;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.senior.spm.entity.StaffUser;
+import com.senior.spm.entity.Student;
+import com.senior.spm.repository.DeliverableSubmissionRepository;
+import com.senior.spm.repository.StaffUserRepository;
+import com.senior.spm.repository.StudentRepository;
+import com.senior.spm.service.JWTService;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class SubmissionControllerIntegrationTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private JWTService jwtService;
+
+    @Autowired
+    private StudentRepository studentRepository;
+
+    @Autowired
+    private StaffUserRepository staffUserRepository;
+
+    @Autowired
+    private DeliverableSubmissionRepository deliverableSubmissionRepository;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    private static final UUID VALID_DELIVERABLE_ID =
+            UUID.fromString("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
+
+    private static final UUID EXPIRED_DELIVERABLE_ID =
+            UUID.fromString("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaab");
+
+    private static final UUID NO_COMMITTEE_DELIVERABLE_ID =
+            UUID.fromString("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaac");
+
+    @BeforeEach
+    void cleanSubmissions() {
+        deliverableSubmissionRepository.deleteAll();
+    }
+
+    private String teamLeaderToken() {
+        Student student = studentRepository.findByStudentId("23070006018").orElseThrow();
+        return "Bearer " + jwtService.issueToken(student);
+    }
+
+    private String memberToken() {
+        Student student = studentRepository.findByStudentId("23070006019").orElseThrow();
+        return "Bearer " + jwtService.issueToken(student);
+    }
+
+    private String professorAToken() {
+        StaffUser professor = staffUserRepository.findByMail("professor@test.com").orElseThrow();
+        return "Bearer " + jwtService.issueToken(professor);
+    }
+
+    private String professorBToken() {
+        StaffUser professor = staffUserRepository.findByMail("professorb@test.com").orElseThrow();
+        return "Bearer " + jwtService.issueToken(professor);
+    }
+
+    private String adminToken() {
+        StaffUser admin = staffUserRepository.findByMail("test@test.com").orElseThrow();
+        return "Bearer " + jwtService.issueToken(admin);
+    }
+
+    private String submissionBody(String content) {
+        return """
+                {
+                  "markdownContent": "%s"
+                }
+                """.formatted(content);
+    }
+
+    private String commentBody() {
+        return """
+                {
+                  "commentText": "Unauthorized professor comment attempt",
+                  "sectionReference": "Introduction"
+                }
+                """;
+    }
+
+    private String createValidSubmissionAndReturnId() throws Exception {
+        String responseBody = mockMvc.perform(post("/api/deliverables/{deliverableId}/submissions", VALID_DELIVERABLE_ID)
+                        .header("Authorization", teamLeaderToken())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(submissionBody("QA setup submission")))
+                .andExpect(status().isCreated())
+                .andReturn()
+                .getResponse()
+                .getContentAsString();
+
+        JsonNode json = objectMapper.readTree(responseBody);
+
+        if (json.has("submissionId")) {
+            return json.get("submissionId").asText();
+        }
+
+        if (json.has("id")) {
+            return json.get("id").asText();
+        }
+
+        throw new IllegalStateException("Submission id field not found in response: " + responseBody);
+    }
+
+    @Test
+    void issue203_validSubmission_shouldReturn201Created() throws Exception {
+        mockMvc.perform(post("/api/deliverables/{deliverableId}/submissions", VALID_DELIVERABLE_ID)
+                        .header("Authorization", teamLeaderToken())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(submissionBody("QA valid submission")))
+                .andExpect(status().isCreated());
+    }
+
+    @Test
+    void issue203_expiredDeadline_shouldReturn400BadRequest() throws Exception {
+        mockMvc.perform(post("/api/deliverables/{deliverableId}/submissions", EXPIRED_DELIVERABLE_ID)
+                        .header("Authorization", teamLeaderToken())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(submissionBody("QA expired submission")))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void issue203_groupWithoutCommitteeAssignment_shouldReturn400BadRequest() throws Exception {
+        mockMvc.perform(post("/api/deliverables/{deliverableId}/submissions", NO_COMMITTEE_DELIVERABLE_ID)
+                        .header("Authorization", teamLeaderToken())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(submissionBody("QA no committee submission")))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void issue204_adminSubmitAttempt_shouldReturn403Forbidden() throws Exception {
+        mockMvc.perform(post("/api/deliverables/{deliverableId}/submissions", VALID_DELIVERABLE_ID)
+                        .header("Authorization", adminToken())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(submissionBody("Admin submit attempt")))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    void issue204_standardMemberSubmitAttempt_shouldReturn403Forbidden() throws Exception {
+        mockMvc.perform(post("/api/deliverables/{deliverableId}/submissions", VALID_DELIVERABLE_ID)
+                        .header("Authorization", memberToken())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(submissionBody("Member submit attempt")))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    void issue204_standardMemberUpdateAttempt_shouldReturn403Forbidden() throws Exception {
+        String submissionId = createValidSubmissionAndReturnId();
+
+        mockMvc.perform(put("/api/submissions/{submissionId}", submissionId)
+                        .header("Authorization", memberToken())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(submissionBody("Member update attempt")))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    void issue204_professorBAccessingProfessorASubmission_shouldReturn403Forbidden() throws Exception {
+        String submissionId = createValidSubmissionAndReturnId();
+
+        mockMvc.perform(get("/api/submissions/{submissionId}", submissionId)
+                        .header("Authorization", professorBToken()))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    void issue204_professorBCommentAttempt_shouldReturn403Forbidden() throws Exception {
+        String submissionId = createValidSubmissionAndReturnId();
+
+        mockMvc.perform(post("/api/submissions/{submissionId}/comments", submissionId)
+                        .header("Authorization", professorBToken())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(commentBody()))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    void issue204_professorAAccessingAssignedSubmission_shouldReturn200Ok() throws Exception {
+        String submissionId = createValidSubmissionAndReturnId();
+
+        mockMvc.perform(get("/api/submissions/{submissionId}", submissionId)
+                        .header("Authorization", professorAToken()))
+                .andExpect(status().isOk());
+    }
+}


### PR DESCRIPTION
This PR adds integration test coverage for submission rules and RBAC enforcement.

Scope:
- Issue #203: Submission validation rules
- Issue #204: Role-based access control for submissions

Implemented Tests:
- Valid submission → 201 Created
- Expired deadline → 400 Bad Request
- Missing committee assignment → 400 Bad Request
- Admin submission attempt → 403 Forbidden
- Member submission/update attempt → 403 Forbidden
- Unauthorized professor access/comment → 403 Forbidden
- Assigned professor access → 200 OK

Additional Changes:
- Added QA seed data in data.sql to support deterministic test scenarios
- Updated test documentation (README.md)

Test Results:
- Tests run: 9
- Failures: 0
- Errors: 0
- Build: SUCCESS