### PR TITLE
test: add auth, persistence & system-config integration tests (#254)

### DIFF
--- a/backend/src/test/java/com/senior/spm/controller/FinalGradeCalculateIntegrationTest.java
+++ b/backend/src/test/java/com/senior/spm/controller/FinalGradeCalculateIntegrationTest.java
@@ -1,0 +1,349 @@
+package com.senior.spm.controller;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+
+import com.senior.spm.entity.GroupMembership;
+import com.senior.spm.entity.ProjectGroup;
+import com.senior.spm.entity.Sprint;
+import com.senior.spm.entity.SprintTrackingLog;
+import com.senior.spm.entity.StaffUser;
+import com.senior.spm.entity.StaffUser.Role;
+import com.senior.spm.entity.Student;
+import com.senior.spm.entity.SystemConfig;
+import com.senior.spm.repository.FinalGradeRepository;
+import com.senior.spm.repository.GroupMembershipRepository;
+import com.senior.spm.repository.ProjectGroupRepository;
+import com.senior.spm.repository.SprintRepository;
+import com.senior.spm.repository.SprintTrackingLogRepository;
+import com.senior.spm.repository.StaffUserRepository;
+import com.senior.spm.repository.StudentRepository;
+import com.senior.spm.repository.SystemConfigRepository;
+import com.senior.spm.service.JWTService;
+
+/**
+ * JWT-based integration tests for GET /api/students/{studentId}/grade/calculate.
+ *
+ * Covers (issue #254):
+ *   – Auth matrix with real JWT tokens
+ *   – C_i log filter combinations (assigneeGithubUsername × prMerged)
+ *   – FinalGrade row persistence confirmed via JDBC + upsert on second call
+ */
+@SpringBootTest
+@AutoConfigureMockMvc
+@TestPropertySource(locations = "classpath:test.properties")
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+class FinalGradeCalculateIntegrationTest {
+
+    private static final String TERM_ID      = "2026-TEST-CALC";
+    private static final String STUDENT_A_ID = "11111111111";
+    private static final String STUDENT_B_ID = "22222222222";
+
+    @Autowired MockMvc mockMvc;
+    @Autowired JWTService jwtService;
+    @Autowired JdbcTemplate jdbcTemplate;
+
+    @Autowired StudentRepository studentRepository;
+    @Autowired StaffUserRepository staffUserRepository;
+    @Autowired ProjectGroupRepository projectGroupRepository;
+    @Autowired GroupMembershipRepository groupMembershipRepository;
+    @Autowired SystemConfigRepository systemConfigRepository;
+    @Autowired SprintRepository sprintRepository;
+    @Autowired SprintTrackingLogRepository sprintTrackingLogRepository;
+    @Autowired FinalGradeRepository finalGradeRepository;
+
+    private Student studentA;
+    private Student studentB;
+    private StaffUser professorAdvisor;
+    private StaffUser professorNotAdvisor;
+    private StaffUser coordinator;
+    private ProjectGroup groupA;
+    private ProjectGroup groupB;
+
+    private String studentAToken;
+    private String professorAdvisorToken;
+    private String professorNotAdvisorToken;
+    private String coordinatorToken;
+
+    @BeforeEach
+    void setUp() {
+        cleanAll();
+
+        SystemConfig sc = new SystemConfig();
+        sc.setConfigKey("active_term_id");
+        sc.setConfigValue(TERM_ID);
+        systemConfigRepository.save(sc);
+
+        professorAdvisor    = staffUserRepository.save(makeProfessor("advisor@calc-test.com"));
+        professorNotAdvisor = staffUserRepository.save(makeProfessor("other@calc-test.com"));
+        coordinator         = staffUserRepository.save(makeCoordinator("coord@calc-test.com"));
+
+        studentA = studentRepository.save(makeStudent(STUDENT_A_ID, "gh-student-a"));
+        studentB = studentRepository.save(makeStudent(STUDENT_B_ID, "gh-student-b"));
+
+        groupA = projectGroupRepository.save(makeGroupWithAdvisor("Group A", professorAdvisor));
+        groupB = projectGroupRepository.save(makeGroup("Group B"));
+
+        groupMembershipRepository.save(makeMembership(studentA, groupA));
+        groupMembershipRepository.save(makeMembership(studentB, groupB));
+
+        studentAToken            = jwtService.issueToken(studentA);
+        professorAdvisorToken    = jwtService.issueToken(professorAdvisor);
+        professorNotAdvisorToken = jwtService.issueToken(professorNotAdvisor);
+        coordinatorToken         = jwtService.issueToken(coordinator);
+    }
+
+    @AfterEach
+    void tearDown() {
+        cleanAll();
+    }
+
+    // ═══════════════════════════════════════════════════════════════════
+    //  Auth integration tests — real JWT tokens
+    // ═══════════════════════════════════════════════════════════════════
+
+    @Test
+    @DisplayName("Student A JWT → /calculate for Student A → 200")
+    void studentA_calculateOwnGrade_returns200() throws Exception {
+        mockMvc.perform(get("/api/students/{id}/grade/calculate", STUDENT_A_ID)
+                .header("Authorization", "Bearer " + studentAToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.studentId").value(STUDENT_A_ID));
+    }
+
+    @Test
+    @DisplayName("Student A JWT → /calculate for Student B → 403")
+    void studentA_calculateOtherStudentGrade_returns403() throws Exception {
+        mockMvc.perform(get("/api/students/{id}/grade/calculate", STUDENT_B_ID)
+                .header("Authorization", "Bearer " + studentAToken))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @DisplayName("Professor NOT advisor of student's group → 403")
+    void professorNotAdvisor_calculate_returns403() throws Exception {
+        mockMvc.perform(get("/api/students/{id}/grade/calculate", STUDENT_A_ID)
+                .header("Authorization", "Bearer " + professorNotAdvisorToken))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @DisplayName("Professor IS advisor of student's group → 200")
+    void professorIsAdvisor_calculate_returns200() throws Exception {
+        mockMvc.perform(get("/api/students/{id}/grade/calculate", STUDENT_A_ID)
+                .header("Authorization", "Bearer " + professorAdvisorToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.studentId").value(STUDENT_A_ID));
+    }
+
+    @Test
+    @DisplayName("Coordinator → 200 for Student A")
+    void coordinator_calculateStudentAGrade_returns200() throws Exception {
+        mockMvc.perform(get("/api/students/{id}/grade/calculate", STUDENT_A_ID)
+                .header("Authorization", "Bearer " + coordinatorToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.studentId").value(STUDENT_A_ID));
+    }
+
+    @Test
+    @DisplayName("Coordinator → 200 for any student (Student B)")
+    void coordinator_calculateStudentBGrade_returns200() throws Exception {
+        mockMvc.perform(get("/api/students/{id}/grade/calculate", STUDENT_B_ID)
+                .header("Authorization", "Bearer " + coordinatorToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.studentId").value(STUDENT_B_ID));
+    }
+
+    // ═══════════════════════════════════════════════════════════════════
+    //  C_i identification tests
+    //  Algorithm: C_i = SUM(storyPoints where assignee matches AND prMerged=true)
+    //                 / SUM(sprint.storyPointTarget)
+    // ═══════════════════════════════════════════════════════════════════
+
+    @Test
+    @DisplayName("Matching assigneeGithubUsername + prMerged=true → C_i > 0 (counted)")
+    void ci_matchingUsername_prMergedTrue_isCounted() throws Exception {
+        Sprint sprint = sprintRepository.save(makeSprint(10));
+        sprintTrackingLogRepository.save(
+                makeLog(groupA, sprint, "gh-student-a", true, 10));
+
+        mockMvc.perform(get("/api/students/{id}/grade/calculate", STUDENT_A_ID)
+                .header("Authorization", "Bearer " + coordinatorToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.completionRatio").value(Matchers.greaterThan(0.0)));
+    }
+
+    @Test
+    @DisplayName("Matching assigneeGithubUsername + prMerged=false → C_i = 0 (NOT counted)")
+    void ci_matchingUsername_prMergedFalse_notCounted() throws Exception {
+        Sprint sprint = sprintRepository.save(makeSprint(10));
+        sprintTrackingLogRepository.save(
+                makeLog(groupA, sprint, "gh-student-a", false, 10));
+
+        mockMvc.perform(get("/api/students/{id}/grade/calculate", STUDENT_A_ID)
+                .header("Authorization", "Bearer " + coordinatorToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.completionRatio").value(0.0));
+    }
+
+    @Test
+    @DisplayName("Non-matching assigneeGithubUsername + prMerged=true → C_i = 0 (NOT counted)")
+    void ci_nonMatchingUsername_prMergedTrue_notCounted() throws Exception {
+        Sprint sprint = sprintRepository.save(makeSprint(10));
+        sprintTrackingLogRepository.save(
+                makeLog(groupA, sprint, "gh-other-user", true, 10));
+
+        mockMvc.perform(get("/api/students/{id}/grade/calculate", STUDENT_A_ID)
+                .header("Authorization", "Bearer " + coordinatorToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.completionRatio").value(0.0));
+    }
+
+    // ═══════════════════════════════════════════════════════════════════
+    //  Persistence test — JDBC assertion + upsert on second call
+    // ═══════════════════════════════════════════════════════════════════
+
+    @Test
+    @DisplayName("GET /calculate upserts one row; second call updates calculated_at — no duplicate row")
+    void calculate_persistsRow_secondCallUpdatesCalculatedAt_noDuplicate() throws Exception {
+        // First call → row should be created
+        mockMvc.perform(get("/api/students/{id}/grade/calculate", STUDENT_A_ID)
+                .header("Authorization", "Bearer " + coordinatorToken))
+                .andExpect(status().isOk());
+
+        // JDBC assertion: exactly 1 row in final_grade for this term
+        Integer rowCount = jdbcTemplate.queryForObject(
+                "SELECT COUNT(*) FROM final_grade WHERE term_id = ?",
+                Integer.class, TERM_ID);
+        assertThat(rowCount).isEqualTo(1);
+
+        LocalDateTime firstCalculatedAt = jdbcTemplate.queryForObject(
+                "SELECT calculated_at FROM final_grade WHERE term_id = ?",
+                LocalDateTime.class, TERM_ID);
+        assertThat(firstCalculatedAt).isNotNull();
+
+        // Ensure the second call will produce a strictly later timestamp
+        Thread.sleep(50);
+
+        // Second call → same row must be updated (upsert), not a new row
+        mockMvc.perform(get("/api/students/{id}/grade/calculate", STUDENT_A_ID)
+                .header("Authorization", "Bearer " + coordinatorToken))
+                .andExpect(status().isOk());
+
+        // JDBC assertion: still exactly 1 row — no duplicate was inserted
+        Integer rowCountAfter = jdbcTemplate.queryForObject(
+                "SELECT COUNT(*) FROM final_grade WHERE term_id = ?",
+                Integer.class, TERM_ID);
+        assertThat(rowCountAfter).isEqualTo(1);
+
+        LocalDateTime secondCalculatedAt = jdbcTemplate.queryForObject(
+                "SELECT calculated_at FROM final_grade WHERE term_id = ?",
+                LocalDateTime.class, TERM_ID);
+        assertThat(secondCalculatedAt).isAfterOrEqualTo(firstCalculatedAt);
+    }
+
+    // ═══════════════════════════════════════════════════════════════════
+    //  Helpers
+    // ═══════════════════════════════════════════════════════════════════
+
+    private void cleanAll() {
+        finalGradeRepository.deleteAll();
+        sprintTrackingLogRepository.deleteAll();
+        groupMembershipRepository.deleteAll();
+        projectGroupRepository.deleteAll();
+        sprintRepository.deleteAll();
+        studentRepository.deleteAll();
+        staffUserRepository.deleteAll();
+        systemConfigRepository.deleteAll();
+    }
+
+    private StaffUser makeProfessor(String mail) {
+        StaffUser u = new StaffUser();
+        u.setMail(mail);
+        u.setPasswordHash("$2a$10$dXJ3SW6G7P50lGmMkkmwe.20cQQubK3.HZWzG3YB1tlRy.fqvM/BG");
+        u.setRole(Role.Professor);
+        u.setAdvisorCapacity(5);
+        return u;
+    }
+
+    private StaffUser makeCoordinator(String mail) {
+        StaffUser u = new StaffUser();
+        u.setMail(mail);
+        u.setPasswordHash("$2a$10$dXJ3SW6G7P50lGmMkkmwe.20cQQubK3.HZWzG3YB1tlRy.fqvM/BG");
+        u.setRole(Role.Coordinator);
+        return u;
+    }
+
+    private Student makeStudent(String studentId, String githubUsername) {
+        Student s = new Student();
+        s.setStudentId(studentId);
+        s.setGithubUsername(githubUsername);
+        return s;
+    }
+
+    private ProjectGroup makeGroup(String name) {
+        ProjectGroup g = new ProjectGroup();
+        g.setGroupName(name);
+        g.setTermId(TERM_ID);
+        g.setStatus(ProjectGroup.GroupStatus.ADVISOR_ASSIGNED);
+        g.setCreatedAt(LocalDateTime.now(ZoneId.of("UTC")));
+        return g;
+    }
+
+    private ProjectGroup makeGroupWithAdvisor(String name, StaffUser advisor) {
+        ProjectGroup g = makeGroup(name);
+        g.setAdvisor(advisor);
+        return g;
+    }
+
+    private GroupMembership makeMembership(Student s, ProjectGroup g) {
+        GroupMembership m = new GroupMembership();
+        m.setStudent(s);
+        m.setGroup(g);
+        m.setRole(GroupMembership.MemberRole.TEAM_LEADER);
+        m.setJoinedAt(LocalDateTime.now(ZoneId.of("UTC")));
+        return m;
+    }
+
+    private Sprint makeSprint(int storyPointTarget) {
+        Sprint sp = new Sprint();
+        sp.setStartDate(LocalDate.now().minusDays(14));
+        sp.setEndDate(LocalDate.now().minusDays(1));
+        sp.setStoryPointTarget(storyPointTarget);
+        return sp;
+    }
+
+    private SprintTrackingLog makeLog(ProjectGroup group, Sprint sprint,
+            String assigneeUsername, boolean prMerged, int storyPoints) {
+        SprintTrackingLog log = new SprintTrackingLog();
+        log.setGroup(group);
+        log.setSprint(sprint);
+        log.setIssueKey("PROJ-001");
+        log.setAssigneeGithubUsername(assigneeUsername);
+        log.setPrMerged(prMerged);
+        log.setStoryPoints(storyPoints);
+        log.setFetchedAt(LocalDateTime.now(ZoneId.of("UTC")));
+        log.setAiPrResult(SprintTrackingLog.AiValidationResult.PENDING);
+        log.setAiDiffResult(SprintTrackingLog.AiValidationResult.PENDING);
+        return log;
+    }
+}

--- a/backend/src/test/java/com/senior/spm/controller/RubricGradingControllerTest.java
+++ b/backend/src/test/java/com/senior/spm/controller/RubricGradingControllerTest.java
@@ -269,6 +269,46 @@ class RubricGradingControllerTest {
                 .andExpect(jsonPath("$.message").isNotEmpty());
     }
 
+    // ═══════════════════════════════════════════════════════════════════
+    //  Soft criterion — invalid grade value → 400
+    // ═══════════════════════════════════════════════════════════════════
+
+    @Test
+    @DisplayName("Soft criterion receiving 'X' (not in A/B/C/D/F) returns 400")
+    void softCriterion_invalidGrade_returns400() throws Exception {
+        mockMvc.perform(post("/api/submissions/{id}/grade", submission.getId())
+                .with(authentication(profAuth(professor)))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(gradesJson(
+                        entry(binaryCriterion.getId(), "S"),
+                        entry(softCriterion.getId(),   "X"))))  // invalid for Soft
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.message").value(
+                        org.hamcrest.Matchers.containsString(softCriterion.getId().toString())));
+    }
+
+    // ═══════════════════════════════════════════════════════════════════
+    //  Deliverable-scoped committee check:
+    //  Professor on Proposal committee cannot grade a SoW submission → 403
+    // ═══════════════════════════════════════════════════════════════════
+
+    @Test
+    @DisplayName("Professor assigned to Proposal committee grades SoW submission → 403")
+    void professorInProposalCommittee_grade_sowSubmission_returns403() throws Exception {
+        // Professor is already on the Proposal committee (set up in @BeforeEach).
+        // Create a SoW deliverable + submission for the same group.
+        Deliverable sowDeliverable = deliverableRepository.save(makeSoWDeliverable());
+        DeliverableSubmission sowSubmission = submissionRepository.save(makeSubmission(group, sowDeliverable));
+
+        // No committee exists for professor × group × sowDeliverable → 403
+        mockMvc.perform(post("/api/submissions/{id}/grade", sowSubmission.getId())
+                .with(authentication(profAuth(professor)))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(gradesJson(entry(binaryCriterion.getId(), "S"))))
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.message").isNotEmpty());
+    }
+
     // ── helpers ──────────────────────────────────────────────────────────
 
     private StaffUser makeProfessor(String mail) {
@@ -285,6 +325,16 @@ class RubricGradingControllerTest {
         d.setName(name);
         d.setType(Deliverable.DeliverableType.Proposal);
         d.setWeight(new BigDecimal(weight));
+        d.setSubmissionDeadline(LocalDateTime.now().plusDays(30));
+        d.setReviewDeadline(LocalDateTime.now().plusDays(37));
+        return d;
+    }
+
+    private Deliverable makeSoWDeliverable() {
+        Deliverable d = new Deliverable();
+        d.setName("SoW");
+        d.setType(Deliverable.DeliverableType.SoW);
+        d.setWeight(new BigDecimal("20"));
         d.setSubmissionDeadline(LocalDateTime.now().plusDays(30));
         d.setReviewDeadline(LocalDateTime.now().plusDays(37));
         return d;

--- a/backend/src/test/java/com/senior/spm/controller/SystemConfigControllerTest.java
+++ b/backend/src/test/java/com/senior/spm/controller/SystemConfigControllerTest.java
@@ -1,0 +1,171 @@
+package com.senior.spm.controller;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+
+import com.senior.spm.entity.StaffUser;
+import com.senior.spm.entity.StaffUser.Role;
+import com.senior.spm.entity.Student;
+import com.senior.spm.repository.StaffUserRepository;
+import com.senior.spm.repository.StudentRepository;
+import com.senior.spm.repository.SystemConfigRepository;
+import com.senior.spm.service.JWTService;
+
+/**
+ * Integration tests for PATCH /api/coordinator/system-config (S4-09 backend coverage, issue #254).
+ *
+ * Covers:
+ *   – Valid coordinator payload → 200, both keys persisted in H2
+ *   – Non-coordinator callers (professor, student) → 403
+ *   – maxTeamSize: 0 violates @Min(1) constraint → 400
+ */
+@SpringBootTest
+@AutoConfigureMockMvc
+@TestPropertySource(locations = "classpath:test.properties")
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+class SystemConfigControllerTest {
+
+    @Autowired MockMvc mockMvc;
+    @Autowired JWTService jwtService;
+
+    @Autowired StaffUserRepository staffUserRepository;
+    @Autowired StudentRepository studentRepository;
+    @Autowired SystemConfigRepository systemConfigRepository;
+
+    private String coordinatorToken;
+    private String professorToken;
+    private String studentToken;
+
+    @BeforeEach
+    void setUp() {
+        cleanAll();
+
+        StaffUser coordinator = staffUserRepository.save(makeStaff("coord@sc-test.com", Role.Coordinator));
+        StaffUser professor   = staffUserRepository.save(makeStaff("prof@sc-test.com",  Role.Professor));
+        Student   student     = studentRepository.save(makeStudent("33300000001"));
+
+        coordinatorToken = jwtService.issueToken(coordinator);
+        professorToken   = jwtService.issueToken(professor);
+        studentToken     = jwtService.issueToken(student);
+    }
+
+    @AfterEach
+    void tearDown() {
+        cleanAll();
+    }
+
+    // ═══════════════════════════════════════════════════════════════════
+    //  Happy path — coordinator with valid payload
+    // ═══════════════════════════════════════════════════════════════════
+
+    @Test
+    @DisplayName("Coordinator PATCH with both fields → 200, both values persisted in H2")
+    void coordinator_validPayload_returns200AndPersistsBothValues() throws Exception {
+        mockMvc.perform(patch("/api/coordinator/system-config")
+                .header("Authorization", "Bearer " + coordinatorToken)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"activeTermId\":\"2026-SC-TEST\",\"maxTeamSize\":6}"))
+                .andExpect(status().isOk());
+
+        // H2 assertion — both config keys must be present with the sent values
+        assertThat(systemConfigRepository.findByConfigKey("active_term_id"))
+                .isPresent()
+                .hasValueSatisfying(c -> assertThat(c.getConfigValue()).isEqualTo("2026-SC-TEST"));
+
+        assertThat(systemConfigRepository.findByConfigKey("max_team_size"))
+                .isPresent()
+                .hasValueSatisfying(c -> assertThat(c.getConfigValue()).isEqualTo("6"));
+    }
+
+    @Test
+    @DisplayName("Coordinator PATCH with only activeTermId → 200, only that key persisted")
+    void coordinator_onlyActiveTermId_returns200AndPersistsSingleKey() throws Exception {
+        mockMvc.perform(patch("/api/coordinator/system-config")
+                .header("Authorization", "Bearer " + coordinatorToken)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"activeTermId\":\"2026-ONLY-TERM\"}"))
+                .andExpect(status().isOk());
+
+        assertThat(systemConfigRepository.findByConfigKey("active_term_id"))
+                .isPresent()
+                .hasValueSatisfying(c -> assertThat(c.getConfigValue()).isEqualTo("2026-ONLY-TERM"));
+
+        assertThat(systemConfigRepository.findByConfigKey("max_team_size")).isEmpty();
+    }
+
+    // ═══════════════════════════════════════════════════════════════════
+    //  Non-coordinator callers — 403
+    // ═══════════════════════════════════════════════════════════════════
+
+    @Test
+    @DisplayName("Professor PATCH → 403")
+    void professor_returns403() throws Exception {
+        mockMvc.perform(patch("/api/coordinator/system-config")
+                .header("Authorization", "Bearer " + professorToken)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"activeTermId\":\"2026-SC-TEST\",\"maxTeamSize\":5}"))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @DisplayName("Student PATCH → 403")
+    void student_returns403() throws Exception {
+        mockMvc.perform(patch("/api/coordinator/system-config")
+                .header("Authorization", "Bearer " + studentToken)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"activeTermId\":\"2026-SC-TEST\",\"maxTeamSize\":5}"))
+                .andExpect(status().isForbidden());
+    }
+
+    // ═══════════════════════════════════════════════════════════════════
+    //  Validation — maxTeamSize: 0 violates @Min(1)
+    // ═══════════════════════════════════════════════════════════════════
+
+    @Test
+    @DisplayName("maxTeamSize: 0 → 400 (violates @Min(1))")
+    void maxTeamSizeZero_returns400() throws Exception {
+        mockMvc.perform(patch("/api/coordinator/system-config")
+                .header("Authorization", "Bearer " + coordinatorToken)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"maxTeamSize\":0}"))
+                .andExpect(status().isBadRequest());
+    }
+
+    // ═══════════════════════════════════════════════════════════════════
+    //  Helpers
+    // ═══════════════════════════════════════════════════════════════════
+
+    private void cleanAll() {
+        systemConfigRepository.deleteAll();
+        studentRepository.deleteAll();
+        staffUserRepository.deleteAll();
+    }
+
+    private StaffUser makeStaff(String mail, Role role) {
+        StaffUser u = new StaffUser();
+        u.setMail(mail);
+        u.setPasswordHash("$2a$10$dXJ3SW6G7P50lGmMkkmwe.20cQQubK3.HZWzG3YB1tlRy.fqvM/BG");
+        u.setRole(role);
+        u.setAdvisorCapacity(5);
+        return u;
+    }
+
+    private Student makeStudent(String studentId) {
+        Student s = new Student();
+        s.setStudentId(studentId);
+        return s;
+    }
+}


### PR DESCRIPTION
## Test Coverage Summary

All **26 tests pass**. Here's a structured summary of what was written:

---

###  FinalGradeCalculateIntegrationTest.java — 10 tests  
Uses real JWT tokens

####   Auth Matrix
- Student A → own grade → **200**
- Student A → Student B's grade → **403**
- Professor not advisor → **403**
- Professor IS advisor → **200**
- Coordinator → **200** for A and B

####  Cᵢ Identification
- matching `username + prMerged=true` → counted (**Cᵢ > 0**)
- `prMerged=false` → **0**
- wrong username → **0**

####  Persistence
- JDBC `COUNT(*)` asserts **one row after first call**
- `Thread.sleep(50)` + second call:
  - `calculated_at` updated
  - row count still **1**

---

###  SystemConfigControllerTest.java — 5 tests

- Coordinator + valid payload → **200**
  - `active_term_id` and `max_team_size` verified via `SystemConfigRepository`
- Coordinator + only `activeTermId` → **200**
  - single key persisted
- Professor → **403**
- Student → **403**
- `maxTeamSize = 0` → **400**
  - triggers `@Min(1)` validation on DTO

---

###  RubricGradingControllerTest.java — 2 tests (11 total)

- Soft criterion + `"X"` → **400**
  - criterion ID included in error message
- Professor (Proposal committee grading SoW submission) → **403**
  - enforce deliverable-scoped committee authorization

resolves #254 