### PR TITLE
feat: add audit log categories and paginated search query (#299, #300)

### DIFF
--- a/backend/src/main/java/com/senior/spm/entity/AuditLog.java
+++ b/backend/src/main/java/com/senior/spm/entity/AuditLog.java
@@ -22,12 +22,14 @@ import lombok.Setter;
     name = "audit_log",
     indexes = {
         @Index(name = "idx_al_user_id",     columnList = "userId"),
+        @Index(name = "idx_al_category",    columnList = "category"),
         @Index(name = "idx_al_outcome",     columnList = "outcome"),
         @Index(name = "idx_al_occurred_at", columnList = "occurredAt")
     }
 )
 public class AuditLog {
 
+    public enum Category { AUTH, GROUP, ADVISOR, GRADING }
     public enum UserType { STAFF, STUDENT }
     public enum Outcome  { SUCCESS, FAILURE }
 
@@ -44,6 +46,10 @@ public class AuditLog {
 
     @Column(length = 100, nullable = false)
     private String action;
+
+    @Enumerated(EnumType.STRING)
+    @Column(length = 20, nullable = false)
+    private Category category;
 
     @Enumerated(EnumType.STRING)
     @Column(length = 20, nullable = false)

--- a/backend/src/main/java/com/senior/spm/repository/AuditLogRepository.java
+++ b/backend/src/main/java/com/senior/spm/repository/AuditLogRepository.java
@@ -1,10 +1,38 @@
 package com.senior.spm.repository;
 
+import java.time.LocalDateTime;
 import java.util.UUID;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import com.senior.spm.entity.AuditLog;
+import com.senior.spm.entity.AuditLog.Category;
+import com.senior.spm.entity.AuditLog.Outcome;
+import com.senior.spm.entity.AuditLog.UserType;
 
 public interface AuditLogRepository extends JpaRepository<AuditLog, UUID> {
+
+    @Query("""
+            SELECT a FROM AuditLog a
+            WHERE (:userType IS NULL OR a.userType = :userType)
+              AND (:category IS NULL OR a.category = :category)
+              AND (:outcome  IS NULL OR a.outcome  = :outcome)
+              AND (:userId   IS NULL OR a.userId   = :userId)
+              AND (:from     IS NULL OR a.occurredAt >= :from)
+              AND (:to       IS NULL OR a.occurredAt <= :to)
+            ORDER BY a.occurredAt DESC
+            """)
+    Page<AuditLog> search(
+            @Param("userType") UserType   userType,
+            @Param("category") Category   category,
+            @Param("outcome")  Outcome    outcome,
+            @Param("userId")   UUID       userId,
+            @Param("from")     LocalDateTime from,
+            @Param("to")       LocalDateTime to,
+            Pageable pageable
+    );
 }

--- a/backend/src/main/java/com/senior/spm/service/AdvisorService.java
+++ b/backend/src/main/java/com/senior/spm/service/AdvisorService.java
@@ -35,6 +35,7 @@ import com.senior.spm.service.dto.AdvisorRequestDetail;
 import com.senior.spm.service.dto.AdvisorRequestSummary;
 import com.senior.spm.service.dto.AdvisorRespondResponse;
 
+import com.senior.spm.entity.AuditLog.Category;
 import com.senior.spm.entity.AuditLog.Outcome;
 import com.senior.spm.entity.AuditLog.UserType;
 
@@ -181,7 +182,7 @@ public class AdvisorService {
         request.setStatus(AdvisorRequest.RequestStatus.PENDING);
         request.setSentAt(now);
         AdvisorRequest saved = advisorRequestRepository.save(request);
-        auditLogService.record(requesterUUID, UserType.STUDENT, "ADVISOR_REQUEST_SENT", Outcome.SUCCESS, null);
+        auditLogService.record(requesterUUID, UserType.STUDENT, "ADVISOR_REQUEST_SENT", Category.ADVISOR, Outcome.SUCCESS, null);
 
         log.trace("[EVENT] userId={} action={} entityId={} detail={}",
                 requesterUUID, "ADVISOR_REQUEST_SENT", advisorId, groupId);
@@ -289,7 +290,7 @@ public class AdvisorService {
         // 5. Cancel and persist
         request.setStatus(AdvisorRequest.RequestStatus.CANCELLED);
         advisorRequestRepository.save(request);
-        auditLogService.record(requesterUUID, UserType.STUDENT, "ADVISOR_REQUEST_CANCELLED", Outcome.SUCCESS, null);
+        auditLogService.record(requesterUUID, UserType.STUDENT, "ADVISOR_REQUEST_CANCELLED", Category.ADVISOR, Outcome.SUCCESS, null);
 
         return AdvisorRequestResponse.builder()
                 .requestId(request.getId())
@@ -430,7 +431,7 @@ public class AdvisorService {
             request.setStatus(AdvisorRequest.RequestStatus.REJECTED);
             request.setRespondedAt(now);
             advisorRequestRepository.save(request);
-            auditLogService.record(professorId, UserType.STAFF, "ADVISOR_REQUEST_RESPONDED", Outcome.SUCCESS, null);
+            auditLogService.record(professorId, UserType.STAFF, "ADVISOR_REQUEST_RESPONDED", Category.ADVISOR, Outcome.SUCCESS, null);
 
             log.trace("[EVENT] userId={} action={} entityId={} detail={}",
                     professorId, "ADVISOR_REQUEST_RESPONDED", request.getGroup().getId(), "REJECTED");
@@ -469,7 +470,7 @@ public class AdvisorService {
 
         // Auto-reject all other PENDING requests for this group (same group, different advisors)
         advisorRequestRepository.bulkUpdateStatusForGroup(AdvisorRequest.RequestStatus.AUTO_REJECTED, group.getId(), request.getId());
-        auditLogService.record(professorId, UserType.STAFF, "ADVISOR_REQUEST_RESPONDED", Outcome.SUCCESS, null);
+        auditLogService.record(professorId, UserType.STAFF, "ADVISOR_REQUEST_RESPONDED", Category.ADVISOR, Outcome.SUCCESS, null);
 
         log.trace("[EVENT] userId={} action={} entityId={} detail={}",
                 professorId, "ADVISOR_REQUEST_RESPONDED", group.getId(), "ACCEPTED");
@@ -617,7 +618,7 @@ public class AdvisorService {
 
         advisorRequestRepository.bulkUpdateStatusByGroupId(AdvisorRequest.RequestStatus.AUTO_REJECTED, groupId);
 
-        auditLogService.record(currentUserId(), UserType.STAFF, "ADVISOR_ASSIGNED", Outcome.SUCCESS, null);
+        auditLogService.record(currentUserId(), UserType.STAFF, "ADVISOR_ASSIGNED", Category.ADVISOR, Outcome.SUCCESS, null);
         return AdvisorOverrideResponse.builder()
                 .groupId(group.getId())
                 .status(ProjectGroup.GroupStatus.ADVISOR_ASSIGNED)
@@ -661,7 +662,7 @@ public class AdvisorService {
         group.setStatus(ProjectGroup.GroupStatus.TOOLS_BOUND);
         projectGroupRepository.save(group);
 
-        auditLogService.record(currentUserId(), UserType.STAFF, "ADVISOR_REMOVED", Outcome.SUCCESS, null);
+        auditLogService.record(currentUserId(), UserType.STAFF, "ADVISOR_REMOVED", Category.ADVISOR, Outcome.SUCCESS, null);
         return AdvisorOverrideResponse.builder()
                 .groupId(group.getId())
                 .status(ProjectGroup.GroupStatus.TOOLS_BOUND)

--- a/backend/src/main/java/com/senior/spm/service/AuditLogService.java
+++ b/backend/src/main/java/com/senior/spm/service/AuditLogService.java
@@ -8,6 +8,7 @@ import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.senior.spm.entity.AuditLog;
+import com.senior.spm.entity.AuditLog.Category;
 import com.senior.spm.entity.AuditLog.Outcome;
 import com.senior.spm.entity.AuditLog.UserType;
 import com.senior.spm.repository.AuditLogRepository;
@@ -29,12 +30,13 @@ public class AuditLogService {
      * the calling business operation.
      */
     @Transactional(propagation = Propagation.REQUIRES_NEW)
-    public void record(UUID userId, UserType userType, String action, Outcome outcome, String ipAddress) {
+    public void record(UUID userId, UserType userType, String action, Category category, Outcome outcome, String ipAddress) {
         try {
             AuditLog entry = new AuditLog();
             entry.setUserId(userId);
             entry.setUserType(userType);
             entry.setAction(action);
+            entry.setCategory(category);
             entry.setOutcome(outcome);
             entry.setIpAddress(ipAddress);
             entry.setOccurredAt(LocalDateTime.now());

--- a/backend/src/main/java/com/senior/spm/service/AuthService.java
+++ b/backend/src/main/java/com/senior/spm/service/AuthService.java
@@ -9,6 +9,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import com.senior.spm.controller.response.GithubLoginResponse;
 import com.senior.spm.controller.response.LoginResponse;
+import com.senior.spm.entity.AuditLog.Category;
 import com.senior.spm.entity.AuditLog.Outcome;
 import com.senior.spm.entity.AuditLog.UserType;
 import com.senior.spm.exception.NotFoundException;
@@ -63,11 +64,11 @@ public class AuthService {
 
             log.trace("[EVENT] userId={} action={} entityId={} detail={}",
                     staffUser.get().getId(), "STAFF_LOGIN", staffUser.get().getId(), "staff-password-auth");
-            auditLogService.record(staffUser.get().getId(), UserType.STAFF, "STAFF_LOGIN", Outcome.SUCCESS, null);
+            auditLogService.record(staffUser.get().getId(), UserType.STAFF, "STAFF_LOGIN", Category.AUTH, Outcome.SUCCESS, null);
             return new LoginResponse(token, userInfo);
         }
 
-        auditLogService.record(null, UserType.STAFF, "STAFF_LOGIN", Outcome.FAILURE, null);
+        auditLogService.record(null, UserType.STAFF, "STAFF_LOGIN", Category.AUTH, Outcome.FAILURE, null);
         return null;
     }
 
@@ -89,7 +90,7 @@ public class AuthService {
         try {
             staffUserRepository.save(staffUser);
             passwordResetTokenRepository.delete(resetToken.get());
-            auditLogService.record(staffUser.getId(), UserType.STAFF, "PASSWORD_RESET", Outcome.SUCCESS, null);
+            auditLogService.record(staffUser.getId(), UserType.STAFF, "PASSWORD_RESET", Category.AUTH, Outcome.SUCCESS, null);
         } catch (IllegalArgumentException | OptimisticEntityLockException e) {
             throw new RepositoryException("Server error while resetting password: " + e.getMessage(), e);
         }
@@ -134,7 +135,7 @@ public class AuthService {
 
         log.trace("[EVENT] userId={} action={} entityId={} detail={}",
                 studentOpt.get().getId(), "STUDENT_LOGIN", studentOpt.get().getId(), "github-oauth");
-        auditLogService.record(studentOpt.get().getId(), UserType.STUDENT, "STUDENT_LOGIN", Outcome.SUCCESS, null);
+        auditLogService.record(studentOpt.get().getId(), UserType.STUDENT, "STUDENT_LOGIN", Category.AUTH, Outcome.SUCCESS, null);
         return new GithubLoginResponse(token, userInfo);
     }
 }

--- a/backend/src/main/java/com/senior/spm/service/GroupService.java
+++ b/backend/src/main/java/com/senior/spm/service/GroupService.java
@@ -34,6 +34,7 @@ import com.senior.spm.repository.ProjectGroupRepository;
 import com.senior.spm.repository.ScheduleWindowRepository;
 import com.senior.spm.repository.StudentRepository;
 
+import com.senior.spm.entity.AuditLog.Category;
 import com.senior.spm.entity.AuditLog.Outcome;
 import com.senior.spm.entity.AuditLog.UserType;
 
@@ -118,7 +119,7 @@ public class GroupService {
                 studentUUID, "GROUP_CREATED", savedGroup.getId(), groupName);
         // 8. Return GroupDetailResponse
         GroupDetailResponse result = toGroupDetailResponse(savedGroup, studentUUID);
-        auditLogService.record(studentUUID, UserType.STUDENT, "GROUP_CREATED", Outcome.SUCCESS, null);
+        auditLogService.record(studentUUID, UserType.STUDENT, "GROUP_CREATED", Category.GROUP, Outcome.SUCCESS, null);
         return result;
     }
 
@@ -202,7 +203,7 @@ public class GroupService {
         try {
             jiraValidationService.validate(jiraSpaceUrl, jiraEmail, jiraProjectKey, jiraApiToken);
         } catch (RuntimeException e) {
-            auditLogService.record(requesterUUID, UserType.STUDENT, "JIRA_BOUND", Outcome.FAILURE, null);
+            auditLogService.record(requesterUUID, UserType.STUDENT, "JIRA_BOUND", Category.GROUP, Outcome.FAILURE, null);
             throw e;
         }
 
@@ -230,7 +231,7 @@ public class GroupService {
         group.setJiraTokenExpiresAt(jiraTokenExpiresAt);
         group.setStatus(newStatus);
         ProjectGroup savedGroup = projectGroupRepository.save(group);
-        auditLogService.record(requesterUUID, UserType.STUDENT, "JIRA_BOUND", Outcome.SUCCESS, null);
+        auditLogService.record(requesterUUID, UserType.STUDENT, "JIRA_BOUND", Category.GROUP, Outcome.SUCCESS, null);
 
         // 7. Build response — encrypted token is never included
         BindToolResponse response = new BindToolResponse();
@@ -299,7 +300,7 @@ public class GroupService {
         try {
             validationResult = gitHubValidationService.validate(githubOrgName, githubPat, githubRepoName);
         } catch (RuntimeException e) {
-            auditLogService.record(requesterUUID, UserType.STUDENT, "GITHUB_BOUND", Outcome.FAILURE, null);
+            auditLogService.record(requesterUUID, UserType.STUDENT, "GITHUB_BOUND", Category.GROUP, Outcome.FAILURE, null);
             throw e;
         }
 
@@ -325,7 +326,7 @@ public class GroupService {
         group.setGithubPatExpiresAt(validationResult.tokenExpiresAt());
         group.setStatus(newStatus);
         ProjectGroup savedGroup = projectGroupRepository.save(group);
-        auditLogService.record(requesterUUID, UserType.STUDENT, "GITHUB_BOUND", Outcome.SUCCESS, null);
+        auditLogService.record(requesterUUID, UserType.STUDENT, "GITHUB_BOUND", Category.GROUP, Outcome.SUCCESS, null);
 
         // 7. Build response — encrypted PAT is never included
         BindToolResponse response = new BindToolResponse();
@@ -505,7 +506,7 @@ public class GroupService {
         // 6. Auto-deny all PENDING invitations for this student
         groupInvitationRepository.autoDenyAllPendingByInviteeId(student.getId());
 
-        auditLogService.record(currentUserId(), UserType.STAFF, "MEMBER_ADDED", Outcome.SUCCESS, null);
+        auditLogService.record(currentUserId(), UserType.STAFF, "MEMBER_ADDED", Category.GROUP, Outcome.SUCCESS, null);
         return toGroupDetailResponse(group, null);
     }
 
@@ -555,7 +556,7 @@ public class GroupService {
         // 5. Delete membership
         groupMembershipRepository.delete(membership);
 
-        auditLogService.record(currentUserId(), UserType.STAFF, "MEMBER_REMOVED", Outcome.SUCCESS, null);
+        auditLogService.record(currentUserId(), UserType.STAFF, "MEMBER_REMOVED", Category.GROUP, Outcome.SUCCESS, null);
         return toGroupDetailResponse(group, null);
     }
 
@@ -614,7 +615,7 @@ public class GroupService {
             groupId
         );
 
-        auditLogService.record(currentUserId(), UserType.STAFF, "GROUP_DISBANDED", Outcome.SUCCESS, null);
+        auditLogService.record(currentUserId(), UserType.STAFF, "GROUP_DISBANDED", Category.GROUP, Outcome.SUCCESS, null);
         return toGroupDetailResponse(group, null);
     }
 

--- a/backend/src/main/java/com/senior/spm/service/InvitationService.java
+++ b/backend/src/main/java/com/senior/spm/service/InvitationService.java
@@ -29,6 +29,7 @@ import com.senior.spm.repository.GroupMembershipRepository;
 import com.senior.spm.repository.ProjectGroupRepository;
 import com.senior.spm.repository.StudentRepository;
 
+import com.senior.spm.entity.AuditLog.Category;
 import com.senior.spm.entity.AuditLog.Outcome;
 import com.senior.spm.entity.AuditLog.UserType;
 
@@ -113,7 +114,7 @@ public class InvitationService {
         GroupInvitation saved = groupInvitationRepository.save(invitation);
         log.trace("[EVENT] userId={} action={} entityId={} detail={}",
                 requesterUUID, "INVITATION_SENT", saved.getId(), targetStudentId);
-        auditLogService.record(requesterUUID, UserType.STUDENT, "INVITATION_SENT", Outcome.SUCCESS, null);
+        auditLogService.record(requesterUUID, UserType.STUDENT, "INVITATION_SENT", Category.GROUP, Outcome.SUCCESS, null);
         return toSendInvitationResponse(saved);
     }
 
@@ -213,7 +214,7 @@ public class InvitationService {
             InvitationActionResponse response = toStatusOnlyResponse(groupInvitationRepository.save(invitation));
             log.trace("[EVENT] userId={} action={} entityId={} detail={}",
                     studentUUID, "INVITATION_RESPONDED", invitationId, "DECLINED");
-            auditLogService.record(studentUUID, UserType.STUDENT, "INVITATION_RESPONDED", Outcome.SUCCESS, null);
+            auditLogService.record(studentUUID, UserType.STUDENT, "INVITATION_RESPONDED", Category.GROUP, Outcome.SUCCESS, null);
             return response;
         }
 
@@ -255,7 +256,7 @@ public class InvitationService {
 
         log.trace("[EVENT] userId={} action={} entityId={} detail={}",
                 studentUUID, "INVITATION_RESPONDED", invitationId, "ACCEPTED");
-        auditLogService.record(studentUUID, UserType.STUDENT, "INVITATION_RESPONDED", Outcome.SUCCESS, null);
+        auditLogService.record(studentUUID, UserType.STUDENT, "INVITATION_RESPONDED", Category.GROUP, Outcome.SUCCESS, null);
         return groupService.getGroupDetail(group.getId());
     }
 

--- a/backend/src/main/java/com/senior/spm/service/ScrumGradingService.java
+++ b/backend/src/main/java/com/senior/spm/service/ScrumGradingService.java
@@ -36,6 +36,7 @@ import com.senior.spm.repository.ScrumGradeRepository;
 import com.senior.spm.repository.SprintRepository;
 import com.senior.spm.repository.SprintTrackingLogRepository;
 
+import com.senior.spm.entity.AuditLog.Category;
 import com.senior.spm.entity.AuditLog.Outcome;
 import com.senior.spm.entity.AuditLog.UserType;
 
@@ -107,7 +108,7 @@ public class ScrumGradingService {
         }
         log.trace("[EVENT] userId={} action={} entityId={} detail={}",
                 advisorId, "SCRUM_GRADE_SUBMITTED", groupId, sprintId);
-        auditLogService.record(advisorId, UserType.STAFF, "SCRUM_GRADE_SUBMITTED", Outcome.SUCCESS, null);
+        auditLogService.record(advisorId, UserType.STAFF, "SCRUM_GRADE_SUBMITTED", Category.GRADING, Outcome.SUCCESS, null);
         return grade;
     }
 

--- a/backend/src/test/java/com/senior/spm/repository/AuditLogRepositoryTest.java
+++ b/backend/src/test/java/com/senior/spm/repository/AuditLogRepositoryTest.java
@@ -1,0 +1,182 @@
+package com.senior.spm.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+
+import com.senior.spm.entity.AuditLog;
+import com.senior.spm.entity.AuditLog.Category;
+import com.senior.spm.entity.AuditLog.Outcome;
+import com.senior.spm.entity.AuditLog.UserType;
+import org.springframework.test.context.TestPropertySource;
+
+/**
+ * Verifies AuditLogRepository.search() — the 6-param optional-filter paginated query.
+ *
+ * Acceptance criteria (Issue #300):
+ *   - All 6 filter params accept null (no filter applied when null)
+ *   - Results paginated and sorted by occurredAt DESC
+ *   - search(null,null,null,null,null,null,PageRequest.of(0,20)) returns all rows
+ *   - search(null,null,FAILURE,null,null,null,...) returns only FAILURE rows
+ */
+@DataJpaTest
+@TestPropertySource(properties = "spring.sql.init.mode=never")
+class AuditLogRepositoryTest extends RepositoryTestBase {
+
+    @Autowired
+    AuditLogRepository repo;
+
+    private final UUID userId1 = UUID.randomUUID();
+    private final UUID userId2 = UUID.randomUUID();
+
+    /** Persists a minimal AuditLog directly via TestEntityManager. */
+    private AuditLog makeAuditLog(UUID userId, UserType userType, String action,
+                                   Category category, Outcome outcome, LocalDateTime occurredAt) {
+        AuditLog log = new AuditLog();
+        log.setUserId(userId);
+        log.setUserType(userType);
+        log.setAction(action);
+        log.setCategory(category);
+        log.setOutcome(outcome);
+        log.setOccurredAt(occurredAt);
+        return em.persistAndFlush(log);
+    }
+
+    @BeforeEach
+    void seed() {
+        // Row 1 — oldest
+        makeAuditLog(userId1, UserType.STUDENT, "STUDENT_LOGIN",
+                Category.AUTH, Outcome.SUCCESS,
+                LocalDateTime.now().minusHours(3));
+
+        // Row 2
+        makeAuditLog(userId1, UserType.STAFF, "STAFF_LOGIN",
+                Category.AUTH, Outcome.FAILURE,
+                LocalDateTime.now().minusHours(2));
+
+        // Row 3
+        makeAuditLog(userId2, UserType.STAFF, "GROUP_CREATED",
+                Category.GROUP, Outcome.SUCCESS,
+                LocalDateTime.now().minusHours(1));
+
+        // Row 4 — most recent
+        makeAuditLog(userId2, UserType.STUDENT, "ADVISOR_REQUEST_SENT",
+                Category.ADVISOR, Outcome.SUCCESS,
+                LocalDateTime.now());
+    }
+
+    // ── Acceptance Criteria (Issue #300) ─────────────────────────────────────
+
+    @Test
+    void search_noFilters_returnsAllRows() {
+        Page<AuditLog> result = repo.search(null, null, null, null, null, null,
+                PageRequest.of(0, 20));
+
+        assertThat(result.getTotalElements()).isEqualTo(4);
+    }
+
+    @Test
+    void search_filterByOutcome_returnsOnlyFailureRows() {
+        Page<AuditLog> result = repo.search(null, null, Outcome.FAILURE, null, null, null,
+                PageRequest.of(0, 20));
+
+        assertThat(result.getTotalElements()).isEqualTo(1);
+        assertThat(result.getContent()).allMatch(a -> a.getOutcome() == Outcome.FAILURE);
+    }
+
+    // ── Additional robustness tests ───────────────────────────────────────────
+
+    @Test
+    void search_filterByCategory_returnsOnlyMatchingRows() {
+        Page<AuditLog> result = repo.search(null, Category.AUTH, null, null, null, null,
+                PageRequest.of(0, 20));
+
+        assertThat(result.getTotalElements()).isEqualTo(2);
+        assertThat(result.getContent()).allMatch(a -> a.getCategory() == Category.AUTH);
+    }
+
+    @Test
+    void search_filterByUserType_returnsOnlyMatchingRows() {
+        Page<AuditLog> result = repo.search(UserType.STAFF, null, null, null, null, null,
+                PageRequest.of(0, 20));
+
+        assertThat(result.getTotalElements()).isEqualTo(2);
+        assertThat(result.getContent()).allMatch(a -> a.getUserType() == UserType.STAFF);
+    }
+
+    @Test
+    void search_filterByUserId_returnsOnlyMatchingRows() {
+        Page<AuditLog> result = repo.search(null, null, null, userId1, null, null,
+                PageRequest.of(0, 20));
+
+        assertThat(result.getTotalElements()).isEqualTo(2);
+        assertThat(result.getContent()).allMatch(a -> userId1.equals(a.getUserId()));
+    }
+
+    @Test
+    void search_filterByDateRange_returnsOnlyInRangeRows() {
+        LocalDateTime from = LocalDateTime.now().minusHours(2).minusMinutes(30);
+        LocalDateTime to   = LocalDateTime.now().minusMinutes(30);
+
+        Page<AuditLog> result = repo.search(null, null, null, null, from, to,
+                PageRequest.of(0, 20));
+
+        // Only rows 2 (minus 2h) and 3 (minus 1h) fall in this range
+        assertThat(result.getTotalElements()).isEqualTo(2);
+        assertThat(result.getContent())
+                .allMatch(a -> !a.getOccurredAt().isBefore(from) && !a.getOccurredAt().isAfter(to));
+    }
+
+    @Test
+    void search_resultsOrderedByOccurredAtDesc() {
+        Page<AuditLog> result = repo.search(null, null, null, null, null, null,
+                PageRequest.of(0, 20));
+
+        var items = result.getContent();
+        for (int i = 0; i < items.size() - 1; i++) {
+            assertThat(items.get(i).getOccurredAt())
+                    .isAfterOrEqualTo(items.get(i + 1).getOccurredAt());
+        }
+    }
+
+    @Test
+    void search_pagination_respectsPageSizeAndOffset() {
+        // Page 0 with size 2 → first 2 (most recent)
+        Page<AuditLog> page0 = repo.search(null, null, null, null, null, null,
+                PageRequest.of(0, 2));
+        // Page 1 with size 2 → remaining 2
+        Page<AuditLog> page1 = repo.search(null, null, null, null, null, null,
+                PageRequest.of(1, 2));
+
+        assertThat(page0.getContent()).hasSize(2);
+        assertThat(page1.getContent()).hasSize(2);
+        assertThat(page0.getTotalPages()).isEqualTo(2);
+        assertThat(page0.getTotalElements()).isEqualTo(4);
+
+        // No overlap between pages
+        var page0Ids = page0.getContent().stream().map(AuditLog::getId).toList();
+        var page1Ids = page1.getContent().stream().map(AuditLog::getId).toList();
+        assertThat(page0Ids).doesNotContainAnyElementsOf(page1Ids);
+    }
+
+    @Test
+    void search_emptyTable_returnsEmptyPage() {
+        // Delete all seeded rows
+        repo.deleteAll();
+        em.flush();
+
+        Page<AuditLog> result = repo.search(null, null, null, null, null, null,
+                PageRequest.of(0, 20));
+
+        assertThat(result.getTotalElements()).isEqualTo(0);
+        assertThat(result.getContent()).isEmpty();
+    }
+}

--- a/backend/src/test/java/com/senior/spm/service/AdvisorServiceBrowseRequestTest.java
+++ b/backend/src/test/java/com/senior/spm/service/AdvisorServiceBrowseRequestTest.java
@@ -786,6 +786,7 @@ class AdvisorServiceBrowseRequestTest {
                     eq(coordinatorId),
                     eq(com.senior.spm.entity.AuditLog.UserType.STAFF),
                     eq("ADVISOR_ASSIGNED"),
+                    eq(com.senior.spm.entity.AuditLog.Category.ADVISOR),
                     eq(com.senior.spm.entity.AuditLog.Outcome.SUCCESS),
                     isNull());
         }
@@ -848,6 +849,7 @@ class AdvisorServiceBrowseRequestTest {
                     eq(coordinatorId),
                     eq(com.senior.spm.entity.AuditLog.UserType.STAFF),
                     eq("ADVISOR_REMOVED"),
+                    eq(com.senior.spm.entity.AuditLog.Category.ADVISOR),
                     eq(com.senior.spm.entity.AuditLog.Outcome.SUCCESS),
                     isNull());
         }

--- a/backend/src/test/java/com/senior/spm/service/AuditLogServiceTest.java
+++ b/backend/src/test/java/com/senior/spm/service/AuditLogServiceTest.java
@@ -24,6 +24,7 @@ import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.transaction.support.TransactionTemplate;
 
 import com.senior.spm.entity.AuditLog;
+import com.senior.spm.entity.AuditLog.Category;
 import com.senior.spm.entity.AuditLog.Outcome;
 import com.senior.spm.entity.AuditLog.UserType;
 import com.senior.spm.repository.AuditLogRepository;
@@ -50,12 +51,13 @@ class AuditLogServiceTest {
             ArgumentCaptor<AuditLog> captor = forClass(AuditLog.class);
             when(auditLogRepository.save(captor.capture())).thenAnswer(i -> i.getArgument(0));
 
-            auditLogService.record(userId, UserType.STAFF, "STAFF_LOGIN", Outcome.SUCCESS, "10.0.0.1");
+            auditLogService.record(userId, UserType.STAFF, "STAFF_LOGIN", Category.AUTH, Outcome.SUCCESS, "10.0.0.1");
 
             AuditLog saved = captor.getValue();
             assertThat(saved.getUserId()).isEqualTo(userId);
             assertThat(saved.getUserType()).isEqualTo(UserType.STAFF);
             assertThat(saved.getAction()).isEqualTo("STAFF_LOGIN");
+            assertThat(saved.getCategory()).isEqualTo(Category.AUTH);
             assertThat(saved.getOutcome()).isEqualTo(Outcome.SUCCESS);
             assertThat(saved.getIpAddress()).isEqualTo("10.0.0.1");
             assertThat(saved.getOccurredAt()).isNotNull();
@@ -66,7 +68,7 @@ class AuditLogServiceTest {
             ArgumentCaptor<AuditLog> captor = forClass(AuditLog.class);
             when(auditLogRepository.save(captor.capture())).thenAnswer(i -> i.getArgument(0));
 
-            auditLogService.record(null, UserType.STAFF, "STAFF_LOGIN", Outcome.FAILURE, null);
+            auditLogService.record(null, UserType.STAFF, "STAFF_LOGIN", Category.AUTH, Outcome.FAILURE, null);
 
             AuditLog saved = captor.getValue();
             assertThat(saved.getUserId()).isNull();
@@ -80,7 +82,7 @@ class AuditLogServiceTest {
                 .when(auditLogRepository).save(org.mockito.ArgumentMatchers.any());
 
             assertThatCode(() ->
-                auditLogService.record(UUID.randomUUID(), UserType.STAFF, "STAFF_LOGIN", Outcome.SUCCESS, null)
+                auditLogService.record(UUID.randomUUID(), UserType.STAFF, "STAFF_LOGIN", Category.AUTH, Outcome.SUCCESS, null)
             ).doesNotThrowAnyException();
         }
     }
@@ -113,7 +115,7 @@ class AuditLogServiceTest {
             // but the REQUIRES_NEW inner transaction must have already committed the audit row.
             assertThatThrownBy(() ->
                 outerTx.execute(status -> {
-                    auditLogService.record(userId, UserType.STAFF, "STAFF_LOGIN", Outcome.SUCCESS, null);
+                    auditLogService.record(userId, UserType.STAFF, "STAFF_LOGIN", Category.AUTH, Outcome.SUCCESS, null);
                     throw new RuntimeException("simulated business failure");
                 })
             ).isInstanceOf(RuntimeException.class);
@@ -122,6 +124,7 @@ class AuditLogServiceTest {
             AuditLog persisted = auditLogRepository.findAll().get(0);
             assertThat(persisted.getUserId()).isEqualTo(userId);
             assertThat(persisted.getAction()).isEqualTo("STAFF_LOGIN");
+            assertThat(persisted.getCategory()).isEqualTo(Category.AUTH);
             assertThat(persisted.getOutcome()).isEqualTo(Outcome.SUCCESS);
         }
     }

--- a/backend/src/test/java/com/senior/spm/service/GroupServiceTest.java
+++ b/backend/src/test/java/com/senior/spm/service/GroupServiceTest.java
@@ -544,6 +544,7 @@ class GroupServiceTest {
                     eq(coordinatorId),
                     eq(AuditLog.UserType.STAFF),
                     eq("MEMBER_ADDED"),
+                    eq(AuditLog.Category.GROUP),
                     eq(AuditLog.Outcome.SUCCESS),
                     isNull());
         }
@@ -672,6 +673,7 @@ class GroupServiceTest {
                     eq(coordinatorId),
                     eq(AuditLog.UserType.STAFF),
                     eq("MEMBER_REMOVED"),
+                    eq(AuditLog.Category.GROUP),
                     eq(AuditLog.Outcome.SUCCESS),
                     isNull());
         }
@@ -789,6 +791,7 @@ class GroupServiceTest {
                     eq(coordinatorId),
                     eq(AuditLog.UserType.STAFF),
                     eq("GROUP_DISBANDED"),
+                    eq(AuditLog.Category.GROUP),
                     eq(AuditLog.Outcome.SUCCESS),
                     isNull());
         }


### PR DESCRIPTION
## Description
This PR resolves two interconnected backend issues related to the Audit Log system (BACK-1 and BACK-2). It introduces a category-based classification for all audit events and provides a flexible, paginated search capability at the repository level.

Resolves #299
Resolves #300

## Implemented Changes

### 1. Audit Log Classification (#299)
- Introduced the `Category` enum (`AUTH`, `GROUP`, `ADVISOR`, `GRADING`) to the `AuditLog` entity.
- Added the `category` column to the database schema with a dedicated index (`idx_al_category`) for query performance.
- Refactored `AuditLogService.record(...)` method signature to accept the `Category` parameter.
- Updated **all 22 production call sites** across `AuthService`, `GroupService`, `InvitationService`, `AdvisorService`, and `ScrumGradingService` to pass the appropriate category.

### 2. Flexible Search Query (#300)
- Enhanced `AuditLogRepository` with a custom JPQL `@Query` for paginated searching.
- Supported 6 optional filters (`userType`, `category`, `outcome`, `userId`, `from`, `to`), allowing all of them to accept `null` to bypass filtering.
- Ensured search results are consistently ordered by `occurredAt DESC`.

## Verification & Testing
- **Unit & Integration Tests:** 
  - Fixed argument mismatch issues in Mockito `verify` calls within existing test suites (`GroupServiceTest`, `AdvisorServiceBrowseRequestTest`, etc.).
  - Added a comprehensive `@DataJpaTest` suite (`AuditLogRepositoryTest`) covering 9 distinct scenarios for the new search query (including empty results, date ranges, and pagination checks).
  - All 193 tests passed successfully.
- **Manual Verification:** Deployed the backend locally with `ddl-auto=update` and confirmed via MySQL that the new column is successfully created and correctly populated during real application flows (e.g., `STAFF_LOGIN` -> `AUTH`).

## Reviewer Checklist
- [x] Does the implementation satisfy both #299 and #300 requirements?
- [x] Are the new `@Query` parameters safe and returning expected pages?
- [x] Are the tests robust enough for edge cases (null inputs, empty tables)?
