### PR TITLE
Feature/issue 302 audit log security config

### DIFF
--- a/backend/src/main/java/com/senior/spm/config/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/senior/spm/config/GlobalExceptionHandler.java
@@ -11,6 +11,7 @@ import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 
 import com.senior.spm.controller.response.ErrorMessage;
 import com.senior.spm.exception.AdvisorAtCapacityException;
@@ -41,6 +42,12 @@ public class GlobalExceptionHandler {
                 .map(e -> e.getField() + ": " + e.getDefaultMessage())
                 .collect(Collectors.joining(", "));
         return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(new ErrorMessage(message));
+    }
+
+    @ExceptionHandler(MethodArgumentTypeMismatchException.class)
+    public ResponseEntity<ErrorMessage> handleTypeMismatch(MethodArgumentTypeMismatchException ex) {
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                .body(new ErrorMessage("Invalid value for parameter '" + ex.getName() + "': " + ex.getValue()));
     }
 
     @ExceptionHandler(AccessDeniedException.class)

--- a/backend/src/main/java/com/senior/spm/config/SecurityConfig.java
+++ b/backend/src/main/java/com/senior/spm/config/SecurityConfig.java
@@ -65,6 +65,7 @@ public class SecurityConfig {
                                 .requestMatchers("/api/submissions/**").hasAnyRole("STUDENT", "PROFESSOR")
                                 .requestMatchers("/api/auth/**").permitAll()
                                 .requestMatchers("/v3/api-docs/**", "/swagger-ui/**", "/swagger-ui.html").permitAll()
+                                .requestMatchers(HttpMethod.GET, "/api/admin/audit-logs").hasAnyRole("COORDINATOR", "ADMIN")
                                 .requestMatchers("/api/admin/**").hasRole("ADMIN")
                                 .anyRequest().authenticated())
                 .exceptionHandling(

--- a/backend/src/main/java/com/senior/spm/controller/AdminController.java
+++ b/backend/src/main/java/com/senior/spm/controller/AdminController.java
@@ -1,7 +1,15 @@
 package com.senior.spm.controller;
 
+import java.time.LocalDateTime;
 import java.util.Map;
+import java.util.UUID;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -9,13 +17,18 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.senior.spm.controller.request.LlmConfigRequest;
 import com.senior.spm.controller.request.RegisterProfessorRequest;
+import com.senior.spm.controller.response.AuditLogResponse;
 import com.senior.spm.controller.response.ErrorMessage;
 import com.senior.spm.controller.response.LlmConfigResponse;
+import com.senior.spm.controller.response.PagedAuditLogResponse;
+import com.senior.spm.entity.AuditLog;
 import com.senior.spm.exception.AlreadyExistsException;
+import com.senior.spm.service.AuditLogService;
 import com.senior.spm.service.LlmConfigService;
 import com.senior.spm.service.StaffUserService;
 
@@ -27,11 +40,14 @@ public class AdminController {
 
     private final StaffUserService staffUserService;
     private final LlmConfigService llmConfigService;
+    private final AuditLogService auditLogService;
 
     public AdminController(StaffUserService staffUserService,
-                           LlmConfigService llmConfigService) {
+                           LlmConfigService llmConfigService,
+                           AuditLogService auditLogService) {
         this.staffUserService = staffUserService;
         this.llmConfigService = llmConfigService;
+        this.auditLogService = auditLogService;
     }
 
     @PostMapping("/register-professor")
@@ -56,5 +72,30 @@ public class AdminController {
     public ResponseEntity<Map<String, String>> updateLlmConfig(@Valid @RequestBody LlmConfigRequest request) {
         llmConfigService.updateLlmKey(request.getApiKey());
         return ResponseEntity.ok(Map.of("message", "LLM API key updated successfully"));
+    }
+
+    @GetMapping("/audit-logs")
+    public ResponseEntity<PagedAuditLogResponse> getAuditLogs(
+            @RequestParam(required = false) AuditLog.UserType userType,
+            @RequestParam(required = false) AuditLog.Category category,
+            @RequestParam(required = false) AuditLog.Outcome outcome,
+            @RequestParam(required = false) UUID userId,
+            @RequestParam(required = false)
+                @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime from,
+            @RequestParam(required = false)
+                @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime to,
+            @PageableDefault(size = 20, sort = "occurredAt", direction = Sort.Direction.DESC)
+                Pageable pageable) {
+
+        if (pageable.getPageSize() > 100) {
+            pageable = PageRequest.of(pageable.getPageNumber(), 100, pageable.getSort());
+        }
+
+        Page<AuditLogResponse> page = auditLogService.query(
+                userType, category, outcome, userId, from, to, pageable);
+
+        return ResponseEntity.ok(new PagedAuditLogResponse(
+                page.getContent(), page.getNumber(), page.getSize(),
+                page.getTotalElements(), page.getTotalPages()));
     }
 }

--- a/backend/src/test/java/com/senior/spm/controller/AuditLogControllerTest.java
+++ b/backend/src/test/java/com/senior/spm/controller/AuditLogControllerTest.java
@@ -1,0 +1,205 @@
+package com.senior.spm.controller;
+
+import static org.hamcrest.Matchers.everyItem;
+import static org.hamcrest.Matchers.is;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+
+import com.senior.spm.entity.AuditLog;
+import com.senior.spm.entity.AuditLog.Category;
+import com.senior.spm.entity.AuditLog.Outcome;
+import com.senior.spm.entity.AuditLog.UserType;
+import com.senior.spm.entity.StaffUser;
+import com.senior.spm.entity.StaffUser.Role;
+import com.senior.spm.entity.Student;
+import com.senior.spm.repository.AuditLogRepository;
+import com.senior.spm.repository.StaffUserRepository;
+import com.senior.spm.repository.StudentRepository;
+import com.senior.spm.service.JWTService;
+
+/**
+ * Integration tests for GET /api/admin/audit-logs (issue #302).
+ *
+ * Covers:
+ *   – Auth matrix: coordinator → 200, admin → 200, professor → 403, student → 403, no token → 401
+ *   – size=500 → capped to 100 in response
+ *   – ?outcome=FAILURE filter returns only FAILURE rows
+ *   – ?userId=not-a-uuid → 400
+ */
+@SpringBootTest
+@AutoConfigureMockMvc
+@TestPropertySource(locations = "classpath:test.properties")
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+class AuditLogControllerTest {
+
+    @Autowired MockMvc mockMvc;
+    @Autowired JWTService jwtService;
+
+    @Autowired AuditLogRepository auditLogRepository;
+    @Autowired StaffUserRepository staffUserRepository;
+    @Autowired StudentRepository studentRepository;
+
+    private String coordinatorToken;
+    private String adminToken;
+    private String professorToken;
+    private String studentToken;
+
+    @BeforeEach
+    void setUp() {
+        cleanAll();
+
+        StaffUser coordinator = staffUserRepository.save(makeStaff("coord@al-test.com", Role.Coordinator));
+        StaffUser admin       = staffUserRepository.save(makeStaff("admin@al-test.com", Role.Admin));
+        StaffUser professor   = staffUserRepository.save(makeStaff("prof@al-test.com",  Role.Professor));
+        Student   student     = studentRepository.save(makeStudent("44400000001"));
+
+        coordinatorToken = jwtService.issueToken(coordinator);
+        adminToken       = jwtService.issueToken(admin);
+        professorToken   = jwtService.issueToken(professor);
+        studentToken     = jwtService.issueToken(student);
+    }
+
+    @AfterEach
+    void tearDown() {
+        cleanAll();
+    }
+
+    // ═══════════════════════════════════════════════════════════════════
+    //  Auth matrix
+    // ═══════════════════════════════════════════════════════════════════
+
+    @Test
+    @DisplayName("Coordinator GET /audit-logs → 200")
+    void coordinator_returns200() throws Exception {
+        mockMvc.perform(get("/api/admin/audit-logs")
+                .header("Authorization", "Bearer " + coordinatorToken))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    @DisplayName("Admin GET /audit-logs → 200")
+    void admin_returns200() throws Exception {
+        mockMvc.perform(get("/api/admin/audit-logs")
+                .header("Authorization", "Bearer " + adminToken))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    @DisplayName("Professor GET /audit-logs → 403")
+    void professor_returns403() throws Exception {
+        mockMvc.perform(get("/api/admin/audit-logs")
+                .header("Authorization", "Bearer " + professorToken))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @DisplayName("Student GET /audit-logs → 403")
+    void student_returns403() throws Exception {
+        mockMvc.perform(get("/api/admin/audit-logs")
+                .header("Authorization", "Bearer " + studentToken))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @DisplayName("No token GET /audit-logs → 401")
+    void noToken_returns401() throws Exception {
+        mockMvc.perform(get("/api/admin/audit-logs"))
+                .andExpect(status().isUnauthorized());
+    }
+
+    // ═══════════════════════════════════════════════════════════════════
+    //  Page size cap
+    // ═══════════════════════════════════════════════════════════════════
+
+    @Test
+    @DisplayName("size=500 in request → size=100 in response (cap enforced)")
+    void pageSizeCap_500becomes100() throws Exception {
+        mockMvc.perform(get("/api/admin/audit-logs")
+                .header("Authorization", "Bearer " + coordinatorToken)
+                .param("size", "500"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.size").value(100));
+    }
+
+    // ═══════════════════════════════════════════════════════════════════
+    //  Outcome filter
+    // ═══════════════════════════════════════════════════════════════════
+
+    @Test
+    @DisplayName("?outcome=FAILURE returns only FAILURE rows")
+    void outcomeFilter_returnsOnlyFailureRows() throws Exception {
+        auditLogRepository.save(makeAuditLog("STAFF_LOGIN", Category.AUTH, Outcome.SUCCESS));
+        auditLogRepository.save(makeAuditLog("STAFF_LOGIN", Category.AUTH, Outcome.FAILURE));
+        auditLogRepository.save(makeAuditLog("STAFF_LOGIN", Category.AUTH, Outcome.FAILURE));
+
+        mockMvc.perform(get("/api/admin/audit-logs")
+                .header("Authorization", "Bearer " + coordinatorToken)
+                .param("outcome", "FAILURE"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.totalElements").value(2))
+                .andExpect(jsonPath("$.content[*].outcome", everyItem(is("FAILURE"))));
+    }
+
+    // ═══════════════════════════════════════════════════════════════════
+    //  Invalid UUID → 400
+    // ═══════════════════════════════════════════════════════════════════
+
+    @Test
+    @DisplayName("?userId=not-a-uuid → 400")
+    void invalidUuid_returns400() throws Exception {
+        mockMvc.perform(get("/api/admin/audit-logs")
+                .header("Authorization", "Bearer " + coordinatorToken)
+                .param("userId", "not-a-uuid"))
+                .andExpect(status().isBadRequest());
+    }
+
+    // ═══════════════════════════════════════════════════════════════════
+    //  Helpers
+    // ═══════════════════════════════════════════════════════════════════
+
+    private void cleanAll() {
+        auditLogRepository.deleteAll();
+        studentRepository.deleteAll();
+        staffUserRepository.deleteAll();
+    }
+
+    private StaffUser makeStaff(String mail, Role role) {
+        StaffUser u = new StaffUser();
+        u.setMail(mail);
+        u.setPasswordHash("$2a$10$dXJ3SW6G7P50lGmMkkmwe.20cQQubK3.HZWzG3YB1tlRy.fqvM/BG");
+        u.setRole(role);
+        u.setAdvisorCapacity(5);
+        return u;
+    }
+
+    private Student makeStudent(String studentId) {
+        Student s = new Student();
+        s.setStudentId(studentId);
+        return s;
+    }
+
+    private AuditLog makeAuditLog(String action, Category category, Outcome outcome) {
+        AuditLog log = new AuditLog();
+        log.setUserType(UserType.STAFF);
+        log.setAction(action);
+        log.setCategory(category);
+        log.setOutcome(outcome);
+        log.setOccurredAt(LocalDateTime.now(ZoneId.of("UTC")));
+        return log;
+    }
+}


### PR DESCRIPTION
## Summary

Implements **BACK-4** (issue #302): the read-side HTTP endpoint for the admin audit log viewer, plus the SecurityConfig rule that opens it to Coordinator role in addition to Admin.

Resolves #302
Depends on #301 (merged)

---

## Changes

### `AdminController.java`
- Injected `AuditLogService` via constructor
- Added `GET /api/admin/audit-logs` endpoint with 6 optional filter params (`userType`, `category`, `outcome`, `userId`, `from`, `to`)
- `@PageableDefault(size=20, sort="occurredAt", direction=DESC)` — sensible defaults, no caller configuration required
- Page size hard-capped at 100: any `size` value above 100 is silently clamped via `PageRequest.of(...)` before the query
- Delegates entirely to `AuditLogService.query()` (from #301), wraps result in `PagedAuditLogResponse`

### `SecurityConfig.java`
- Added a specific rule **before** the existing `/api/admin/**` catch-all:
  ```java
  .requestMatchers(HttpMethod.GET, "/api/admin/audit-logs").hasAnyRole("COORDINATOR", "ADMIN")
  ```
- Spring Security evaluates rules top-to-bottom — the specific path matches first, so Coordinators gain access to this endpoint only. All other `/api/admin/**` endpoints remain ADMIN-only via the catch-all.

### `GlobalExceptionHandler.java`
- Added `MethodArgumentTypeMismatchException` handler returning 400
- Required to satisfy the acceptance criterion `?userId=not-a-uuid → 400, not 500` — Spring does not map this exception to 400 by default

### `AuditLogControllerTest.java` (new)
- `@SpringBootTest` + `@AutoConfigureMockMvc` + real JWT tokens via `jwtService.issueToken()`
- 8 integration tests covering all 6 acceptance criteria

---

## Acceptance Criteria

| Criterion | Test | Result |
|-----------|------|--------|
| 200 for COORDINATOR | `coordinator_returns200` | ✅ |
| 403 for PROFESSOR | `professor_returns403` | ✅ |
| 403 for STUDENT | `student_returns403` | ✅ |
| 401 for missing token | `noToken_returns401` | ✅ |
| `size=500` → `size=100` in response | `pageSizeCap_500becomes100` | ✅ |
| `?outcome=FAILURE` returns only FAILURE rows | `outcomeFilter_returnsOnlyFailureRows` | ✅ |
| `?userId=not-a-uuid` → 400 | `invalidUuid_returns400` | ✅ |

---

## Test Results

```
Tests run: 761, Failures: 0, Errors: 0, Skipped: 0 — BUILD SUCCESS
```

---

## Notes

- The `MethodArgumentTypeMismatchException` handler in `GlobalExceptionHandler` is a general-purpose fix — it will also return 400 for any other endpoint that receives a malformed UUID or enum value as a `@RequestParam`, which is the correct behavior project-wide.
- Admin role access to `GET /api/admin/audit-logs` is preserved — the new specific rule includes `hasAnyRole("COORDINATOR", "ADMIN")`, so existing Admin access is unchanged.
- The `?userId` filter accepts a valid UUID and passes it through to `AuditLogRepository.search()`. An invalid UUID string is rejected at the controller binding layer before any service or repository call is made.
