### PR TITLE
fix: add DB-level DEFAULT 5 to advisor_capacity column (#239)

### DIFF
--- a/backend/src/main/java/com/senior/spm/entity/StaffUser.java
+++ b/backend/src/main/java/com/senior/spm/entity/StaffUser.java
@@ -40,7 +40,7 @@ public class StaffUser {
     @Column(nullable = false)
     private boolean firstLogin = true;
 
-    @Column(nullable = false)
+    @Column(nullable = false, columnDefinition = "INT NOT NULL DEFAULT 5")
     private int advisorCapacity = 5;
 
     @OneToMany(mappedBy = "advisor")

--- a/backend/src/main/resources/data.sql
+++ b/backend/src/main/resources/data.sql
@@ -13,7 +13,7 @@ VALUES
 		'test@test.com',
 		'$2a$10$tj811p0KDPOD6Dd58xb0.uBNIT8.CXeJPKoSUSwPuJ0BI.RuC5yGq',
 		'ADMIN',
-		0
+		5
 	);
 
 INSERT
@@ -37,7 +37,7 @@ VALUES
 		'coordinator@test.com',
 		'$2a$10$tj811p0KDPOD6Dd58xb0.uBNIT8.CXeJPKoSUSwPuJ0BI.RuC5yGq',
 		'COORDINATOR',
-		0
+		5
 	);
 
 INSERT


### PR DESCRIPTION
Core fix is a single annotation attribute in StaffUser.java:

  Before: @Column(nullable = false)
  After:  @Column(nullable = false, columnDefinition = "INT NOT NULL DEFAULT 5")

This causes Hibernate to emit INT NOT NULL DEFAULT 5 in the DDL so any
INSERT that omits advisor_capacity no longer fails on MySQL strict mode.

data.sql was already listing advisor_capacity in all staff_user inserts —
it was not the root cause. The only data.sql change in this PR is aligning
the admin and coordinator seed values from 0 to 5 per the issue spec;
this has no functional impact since those roles never hit the advisor
capacity check.

Verified: 37 tests pass across ScrumGradingControllerTest,
GroupCreationIntegrationTest, and AdvisorControllerIntegrationTest —
all of which create StaffUser fixtures.
