### PR TITLE
test: verify coordinator UUID in audit log for 5 service methods (#297)

### DIFF
--- a/backend/src/test/java/com/senior/spm/service/AdvisorServiceBrowseRequestTest.java
+++ b/backend/src/test/java/com/senior/spm/service/AdvisorServiceBrowseRequestTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -769,6 +770,25 @@ class AdvisorServiceBrowseRequestTest {
 
             verify(projectGroupRepository, never()).countByAdvisorIdAndTermIdAndStatusNot(any(), any(), any());
         }
+
+        @Test
+        void writesAuditLog_withCoordinatorUserIdFromSecurityContext() {
+            UUID coordinatorId = UUID.randomUUID();
+            SecurityContextHolder.getContext().setAuthentication(
+                    new UsernamePasswordAuthenticationToken(coordinatorId.toString(), null, List.of()));
+
+            when(projectGroupRepository.findById(GROUP_ID)).thenReturn(Optional.of(group));
+            when(staffUserRepository.findById(ADVISOR_ID)).thenReturn(Optional.of(professor));
+
+            advisorService.assignAdvisor(GROUP_ID, ADVISOR_ID);
+
+            verify(auditLogService).record(
+                    eq(coordinatorId),
+                    eq(com.senior.spm.entity.AuditLog.UserType.STAFF),
+                    eq("ADVISOR_ASSIGNED"),
+                    eq(com.senior.spm.entity.AuditLog.Outcome.SUCCESS),
+                    isNull());
+        }
     }
 
     // ══════════════════════════════════════════════════════════════════════════
@@ -810,6 +830,26 @@ class AdvisorServiceBrowseRequestTest {
             assertThat(captor.getValue().getStatus()).isEqualTo(GroupStatus.TOOLS_BOUND);
             assertThat(response.getStatus()).isEqualTo(GroupStatus.TOOLS_BOUND);
             assertThat(response.getAdvisorId()).isNull();
+        }
+
+        @Test
+        void writesAuditLog_withCoordinatorUserIdFromSecurityContext() {
+            UUID coordinatorId = UUID.randomUUID();
+            SecurityContextHolder.getContext().setAuthentication(
+                    new UsernamePasswordAuthenticationToken(coordinatorId.toString(), null, List.of()));
+
+            group.setStatus(GroupStatus.ADVISOR_ASSIGNED);
+            group.setAdvisor(professor);
+            when(projectGroupRepository.findById(GROUP_ID)).thenReturn(Optional.of(group));
+
+            advisorService.removeAdvisor(GROUP_ID);
+
+            verify(auditLogService).record(
+                    eq(coordinatorId),
+                    eq(com.senior.spm.entity.AuditLog.UserType.STAFF),
+                    eq("ADVISOR_REMOVED"),
+                    eq(com.senior.spm.entity.AuditLog.Outcome.SUCCESS),
+                    isNull());
         }
     }
 

--- a/backend/src/test/java/com/senior/spm/service/GroupServiceTest.java
+++ b/backend/src/test/java/com/senior/spm/service/GroupServiceTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -30,6 +31,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import com.senior.spm.controller.response.BindToolResponse;
 import com.senior.spm.controller.response.GroupDetailResponse;
 import com.senior.spm.entity.AdvisorRequest.RequestStatus;
+import com.senior.spm.entity.AuditLog;
 import com.senior.spm.entity.GroupInvitation.InvitationStatus;
 import com.senior.spm.entity.GroupMembership;
 import com.senior.spm.entity.GroupMembership.MemberRole;
@@ -520,6 +522,31 @@ class GroupServiceTest {
 
             verify(groupMembershipRepository).save(any(GroupMembership.class));
         }
+
+        @Test
+        void writesAuditLog_withCoordinatorUserIdFromSecurityContext() {
+            UUID coordinatorId = UUID.randomUUID();
+            SecurityContextHolder.getContext().setAuthentication(
+                    new UsernamePasswordAuthenticationToken(coordinatorId.toString(), null, List.of()));
+
+            when(projectGroupRepository.findById(groupId)).thenReturn(Optional.of(group));
+            when(studentRepository.findByStudentId(STUDENT_ID_STR)).thenReturn(Optional.of(targetStudent));
+            when(groupMembershipRepository.existsByStudentId(studentUUID)).thenReturn(false);
+            when(groupMembershipRepository.countByGroupId(groupId)).thenReturn(1L);
+            when(groupInvitationRepository.countByGroupIdAndStatus(groupId, InvitationStatus.PENDING)).thenReturn(0L);
+            when(termConfigService.getMaxTeamSize()).thenReturn(5);
+            when(groupMembershipRepository.save(any())).thenReturn(new GroupMembership());
+            when(groupMembershipRepository.findByGroupId(groupId)).thenReturn(List.of());
+
+            groupService.coordinatorAddStudent(groupId, STUDENT_ID_STR);
+
+            verify(auditLogService).record(
+                    eq(coordinatorId),
+                    eq(AuditLog.UserType.STAFF),
+                    eq("MEMBER_ADDED"),
+                    eq(AuditLog.Outcome.SUCCESS),
+                    isNull());
+        }
     }
 
     // ── coordinatorRemoveStudent ───────────────────────────────────────────────
@@ -621,6 +648,33 @@ class GroupServiceTest {
 
             verify(groupMembershipRepository, never()).delete(any());
         }
+
+        @Test
+        void writesAuditLog_withCoordinatorUserIdFromSecurityContext() {
+            UUID coordinatorId = UUID.randomUUID();
+            SecurityContextHolder.getContext().setAuthentication(
+                    new UsernamePasswordAuthenticationToken(coordinatorId.toString(), null, List.of()));
+
+            GroupMembership membership = new GroupMembership();
+            membership.setStudent(targetStudent);
+            membership.setGroup(group);
+            membership.setRole(MemberRole.MEMBER);
+
+            when(projectGroupRepository.findById(groupId)).thenReturn(Optional.of(group));
+            when(studentRepository.findByStudentId(STUDENT_ID_STR)).thenReturn(Optional.of(targetStudent));
+            when(groupMembershipRepository.findByGroupIdAndStudentId(groupId, studentUUID))
+                    .thenReturn(Optional.of(membership));
+            when(groupMembershipRepository.findByGroupId(groupId)).thenReturn(List.of());
+
+            groupService.coordinatorRemoveStudent(groupId, STUDENT_ID_STR);
+
+            verify(auditLogService).record(
+                    eq(coordinatorId),
+                    eq(AuditLog.UserType.STAFF),
+                    eq("MEMBER_REMOVED"),
+                    eq(AuditLog.Outcome.SUCCESS),
+                    isNull());
+        }
     }
 
     // ── disbandGroup ───────────────────────────────────────────────────────────
@@ -717,6 +771,26 @@ class GroupServiceTest {
             ArgumentCaptor<ProjectGroup> captor = ArgumentCaptor.forClass(ProjectGroup.class);
             verify(projectGroupRepository).save(captor.capture());
             assertThat(captor.getValue().getStatus()).isEqualTo(GroupStatus.DISBANDED);
+        }
+
+        @Test
+        void writesAuditLog_withCoordinatorUserIdFromSecurityContext() {
+            UUID coordinatorId = UUID.randomUUID();
+            SecurityContextHolder.getContext().setAuthentication(
+                    new UsernamePasswordAuthenticationToken(coordinatorId.toString(), null, List.of()));
+
+            when(projectGroupRepository.findById(groupId)).thenReturn(Optional.of(activeGroup));
+            when(projectGroupRepository.save(any())).thenReturn(activeGroup);
+            when(groupMembershipRepository.findByGroupId(groupId)).thenReturn(List.of());
+
+            groupService.disbandGroup(groupId);
+
+            verify(auditLogService).record(
+                    eq(coordinatorId),
+                    eq(AuditLog.UserType.STAFF),
+                    eq("GROUP_DISBANDED"),
+                    eq(AuditLog.Outcome.SUCCESS),
+                    isNull());
         }
     }
 


### PR DESCRIPTION
This issue is already resolved by PR #285 (commit `c740a19`), which is listed as the dependency at the bottom of the issue. The audit-log infrastructure PR did not just add the `auditLogService.record(...)` calls — it also added a private `currentUserId()` helper and wired it into all five affected methods at the same time.

The helper is exactly Option B from the issue:

```java
private UUID currentUserId() {
    Object principal = SecurityContextHolder.getContext().getAuthentication().getPrincipal();
    return UUID.fromString((String) principal);
}
```

All five call sites already pass it as the `userId` argument:

- `GroupService.coordinatorAddStudent` → `MEMBER_ADDED` (GroupService.java:508)
- `GroupService.coordinatorRemoveStudent` → `MEMBER_REMOVED` (GroupService.java:558)
- `GroupService.disbandGroup` → `GROUP_DISBANDED` (GroupService.java:617)
- `AdvisorService.assignAdvisor` → `ADVISOR_ASSIGNED` (AdvisorService.java:620)
- `AdvisorService.removeAdvisor` → `ADVISOR_REMOVED` (AdvisorService.java:664)

### What this PR adds

The production fix was already in place, but the existing tests only mocked `AuditLogService` without verifying its arguments — so a future regression that silently passed `null` (or the wrong UUID) would not have failed any test. To lock the acceptance criteria into the suite, this PR adds **five focused verification tests**, one per affected method:

- `GroupServiceTest$CoordinatorAddStudent#writesAuditLog_withCoordinatorUserIdFromSecurityContext`
- `GroupServiceTest$CoordinatorRemoveStudent#writesAuditLog_withCoordinatorUserIdFromSecurityContext`
- `GroupServiceTest$DisbandGroup#writesAuditLog_withCoordinatorUserIdFromSecurityContext`
- `AdvisorServiceBrowseRequestTest$AssignAdvisor#writesAuditLog_withCoordinatorUserIdFromSecurityContext`
- `AdvisorServiceBrowseRequestTest$RemoveAdvisor#writesAuditLog_withCoordinatorUserIdFromSecurityContext`

Each test seeds `SecurityContextHolder` with a known coordinator UUID, runs the happy-path of the corresponding service method, and asserts:

```java
verify(auditLogService).record(
        eq(coordinatorId),
        eq(AuditLog.UserType.STAFF),
        eq("MEMBER_ADDED"),       // or the matching action constant
        eq(AuditLog.Outcome.SUCCESS),
        isNull());
```

This matches the audit row exactly to the principal stored in `SecurityContextHolder`, so any future change that drops the helper or replaces it with a literal `null` will fail at build time.

### Acceptance criteria

- [x] `MEMBER_ADDED`, `MEMBER_REMOVED`, `GROUP_DISBANDED` audit rows have non-null `userId` — verified by the three new `GroupServiceTest` tests
- [x] `ADVISOR_ASSIGNED`, `ADVISOR_REMOVED` audit rows have non-null `userId` — verified by the two new `AdvisorServiceBrowseRequestTest` tests
- [x] All existing service tests still pass — full run of `GroupServiceTest` + `AdvisorServiceBrowseRequestTest` is green (116 tests, 0 failures)

### Notes

The issue description (claiming the rows record `userId = null`) appears to have been written against an earlier draft of #285, before the helper was added in the same commit. No production code changes were needed; the work in this PR is limited to test additions that turn the AC into an enforceable contract.

Closes #297