### PR TITLE
feat(audit-log): add query() service method and response DTOs (BACK-3)

### DIFF
--- a/backend/src/main/java/com/senior/spm/controller/response/AuditLogResponse.java
+++ b/backend/src/main/java/com/senior/spm/controller/response/AuditLogResponse.java
@@ -1,0 +1,8 @@
+package com.senior.spm.controller.response;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+public record AuditLogResponse(UUID id, UUID userId, String userType,
+        String category, String action, String outcome,
+        String ipAddress, LocalDateTime occurredAt) {}

--- a/backend/src/main/java/com/senior/spm/controller/response/PagedAuditLogResponse.java
+++ b/backend/src/main/java/com/senior/spm/controller/response/PagedAuditLogResponse.java
@@ -1,0 +1,6 @@
+package com.senior.spm.controller.response;
+
+import java.util.List;
+
+public record PagedAuditLogResponse(List<AuditLogResponse> content,
+        int page, int size, long totalElements, int totalPages) {}

--- a/backend/src/main/java/com/senior/spm/service/AuditLogService.java
+++ b/backend/src/main/java/com/senior/spm/service/AuditLogService.java
@@ -3,10 +3,13 @@ package com.senior.spm.service;
 import java.time.LocalDateTime;
 import java.util.UUID;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.senior.spm.controller.response.AuditLogResponse;
 import com.senior.spm.entity.AuditLog;
 import com.senior.spm.entity.AuditLog.Category;
 import com.senior.spm.entity.AuditLog.Outcome;
@@ -44,5 +47,22 @@ public class AuditLogService {
         } catch (Exception e) {
             log.error("Audit write failed — action={} userId={} outcome={}", action, userId, outcome, e);
         }
+    }
+
+    @Transactional(readOnly = true)
+    public Page<AuditLogResponse> query(
+            UserType userType, Category category, Outcome outcome, UUID userId,
+            LocalDateTime from, LocalDateTime to, Pageable pageable) {
+        return auditLogRepository
+                .search(userType, category, outcome, userId, from, to, pageable)
+                .map(entry -> new AuditLogResponse(
+                        entry.getId(),
+                        entry.getUserId(),
+                        entry.getUserType() != null ? entry.getUserType().name() : null,
+                        entry.getCategory().name(),
+                        entry.getAction(),
+                        entry.getOutcome().name(),
+                        entry.getIpAddress(),
+                        entry.getOccurredAt()));
     }
 }

--- a/backend/src/test/java/com/senior/spm/service/AuditLogServiceTest.java
+++ b/backend/src/test/java/com/senior/spm/service/AuditLogServiceTest.java
@@ -4,9 +4,12 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentCaptor.forClass;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 import static org.mockito.Mockito.doThrow;
 
+import java.time.LocalDateTime;
+import java.util.List;
 import java.util.UUID;
 
 import org.junit.jupiter.api.Nested;
@@ -18,11 +21,15 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.transaction.support.TransactionTemplate;
 
+import com.senior.spm.controller.response.AuditLogResponse;
 import com.senior.spm.entity.AuditLog;
 import com.senior.spm.entity.AuditLog.Category;
 import com.senior.spm.entity.AuditLog.Outcome;
@@ -79,11 +86,80 @@ class AuditLogServiceTest {
         @Test
         void record_doesNotPropagateException_whenAuditWriteFails() {
             doThrow(new RuntimeException("DB unavailable"))
-                .when(auditLogRepository).save(org.mockito.ArgumentMatchers.any());
+                .when(auditLogRepository).save(any());
 
             assertThatCode(() ->
                 auditLogService.record(UUID.randomUUID(), UserType.STAFF, "STAFF_LOGIN", Category.AUTH, Outcome.SUCCESS, null)
             ).doesNotThrowAnyException();
+        }
+
+        // ---------------------------------------------------------------------
+        // Unit tests — verify query() maps entity → DTO correctly
+        // ---------------------------------------------------------------------
+
+        @Test
+        void query_mapsEnumsToNames_andCopiesScalarFields() {
+            UUID id = UUID.randomUUID();
+            UUID userId = UUID.randomUUID();
+            LocalDateTime occurredAt = LocalDateTime.now();
+
+            AuditLog row = new AuditLog();
+            row.setId(id);
+            row.setUserId(userId);
+            row.setUserType(UserType.STAFF);
+            row.setCategory(Category.AUTH);
+            row.setAction("STAFF_LOGIN");
+            row.setOutcome(Outcome.FAILURE);
+            row.setIpAddress("10.0.0.1");
+            row.setOccurredAt(occurredAt);
+
+            when(auditLogRepository.search(any(), any(), any(), any(), any(), any(), any()))
+                    .thenReturn(new PageImpl<>(List.of(row)));
+
+            Page<AuditLogResponse> result = auditLogService.query(
+                    null, null, null, null, null, null, PageRequest.of(0, 20));
+
+            assertThat(result.getTotalElements()).isEqualTo(1);
+            AuditLogResponse dto = result.getContent().get(0);
+            assertThat(dto.id()).isEqualTo(id);
+            assertThat(dto.userId()).isEqualTo(userId);
+            assertThat(dto.userType()).isEqualTo("STAFF");
+            assertThat(dto.category()).isEqualTo("AUTH");
+            assertThat(dto.action()).isEqualTo("STAFF_LOGIN");
+            assertThat(dto.outcome()).isEqualTo("FAILURE");
+            assertThat(dto.ipAddress()).isEqualTo("10.0.0.1");
+            assertThat(dto.occurredAt()).isEqualTo(occurredAt);
+        }
+
+        @Test
+        void query_mapsNullUserType_toNullString() {
+            AuditLog row = new AuditLog();
+            row.setId(UUID.randomUUID());
+            row.setUserType(null);
+            row.setCategory(Category.AUTH);
+            row.setAction("STAFF_LOGIN");
+            row.setOutcome(Outcome.FAILURE);
+            row.setOccurredAt(LocalDateTime.now());
+
+            when(auditLogRepository.search(any(), any(), any(), any(), any(), any(), any()))
+                    .thenReturn(new PageImpl<>(List.of(row)));
+
+            Page<AuditLogResponse> result = auditLogService.query(
+                    null, null, null, null, null, null, PageRequest.of(0, 20));
+
+            assertThat(result.getContent().get(0).userType()).isNull();
+        }
+
+        @Test
+        void query_returnsEmptyPage_whenRepositoryReturnsEmpty() {
+            when(auditLogRepository.search(any(), any(), any(), any(), any(), any(), any()))
+                    .thenReturn(new PageImpl<>(List.of()));
+
+            Page<AuditLogResponse> result = auditLogService.query(
+                    null, null, null, null, null, null, PageRequest.of(0, 20));
+
+            assertThat(result.getTotalElements()).isZero();
+            assertThat(result.getContent()).isEmpty();
         }
     }
 


### PR DESCRIPTION
## Summary
Implements **BACK-3**: read-side service method and response DTOs for the
admin audit-log viewer. Sits between BACK-2 (`AuditLogRepository.search`,
#300) and the upcoming controller ticket.

- `AuditLogResponse` — flat record DTO. Enums (`userType`, `category`,
  `outcome`) are exposed as `String` and mapped via `.name()`, satisfying
  the AC that values serialize as `"STAFF"` / `"FAILURE"` rather than
  ordinals — independent of Jackson global config.
- `PagedAuditLogResponse` — record wrapper (`content`, `page`, `size`,
  `totalElements`, `totalPages`) for the controller to return.
- `AuditLogService.query(...)` — `@Transactional(readOnly = true)`,
  delegates to the already-validated `search()` and maps `Page<AuditLog>`
  → `Page<AuditLogResponse>` lazily via `Page.map()`. `record()` is
  unchanged and keeps `REQUIRES_NEW`.

## Acceptance criteria
- [x] `query()` with all-null filters returns all rows (rides on
      `search()` which is covered by `AuditLogRepositoryTest`)
- [x] Enum values serialized as strings (`"STAFF"`, `"FAILURE"`) — forced
      via `.name()` in the mapper
- [x] `@Transactional(readOnly = true)` on `query()` — `REQUIRES_NEW`
      stays on `record()` only

## Reuse
- `AuditLogRepository.search(...)` — used as-is, no changes.
- `AuditLog` entity — no changes.
- DTO style follows the existing record pattern (`LlmConfigResponse`).

## Risk
Additive change. No existing caller invokes `query()` (grepped repo), so
this PR cannot break existing behavior. `record()` and its
`REQUIRES_NEW` integration test path are untouched.

## Test plan
- [x] `./mvnw test -Dtest='AuditLogServiceTest,AuditLogRepositoryTest'`
      → **16 tests, 0 failures, BUILD SUCCESS**
- [x] Existing `record()` unit + `RequiresNewIntegrationTest` still pass
- [x] **New** unit tests for `query()` entity → DTO mapping
      (the repository tests don't exercise the mapper):
  - `query_mapsEnumsToNames_andCopiesScalarFields` — full happy-path
    field copy and verifies enums become `"STAFF"` / `"AUTH"` /
    `"FAILURE"` (not ordinals)
  - `query_mapsNullUserType_toNullString` — guards the only nullable
    enum on the entity
  - `query_returnsEmptyPage_whenRepositoryReturnsEmpty` — verifies
    `Page.map()` preserves an empty page
- [ ] Controller ticket (next) will add an end-to-end test through HTTP

## Review follow-ups addressed
- [x] **Test coverage gap on `query()` mapping** — added the three unit
      tests above. Mapping bugs (wrong field order, accidental ordinal
      serialization, missing null guard on `userType`) would now be
      caught by CI rather than slipping through to the controller PR.

## Depends on
- #300 (BACK-2 — `AuditLogRepository.search`)

## Out of scope
- REST controller wiring (separate ticket)
- Frontend wiring (FRONT-1 already merged in #310)
- Controller-layer concerns flagged in review (size cap on `Pageable`,
  admin-only auth around `ipAddress` exposure) — to be addressed in the
  controller PR
