### PR TITLE
feat: GET/api/students/{studentId}/grade — read stored final grade without recalculating

### DIFF
--- a/backend/src/main/java/com/senior/spm/controller/StudentController.java
+++ b/backend/src/main/java/com/senior/spm/controller/StudentController.java
@@ -32,6 +32,7 @@ import lombok.RequiredArgsConstructor;
 public class StudentController {
 
     private static final Pattern STUDENT_ID_PATTERN = Pattern.compile("^[0-9]{11}$");
+    private static final String UNAUTHORIZED_GRADE_MSG = "Caller is unauthorized to view this grade";
 
     private final StudentService studentService;
     private final FinalGradeCalculationService finalGradeCalculationService;
@@ -49,6 +50,21 @@ public class StudentController {
     }
 
     /**
+     * Returns the stored final grade for the student without recalculating.
+     * 204 No Content if no grade has been calculated yet for this student in the active term.
+     */
+    @GetMapping("/{studentId}/grade")
+    public ResponseEntity<?> getStoredGrade(@PathVariable String studentId, Authentication auth) {
+        if (!STUDENT_ID_PATTERN.matcher(studentId).matches()) {
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                    .body(new ErrorMessage("studentId must be an 11-digit number"));
+        }
+        ResponseEntity<?> accessError = checkGradeAccess(studentId, auth);
+        if (accessError != null) return accessError;
+        return doGetStored(studentId);
+    }
+
+    /**
      * Calculates (and upserts) the final grade for the student with the given 11-digit student number.
      *
      * @param studentId 11-digit student number — resolved via {@code StudentRepository.findByStudentId()}
@@ -62,7 +78,17 @@ public class StudentController {
             return ResponseEntity.status(HttpStatus.BAD_REQUEST)
                     .body(new ErrorMessage("studentId must be an 11-digit number"));
         }
+        ResponseEntity<?> accessError = checkGradeAccess(studentId, auth);
+        if (accessError != null) return accessError;
+        return doCalculate(studentId);
+    }
 
+    /**
+     * Validates grade-read authorization for the given studentId.
+     * Returns null if the caller is permitted, or an error ResponseEntity otherwise.
+     * Coordinator: always allowed. Professor: only the student's advisor. Student: own grade only.
+     */
+    private ResponseEntity<?> checkGradeAccess(String studentId, Authentication auth) {
         if (auth == null || !auth.isAuthenticated()) {
             return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
                     .body(new ErrorMessage("Unauthorized"));
@@ -71,6 +97,8 @@ public class StudentController {
         // Caller's role comes from the JWT filter: "ROLE_COORDINATOR", "ROLE_PROFESSOR", "ROLE_STUDENT"
         boolean isCoordinator = auth.getAuthorities().stream()
                 .anyMatch(a -> a.getAuthority().equals("ROLE_COORDINATOR"));
+        if (isCoordinator) return null;
+
         boolean isProfessor = auth.getAuthorities().stream()
                 .anyMatch(a -> a.getAuthority().equals("ROLE_PROFESSOR"));
         boolean isStudent = auth.getAuthorities().stream()
@@ -78,11 +106,6 @@ public class StudentController {
 
         // Caller UUID is stored as principal (set by JwtAuthenticationFilter)
         UUID callerUUID = SecurityUtils.extractPrincipalUUID(auth);
-
-        // Coordinator — always allowed
-        if (isCoordinator) {
-            return doCalculate(studentId);
-        }
 
         // Resolve the target student for auth checks
         com.senior.spm.entity.Student targetStudent;
@@ -97,22 +120,35 @@ public class StudentController {
             UUID advisorId = groupService.getAdvisorIdForStudent(targetStudent.getId());
             if (advisorId == null || !advisorId.equals(callerUUID)) {
                 return ResponseEntity.status(HttpStatus.FORBIDDEN)
-                        .body(new ErrorMessage("Caller is unauthorized to view this grade"));
+                        .body(new ErrorMessage(UNAUTHORIZED_GRADE_MSG));
             }
-            return doCalculate(studentId);
+            return null;
         }
 
         if (isStudent) {
             // Student — allowed only if caller's UUID matches the target student's UUID
             if (!callerUUID.equals(targetStudent.getId())) {
                 return ResponseEntity.status(HttpStatus.FORBIDDEN)
-                        .body(new ErrorMessage("Caller is unauthorized to view this grade"));
+                        .body(new ErrorMessage(UNAUTHORIZED_GRADE_MSG));
             }
-            return doCalculate(studentId);
+            return null;
         }
 
         return ResponseEntity.status(HttpStatus.FORBIDDEN)
-                .body(new ErrorMessage("Caller is unauthorized to view this grade"));
+                .body(new ErrorMessage(UNAUTHORIZED_GRADE_MSG));
+    }
+
+    private ResponseEntity<?> doGetStored(String studentId) {
+        try {
+            FinalGradeResponse response = finalGradeCalculationService.getStoredFinalGrade(studentId);
+            return ResponseEntity.ok(response);
+        } catch (NotFoundException e) {
+            // Per issue #286: 204 No Content when grade has not yet been calculated.
+            return ResponseEntity.noContent().build();
+        } catch (Exception e) {
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                    .body(new ErrorMessage("An unexpected error occurred: " + e.getMessage()));
+        }
     }
 
     private ResponseEntity<?> doCalculate(String studentId) {

--- a/backend/src/main/java/com/senior/spm/controller/StudentController.java
+++ b/backend/src/main/java/com/senior/spm/controller/StudentController.java
@@ -24,11 +24,13 @@ import com.senior.spm.service.StudentService;
 import com.senior.spm.util.SecurityUtils;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
 @RestController
 @RequestMapping("/api/students")
 @RequiredArgsConstructor
 @Validated
+@Slf4j
 public class StudentController {
 
     private static final Pattern STUDENT_ID_PATTERN = Pattern.compile("^[0-9]{11}$");
@@ -94,6 +96,16 @@ public class StudentController {
                     .body(new ErrorMessage("Unauthorized"));
         }
 
+        // Resolve the target student up-front for ALL roles. Without this, a Coordinator
+        // hitting an unknown studentId would skip the lookup and the downstream "no grade"
+        // path would map it to 204 — masking the real 404.
+        com.senior.spm.entity.Student targetStudent;
+        try {
+            targetStudent = studentService.getStudentByStudentId(studentId);
+        } catch (NotFoundException e) {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).body(new ErrorMessage(e.getMessage()));
+        }
+
         // Caller's role comes from the JWT filter: "ROLE_COORDINATOR", "ROLE_PROFESSOR", "ROLE_STUDENT"
         boolean isCoordinator = auth.getAuthorities().stream()
                 .anyMatch(a -> a.getAuthority().equals("ROLE_COORDINATOR"));
@@ -106,14 +118,6 @@ public class StudentController {
 
         // Caller UUID is stored as principal (set by JwtAuthenticationFilter)
         UUID callerUUID = SecurityUtils.extractPrincipalUUID(auth);
-
-        // Resolve the target student for auth checks
-        com.senior.spm.entity.Student targetStudent;
-        try {
-            targetStudent = studentService.getStudentByStudentId(studentId);
-        } catch (NotFoundException e) {
-            return ResponseEntity.status(HttpStatus.NOT_FOUND).body(new ErrorMessage(e.getMessage()));
-        }
 
         if (isProfessor) {
             // Professor — allowed only if caller is the advisor of the student's group
@@ -146,8 +150,9 @@ public class StudentController {
             // Per issue #286: 204 No Content when grade has not yet been calculated.
             return ResponseEntity.noContent().build();
         } catch (Exception e) {
+            log.error("Unexpected error reading stored grade for studentId={}", studentId, e);
             return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
-                    .body(new ErrorMessage("An unexpected error occurred: " + e.getMessage()));
+                    .body(new ErrorMessage("An unexpected error occurred."));
         }
     }
 
@@ -158,8 +163,9 @@ public class StudentController {
         } catch (NotFoundException e) {
             return ResponseEntity.status(HttpStatus.NOT_FOUND).body(new ErrorMessage(e.getMessage()));
         } catch (Exception e) {
+            log.error("Unexpected error calculating grade for studentId={}", studentId, e);
             return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
-                    .body(new ErrorMessage("An unexpected error occurred: " + e.getMessage()));
+                    .body(new ErrorMessage("An unexpected error occurred."));
         }
     }
 }

--- a/backend/src/main/java/com/senior/spm/controller/response/FinalGradeResponse.java
+++ b/backend/src/main/java/com/senior/spm/controller/response/FinalGradeResponse.java
@@ -12,9 +12,12 @@ import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 /**
- * Response body for GET /api/students/{studentId}/grade/calculate.
- * Contains the upserted FinalGrade values plus per-deliverable breakdowns
- * computed on-the-fly (breakdowns are NOT persisted — see endpoints_p7.md D3).
+ * Response body for the final grade endpoints:
+ * <ul>
+ *   <li>{@code GET /api/students/{studentId}/grade} — returns the stored grade (deliverableBreakdown is empty {@code []}).</li>
+ *   <li>{@code GET /api/students/{studentId}/grade/calculate} — recalculates and upserts; returns full breakdown.</li>
+ * </ul>
+ * Per-deliverable breakdowns are computed on-the-fly and are NOT persisted — see endpoints_p7.md D3.
  */
 @Getter
 @Setter

--- a/backend/src/main/java/com/senior/spm/service/FinalGradeCalculationService.java
+++ b/backend/src/main/java/com/senior/spm/service/FinalGradeCalculationService.java
@@ -4,6 +4,7 @@ import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
@@ -209,6 +210,33 @@ public class FinalGradeCalculationService {
                 .completionRatio(completionRatio.setScale(4, RM))
                 .finalGrade(finalGrade.setScale(4, RM))
                 .calculatedAt(calculatedAt)
+                .build();
+    }
+
+    /**
+     * Returns the previously stored final grade for the student identified by their
+     * 11-digit student number. Does NOT trigger recalculation.
+     *
+     * @param studentId11Digit 11-digit student number (pattern ^[0-9]{11}$)
+     * @return FinalGradeResponse with empty deliverableBreakdown (breakdowns are not persisted, see endpoints_p7.md D3)
+     * @throws NotFoundException if no stored grade exists for this student in the active term
+     */
+    @Transactional(readOnly = true)
+    public FinalGradeResponse getStoredFinalGrade(String studentId11Digit) {
+        String termId = termConfigService.getActiveTermId();
+        FinalGrade entity = finalGradeRepository
+                .findByStudent_StudentIdAndTermId(studentId11Digit, termId)
+                .orElseThrow(() -> new NotFoundException(
+                        "No stored final grade found for student " + studentId11Digit));
+
+        return FinalGradeResponse.builder()
+                .studentId(studentId11Digit)
+                .groupId(entity.getGroup().getId())
+                .deliverableBreakdown(Collections.emptyList())
+                .weightedTotal(entity.getWeightedTotal())
+                .completionRatio(entity.getCompletionRatio())
+                .finalGrade(entity.getFinalGrade())
+                .calculatedAt(entity.getCalculatedAt())
                 .build();
     }
 

--- a/backend/src/test/java/com/senior/spm/controller/StudentGradeControllerTest.java
+++ b/backend/src/test/java/com/senior/spm/controller/StudentGradeControllerTest.java
@@ -1,0 +1,237 @@
+package com.senior.spm.controller;
+
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.List;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+
+import com.senior.spm.entity.FinalGrade;
+import com.senior.spm.entity.GroupMembership;
+import com.senior.spm.entity.ProjectGroup;
+import com.senior.spm.entity.StaffUser;
+import com.senior.spm.entity.Student;
+import com.senior.spm.entity.SystemConfig;
+import com.senior.spm.repository.FinalGradeRepository;
+import com.senior.spm.repository.GroupMembershipRepository;
+import com.senior.spm.repository.ProjectGroupRepository;
+import com.senior.spm.repository.StaffUserRepository;
+import com.senior.spm.repository.StudentRepository;
+import com.senior.spm.repository.SystemConfigRepository;
+
+/**
+ * Integration tests for {@code GET /api/students/{studentId}/grade} (Issue #286).
+ * Covers the 8 scenarios from the spec: auth matrix (coordinator / advisor / non-advisor / self / other),
+ * 204 when not yet calculated, 404 when student missing, 400 when format invalid.
+ */
+@SpringBootTest
+@AutoConfigureMockMvc
+@TestPropertySource(locations = "classpath:test.properties")
+class StudentGradeControllerTest {
+
+    private static final String TERM_ID = "2026-SPRING";
+    private static final String STUDENT_ID = "12345678901";
+    private static final String OTHER_STUDENT_ID = "98765432109";
+    private static final String UNKNOWN_STUDENT_ID = "99999999999";
+
+    @Autowired private MockMvc mockMvc;
+    @Autowired private SystemConfigRepository systemConfigRepository;
+    @Autowired private StudentRepository studentRepository;
+    @Autowired private StaffUserRepository staffUserRepository;
+    @Autowired private ProjectGroupRepository projectGroupRepository;
+    @Autowired private GroupMembershipRepository groupMembershipRepository;
+    @Autowired private FinalGradeRepository finalGradeRepository;
+
+    private Student student;
+    private StaffUser advisor;
+    private StaffUser otherProfessor;
+    private StaffUser coordinator;
+    private ProjectGroup group;
+
+    @BeforeEach
+    void setUp() {
+        cleanAll();
+
+        SystemConfig sc = new SystemConfig();
+        sc.setConfigKey("active_term_id");
+        sc.setConfigValue(TERM_ID);
+        systemConfigRepository.save(sc);
+
+        advisor         = staffUserRepository.save(staff("advisor@test.com", StaffUser.Role.Professor));
+        otherProfessor  = staffUserRepository.save(staff("other@test.com",   StaffUser.Role.Professor));
+        coordinator     = staffUserRepository.save(staff("coord@test.com",   StaffUser.Role.Coordinator));
+
+        Student s = new Student();
+        s.setStudentId(STUDENT_ID);
+        student = studentRepository.save(s);
+
+        Student o = new Student();
+        o.setStudentId(OTHER_STUDENT_ID);
+        studentRepository.save(o);
+
+        ProjectGroup g = new ProjectGroup();
+        g.setGroupName("TeamAlpha");
+        g.setTermId(TERM_ID);
+        g.setStatus(ProjectGroup.GroupStatus.ADVISOR_ASSIGNED);
+        g.setCreatedAt(LocalDateTime.now(ZoneId.of("UTC")));
+        g.setAdvisor(advisor);
+        group = projectGroupRepository.save(g);
+
+        GroupMembership gm = new GroupMembership();
+        gm.setGroup(group);
+        gm.setStudent(student);
+        gm.setRole(GroupMembership.MemberRole.MEMBER);
+        gm.setJoinedAt(LocalDateTime.now());
+        groupMembershipRepository.save(gm);
+
+        FinalGrade fg = new FinalGrade();
+        fg.setStudent(student);
+        fg.setGroup(group);
+        fg.setTermId(TERM_ID);
+        fg.setWeightedTotal(new BigDecimal("75.5000"));
+        fg.setCompletionRatio(new BigDecimal("0.9000"));
+        fg.setFinalGrade(new BigDecimal("67.9500"));
+        fg.setCalculatedAt(LocalDateTime.now());
+        finalGradeRepository.save(fg);
+    }
+
+    @AfterEach
+    void tearDown() {
+        cleanAll();
+    }
+
+    private void cleanAll() {
+        finalGradeRepository.deleteAll();
+        groupMembershipRepository.deleteAll();
+        projectGroupRepository.deleteAll();
+        staffUserRepository.deleteAll();
+        studentRepository.deleteAll();
+        systemConfigRepository.deleteAll();
+    }
+
+    // ══════════════════════════════════════════════════════════════════════════
+    //  GET /api/students/{studentId}/grade — auth matrix + content
+    // ══════════════════════════════════════════════════════════════════════════
+
+    @Test
+    @DisplayName("Coordinator: 200 with stored grade fields and deliverableBreakdown=[]")
+    void storedGrade_coordinator_returns200WithEmptyBreakdown() throws Exception {
+        mockMvc.perform(get("/api/students/{studentId}/grade", STUDENT_ID)
+                        .with(authentication(coordinatorAuth(coordinator))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.studentId").value(STUDENT_ID))
+                .andExpect(jsonPath("$.groupId").value(group.getId().toString()))
+                .andExpect(jsonPath("$.deliverableBreakdown").isArray())
+                .andExpect(jsonPath("$.deliverableBreakdown").isEmpty())
+                .andExpect(jsonPath("$.weightedTotal").value(75.5))
+                .andExpect(jsonPath("$.completionRatio").value(0.9))
+                .andExpect(jsonPath("$.finalGrade").value(67.95))
+                .andExpect(jsonPath("$.calculatedAt").isNotEmpty());
+    }
+
+    @Test
+    @DisplayName("Professor (advisor of student's group): 200")
+    void storedGrade_advisorProfessor_returns200() throws Exception {
+        mockMvc.perform(get("/api/students/{studentId}/grade", STUDENT_ID)
+                        .with(authentication(professorAuth(advisor))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.studentId").value(STUDENT_ID));
+    }
+
+    @Test
+    @DisplayName("Professor not advisor of student's group: 403")
+    void storedGrade_nonAdvisorProfessor_returns403() throws Exception {
+        mockMvc.perform(get("/api/students/{studentId}/grade", STUDENT_ID)
+                        .with(authentication(professorAuth(otherProfessor))))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @DisplayName("Student requesting own grade: 200")
+    void storedGrade_studentSelf_returns200() throws Exception {
+        mockMvc.perform(get("/api/students/{studentId}/grade", STUDENT_ID)
+                        .with(authentication(studentAuth(student))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.studentId").value(STUDENT_ID));
+    }
+
+    @Test
+    @DisplayName("Student requesting another student's grade: 403")
+    void storedGrade_studentOther_returns403() throws Exception {
+        mockMvc.perform(get("/api/students/{studentId}/grade", OTHER_STUDENT_ID)
+                        .with(authentication(studentAuth(student))))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @DisplayName("No grade row for student in active term: 204 No Content")
+    void storedGrade_noRecord_returns204() throws Exception {
+        finalGradeRepository.deleteAll();
+
+        mockMvc.perform(get("/api/students/{studentId}/grade", STUDENT_ID)
+                        .with(authentication(coordinatorAuth(coordinator))))
+                .andExpect(status().isNoContent());
+    }
+
+    @Test
+    @DisplayName("Student does not exist (professor caller resolves target): 404")
+    void storedGrade_studentNotFound_returns404() throws Exception {
+        mockMvc.perform(get("/api/students/{studentId}/grade", UNKNOWN_STUDENT_ID)
+                        .with(authentication(professorAuth(advisor))))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    @DisplayName("studentId not 11 digits: 400")
+    void storedGrade_invalidStudentIdFormat_returns400() throws Exception {
+        mockMvc.perform(get("/api/students/{studentId}/grade", "abc")
+                        .with(authentication(coordinatorAuth(coordinator))))
+                .andExpect(status().isBadRequest());
+    }
+
+    // ── helpers ───────────────────────────────────────────────────────────────
+
+    private StaffUser staff(String mail, StaffUser.Role role) {
+        StaffUser u = new StaffUser();
+        u.setMail(mail);
+        u.setPasswordHash("hash");
+        u.setRole(role);
+        u.setAdvisorCapacity(5);
+        return u;
+    }
+
+    private Authentication coordinatorAuth(StaffUser c) {
+        return new UsernamePasswordAuthenticationToken(
+                c.getId().toString(), null,
+                List.of(new SimpleGrantedAuthority("ROLE_COORDINATOR")));
+    }
+
+    private Authentication professorAuth(StaffUser p) {
+        return new UsernamePasswordAuthenticationToken(
+                p.getId().toString(), null,
+                List.of(new SimpleGrantedAuthority("ROLE_PROFESSOR")));
+    }
+
+    private Authentication studentAuth(Student s) {
+        return new UsernamePasswordAuthenticationToken(
+                s.getId().toString(), null,
+                List.of(new SimpleGrantedAuthority("ROLE_STUDENT")));
+    }
+}

--- a/backend/src/test/java/com/senior/spm/controller/StudentGradeControllerTest.java
+++ b/backend/src/test/java/com/senior/spm/controller/StudentGradeControllerTest.java
@@ -199,6 +199,14 @@ class StudentGradeControllerTest {
     }
 
     @Test
+    @DisplayName("Coordinator with unknown studentId: 404 (not 204) — student is resolved before role check")
+    void storedGrade_coordinatorUnknownStudent_returns404() throws Exception {
+        mockMvc.perform(get("/api/students/{studentId}/grade", UNKNOWN_STUDENT_ID)
+                        .with(authentication(coordinatorAuth(coordinator))))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
     @DisplayName("studentId not 11 digits: 400")
     void storedGrade_invalidStudentIdFormat_returns400() throws Exception {
         mockMvc.perform(get("/api/students/{studentId}/grade", "abc")

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -3235,7 +3235,7 @@ paths:
       summary: "Read the previously stored final grade (no recalculation)"
       description: |
         Returns the stored FinalGrade row for the student in the active term, if one exists.
-        Does NOT trigger recalculation — for that, use POST /students/{studentId}/grade/calculate.
+        Does NOT trigger recalculation — for that, use GET /students/{studentId}/grade/calculate.
         The returned `deliverableBreakdown` is always an empty list `[]` because breakdowns
         are computed on-the-fly and not persisted (see endpoints_p7.md D3).
         Auth rules:

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -3229,6 +3229,67 @@ paths:
                 $ref: '#/components/schemas/ErrorMessage'
 
   # ── P7 — Final Grade Calculation ─────────────────────────────────────────
+  /students/{studentId}/grade:
+    get:
+      tags: [Student, Professor, Coordinator]
+      summary: "Read the previously stored final grade (no recalculation)"
+      description: |
+        Returns the stored FinalGrade row for the student in the active term, if one exists.
+        Does NOT trigger recalculation — for that, use POST /students/{studentId}/grade/calculate.
+        The returned `deliverableBreakdown` is always an empty list `[]` because breakdowns
+        are computed on-the-fly and not persisted (see endpoints_p7.md D3).
+        Auth rules:
+        - COORDINATOR: always allowed.
+        - PROFESSOR: allowed only if caller is the advisor of the student's group.
+        - STUDENT: allowed only if calling for themselves.
+      parameters:
+        - name: studentId
+          in: path
+          required: true
+          schema:
+            type: string
+            pattern: '^[0-9]{11}$'
+          description: 11-digit student number (not a UUID)
+      responses:
+        '200':
+          description: Stored final grade returned
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/FinalGradeResponse'
+              example:
+                studentId: "01234567890"
+                groupId: "uuid"
+                deliverableBreakdown: []
+                weightedTotal: 0.0
+                completionRatio: 0.95
+                finalGrade: 0.0
+                calculatedAt: "2026-05-01T14:30:00"
+        '204':
+          description: No final grade has been calculated yet for this student in the active term
+        '400':
+          description: studentId does not match pattern ^[0-9]{11}$
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorMessage'
+        '403':
+          description: Caller is unauthorized to view this grade
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorMessage'
+              example:
+                message: "Caller is unauthorized to view this grade"
+        '404':
+          description: Student not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorMessage'
+              example:
+                message: "Student not found"
+
   /students/{studentId}/grade/calculate:
     get:
       tags: [Student, Professor, Coordinator]


### PR DESCRIPTION
## Summary

Closes #286

`GET /api/students/{studentId}/grade/calculate` has always recalculated and
upserted on every call. This PR adds a companion read-only endpoint that returns
the already-stored `FinalGrade` row without triggering any computation.

## Changes

### Backend — new endpoint
- `GET /api/students/{studentId}/grade` → 200 with stored grade, 204 if not yet
  calculated, 400 on bad format, 403/404 on auth/not-found.
- Auth guards are identical to `/calculate`: Coordinator always allowed, Professor
  only if advisor of the student's group, Student only for their own grade.

### StudentController
- Extracted shared auth logic into `checkGradeAccess()` private helper — both
  endpoints share the same role-check without duplication.
- `UNAUTHORIZED_GRADE_MSG` constant replaces three repeated string literals.
- Removed dead `if (isCoordinator) { return doCalculate(...) }` block that was
  unreachable and would have bypassed the read path if line order ever changed.

### FinalGradeCalculationService
- Added `getStoredFinalGrade(String studentId11Digit)` — pure DB read,
  `@Transactional(readOnly = true)`, no side effects.
- Returns `deliverableBreakdown: []` (breakdowns not persisted, per D3 in
  endpoints_p7.md).

### FinalGradeResponse
- Removed class-level `@JsonInclude(NON_NULL)` — not needed since breakdown is
  always a non-null list.
- Updated Javadoc to describe both endpoints.

### Docs
- Added `GET /students/{studentId}/grade` to `docs/openapi.yaml` with 200, 204,
  400, 403, 404 response definitions.

### Tests
- `StudentGradeControllerTest` — 8 Spring Boot MockMvc integration tests:
  coordinator (200 + full field assertions), advisor professor (200), non-advisor
  professor (403), student self (200), student other (403), no record (204),
  student not found (404), invalid format (400).

## Test results
StudentGradeControllerTest   8/8  ✅
ScrumGradingControllerTest  10/10 ✅
FinalGradeRepositoryTest    10/10 ✅
GradeValueMapperTest        34/34 ✅