### PR TITLE
fix: audit-log-thread-user-test

### DIFF
--- a/backend/src/test/java/com/senior/spm/service/AdvisorServiceTest.java
+++ b/backend/src/test/java/com/senior/spm/service/AdvisorServiceTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -13,16 +14,23 @@ import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
 
+import com.senior.spm.controller.response.AdvisorOverrideResponse;
 import com.senior.spm.entity.AdvisorRequest;
 import com.senior.spm.entity.AdvisorRequest.RequestStatus;
+import com.senior.spm.entity.AuditLog.Outcome;
+import com.senior.spm.entity.AuditLog.UserType;
 import com.senior.spm.entity.GroupMembership;
 import com.senior.spm.entity.GroupMembership.MemberRole;
 import com.senior.spm.entity.ProjectGroup;
@@ -30,12 +38,16 @@ import com.senior.spm.entity.ProjectGroup.GroupStatus;
 import com.senior.spm.entity.StaffUser;
 import com.senior.spm.entity.Student;
 import com.senior.spm.exception.AdvisorAtCapacityException;
+import com.senior.spm.exception.AdvisorNotFoundException;
+import com.senior.spm.exception.BusinessRuleException;
 import com.senior.spm.exception.ForbiddenException;
+import com.senior.spm.exception.GroupNotFoundException;
 import com.senior.spm.exception.RequestNotFoundException;
 import com.senior.spm.exception.RequestNotPendingException;
 import com.senior.spm.repository.AdvisorRequestRepository;
 import com.senior.spm.repository.ProjectGroupRepository;
 import com.senior.spm.repository.GroupMembershipRepository;
+import com.senior.spm.repository.StaffUserRepository;
 import com.senior.spm.service.dto.AdvisorRequestDetail;
 import com.senior.spm.service.dto.AdvisorRequestSummary;
 import com.senior.spm.service.dto.AdvisorRespondResponse;
@@ -46,6 +58,7 @@ class AdvisorServiceTest {
     @Mock private AdvisorRequestRepository advisorRequestRepository;
     @Mock private ProjectGroupRepository projectGroupRepository;
     @Mock private GroupMembershipRepository groupMembershipRepository;
+    @Mock private StaffUserRepository staffUserRepository;
     @Mock private TermConfigService termConfigService;
     @Mock private AuditLogService auditLogService;
 
@@ -60,6 +73,7 @@ class AdvisorServiceTest {
     private static final UUID   OTHER_PROF_ID   = UUID.randomUUID();
     private static final UUID   REQUEST_ID      = UUID.randomUUID();
     private static final UUID   GROUP_ID        = UUID.randomUUID();
+    private static final UUID   COORDINATOR_ID  = UUID.randomUUID();
 
     // ── shared fixtures ────────────────────────────────────────────────────────
 
@@ -69,8 +83,12 @@ class AdvisorServiceTest {
 
     @BeforeEach
     void setUp() {
+        SecurityContextHolder.getContext().setAuthentication(
+                new UsernamePasswordAuthenticationToken(COORDINATOR_ID.toString(), null, List.of()));
+
         professor = new StaffUser();
         professor.setId(PROFESSOR_ID);
+        professor.setRole(StaffUser.Role.Professor);
         professor.setAdvisorCapacity(CAPACITY);
 
         group = new ProjectGroup();
@@ -88,6 +106,11 @@ class AdvisorServiceTest {
         pendingRequest.setGroup(group);
         pendingRequest.setStatus(RequestStatus.PENDING);
         pendingRequest.setSentAt(LocalDateTime.now().minusHours(2));
+    }
+
+    @AfterEach
+    void tearDown() {
+        SecurityContextHolder.clearContext();
     }
 
     // ══════════════════════════════════════════════════════════════════════════
@@ -523,5 +546,143 @@ class AdvisorServiceTest {
         s.setId(UUID.randomUUID());
         s.setStudentId(studentId);
         return s;
+    }
+
+    // ══════════════════════════════════════════════════════════════════════════
+    //  COORDINATOR — assignAdvisor (FIX-2: userId must be non-null)
+    // ══════════════════════════════════════════════════════════════════════════
+
+    @Nested
+    class CoordinatorAssignAdvisor {
+
+        private final UUID advisorId = UUID.randomUUID();
+        private StaffUser newAdvisor;
+
+        @BeforeEach
+        void setUpAdvisor() {
+            newAdvisor = new StaffUser();
+            newAdvisor.setId(advisorId);
+            newAdvisor.setRole(StaffUser.Role.Professor);
+            newAdvisor.setAdvisorCapacity(5);
+        }
+
+        @Test
+        void happyPath_assignsAdvisorAndRecordsAuditWithCoordinatorId() {
+            when(projectGroupRepository.findById(GROUP_ID)).thenReturn(Optional.of(group));
+            when(staffUserRepository.findById(advisorId)).thenReturn(Optional.of(newAdvisor));
+            when(projectGroupRepository.save(any())).thenReturn(group);
+
+            AdvisorOverrideResponse response = advisorService.assignAdvisor(GROUP_ID, advisorId);
+
+            assertThat(response.getGroupId()).isEqualTo(GROUP_ID);
+            assertThat(response.getAdvisorId()).isEqualTo(advisorId);
+
+            ArgumentCaptor<UUID> userIdCaptor = ArgumentCaptor.forClass(UUID.class);
+            verify(auditLogService).record(
+                    userIdCaptor.capture(), eq(UserType.STAFF), eq("ADVISOR_ASSIGNED"), eq(Outcome.SUCCESS), isNull());
+            assertThat(userIdCaptor.getValue()).isEqualTo(COORDINATOR_ID);
+        }
+
+        @Test
+        void throwsGroupNotFoundWhenGroupMissing() {
+            when(projectGroupRepository.findById(GROUP_ID)).thenReturn(Optional.empty());
+
+            assertThatThrownBy(() -> advisorService.assignAdvisor(GROUP_ID, advisorId))
+                    .isInstanceOf(GroupNotFoundException.class);
+
+            verify(auditLogService, never()).record(any(), any(), any(), any(), any());
+        }
+
+        @Test
+        void throwsBusinessRuleExceptionWhenGroupIsDisbanded() {
+            group.setStatus(GroupStatus.DISBANDED);
+            when(projectGroupRepository.findById(GROUP_ID)).thenReturn(Optional.of(group));
+
+            assertThatThrownBy(() -> advisorService.assignAdvisor(GROUP_ID, advisorId))
+                    .isInstanceOf(BusinessRuleException.class)
+                    .hasMessageContaining("disbanded");
+        }
+
+        @Test
+        void throwsBusinessRuleExceptionWhenGroupStatusIsInvalid() {
+            group.setStatus(GroupStatus.FORMING);
+            when(projectGroupRepository.findById(GROUP_ID)).thenReturn(Optional.of(group));
+
+            assertThatThrownBy(() -> advisorService.assignAdvisor(GROUP_ID, advisorId))
+                    .isInstanceOf(BusinessRuleException.class);
+        }
+
+        @Test
+        void throwsAdvisorNotFoundWhenAdvisorMissing() {
+            when(projectGroupRepository.findById(GROUP_ID)).thenReturn(Optional.of(group));
+            when(staffUserRepository.findById(advisorId)).thenReturn(Optional.empty());
+
+            assertThatThrownBy(() -> advisorService.assignAdvisor(GROUP_ID, advisorId))
+                    .isInstanceOf(AdvisorNotFoundException.class);
+        }
+
+        @Test
+        void throwsBusinessRuleExceptionWhenAdvisorAlreadyAssigned() {
+            group.setStatus(GroupStatus.ADVISOR_ASSIGNED);
+            group.setAdvisor(newAdvisor);
+            when(projectGroupRepository.findById(GROUP_ID)).thenReturn(Optional.of(group));
+            when(staffUserRepository.findById(advisorId)).thenReturn(Optional.of(newAdvisor));
+
+            assertThatThrownBy(() -> advisorService.assignAdvisor(GROUP_ID, advisorId))
+                    .isInstanceOf(BusinessRuleException.class)
+                    .hasMessageContaining("already");
+        }
+    }
+
+    // ══════════════════════════════════════════════════════════════════════════
+    //  COORDINATOR — removeAdvisor (FIX-2: userId must be non-null)
+    // ══════════════════════════════════════════════════════════════════════════
+
+    @Nested
+    class CoordinatorRemoveAdvisor {
+
+        @BeforeEach
+        void setUpWithAdvisor() {
+            group.setStatus(GroupStatus.ADVISOR_ASSIGNED);
+            group.setAdvisor(professor);
+        }
+
+        @Test
+        void happyPath_removesAdvisorAndRecordsAuditWithCoordinatorId() {
+            when(projectGroupRepository.findById(GROUP_ID)).thenReturn(Optional.of(group));
+            when(projectGroupRepository.save(any())).thenReturn(group);
+
+            AdvisorOverrideResponse response = advisorService.removeAdvisor(GROUP_ID);
+
+            assertThat(response.getGroupId()).isEqualTo(GROUP_ID);
+            assertThat(response.getAdvisorId()).isNull();
+            assertThat(response.getStatus()).isEqualTo(GroupStatus.TOOLS_BOUND);
+
+            ArgumentCaptor<UUID> userIdCaptor = ArgumentCaptor.forClass(UUID.class);
+            verify(auditLogService).record(
+                    userIdCaptor.capture(), eq(UserType.STAFF), eq("ADVISOR_REMOVED"), eq(Outcome.SUCCESS), isNull());
+            assertThat(userIdCaptor.getValue()).isEqualTo(COORDINATOR_ID);
+        }
+
+        @Test
+        void throwsGroupNotFoundWhenGroupMissing() {
+            when(projectGroupRepository.findById(GROUP_ID)).thenReturn(Optional.empty());
+
+            assertThatThrownBy(() -> advisorService.removeAdvisor(GROUP_ID))
+                    .isInstanceOf(GroupNotFoundException.class);
+
+            verify(auditLogService, never()).record(any(), any(), any(), any(), any());
+        }
+
+        @Test
+        void throwsBusinessRuleExceptionWhenNoAdvisorAssigned() {
+            group.setAdvisor(null);
+            group.setStatus(GroupStatus.TOOLS_BOUND);
+            when(projectGroupRepository.findById(GROUP_ID)).thenReturn(Optional.of(group));
+
+            assertThatThrownBy(() -> advisorService.removeAdvisor(GROUP_ID))
+                    .isInstanceOf(BusinessRuleException.class)
+                    .hasMessageContaining("no advisor");
+        }
     }
 }

--- a/backend/src/test/java/com/senior/spm/service/GroupServiceTest.java
+++ b/backend/src/test/java/com/senior/spm/service/GroupServiceTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -30,6 +31,8 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import com.senior.spm.controller.response.BindToolResponse;
 import com.senior.spm.controller.response.GroupDetailResponse;
 import com.senior.spm.entity.AdvisorRequest.RequestStatus;
+import com.senior.spm.entity.AuditLog.Outcome;
+import com.senior.spm.entity.AuditLog.UserType;
 import com.senior.spm.entity.GroupInvitation.InvitationStatus;
 import com.senior.spm.entity.GroupMembership;
 import com.senior.spm.entity.GroupMembership.MemberRole;
@@ -77,6 +80,7 @@ class GroupServiceTest {
     private static final UUID STUDENT_ID = UUID.randomUUID();
     private static final UUID GROUP_ID = UUID.randomUUID();
     private static final String GROUP_NAME = "TeamAlpha";
+    private static final UUID COORDINATOR_ID = UUID.randomUUID();
 
     private ScheduleWindow openWindow;
     private Student student;
@@ -85,7 +89,7 @@ class GroupServiceTest {
     @BeforeEach
     void setUp() {
         SecurityContextHolder.getContext().setAuthentication(
-            new UsernamePasswordAuthenticationToken(UUID.randomUUID().toString(), null, List.of()));
+            new UsernamePasswordAuthenticationToken(COORDINATOR_ID.toString(), null, List.of()));
 
         openWindow = new ScheduleWindow();
         openWindow.setId(UUID.randomUUID());
@@ -421,6 +425,9 @@ class GroupServiceTest {
             assertThat(captor.getValue().getGroup()).isEqualTo(group);
 
             verify(groupInvitationRepository).autoDenyAllPendingByInviteeId(studentUUID);
+
+            verify(auditLogService).record(
+                    eq(COORDINATOR_ID), eq(UserType.STAFF), eq("MEMBER_ADDED"), eq(Outcome.SUCCESS), isNull());
         }
 
         @Test
@@ -565,6 +572,9 @@ class GroupServiceTest {
 
             verify(groupMembershipRepository).delete(membership);
             assertThat(result.getId()).isEqualTo(groupId);
+
+            verify(auditLogService).record(
+                    eq(COORDINATOR_ID), eq(UserType.STAFF), eq("MEMBER_REMOVED"), eq(Outcome.SUCCESS), isNull());
         }
 
         @Test
@@ -665,6 +675,9 @@ class GroupServiceTest {
                     eq(RequestStatus.AUTO_REJECTED), eq(groupId));
 
             assertThat(result.getStatus()).isEqualTo("DISBANDED");
+
+            verify(auditLogService).record(
+                    eq(COORDINATOR_ID), eq(UserType.STAFF), eq("GROUP_DISBANDED"), eq(Outcome.SUCCESS), isNull());
         }
 
         @Test


### PR DESCRIPTION
# Service Implementation & Test Updates (Audit Log Coverage)

## Service Implementation (Already Done)
Both `GroupService` and `AdvisorService` already had `currentUserId()` reading from `SecurityContextHolder` and passing it to all 5 audit log calls.

No service-layer changes were required.

---

## Test Changes Made

## GroupServiceTest

- Added `COORDINATOR_ID` static constant
- Replaced `UUID.randomUUID()` with fixed `COORDINATOR_ID` in `@BeforeEach`
- Added missing imports:
  - `AuditLog.Outcome`
  - `AuditLog.UserType`
  - `isNull`
- Added audit verification assertions for coordinator actions:
  - `coordinatorAddStudent`
  - `coordinatorRemoveStudent`
  - `disbandGroup`

Example assertions added:
- `verify(auditLogService).record(eq(COORDINATOR_ID), eq(UserType.STAFF), ...)`

---

## AdvisorServiceTest

- Added missing mock:
  - `@Mock StaffUserRepository staffUserRepository`
- Added `COORDINATOR_ID` constant
- Fixed role filtering requirement:
  - `professor.setRole(StaffUser.Role.Professor)` in `@BeforeEach`
- Added SecurityContext handling:
  - Seeded `SecurityContextHolder` in `@BeforeEach`
  - Cleared context in `@AfterEach`
- Introduced coordinator-focused test suites:
  - `CoordinatorAssignAdvisor` (6 tests)
  - `CoordinatorRemoveAdvisor` (3 tests)
- All happy-path tests now assert:
  - `userId == COORDINATOR_ID`

---

## Result

- **Total tests:** 99  
- **Failures:** 0  
- **Audit coverage:** Complete

All 5 audit log events now correctly verify **non-null coordinator UUID propagation** across both services.