### PR TITLE
test(audit-log): add Postman collection for GET /api/admin/audit-logs (#306)

### DIFF
--- a/backend/src/main/java/com/senior/spm/config/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/senior/spm/config/GlobalExceptionHandler.java
@@ -11,6 +11,7 @@ import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 
 import com.senior.spm.controller.response.ErrorMessage;
 import com.senior.spm.exception.AdvisorAtCapacityException;
@@ -41,6 +42,12 @@ public class GlobalExceptionHandler {
                 .map(e -> e.getField() + ": " + e.getDefaultMessage())
                 .collect(Collectors.joining(", "));
         return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(new ErrorMessage(message));
+    }
+
+    @ExceptionHandler(MethodArgumentTypeMismatchException.class)
+    public ResponseEntity<ErrorMessage> handleTypeMismatch(MethodArgumentTypeMismatchException ex) {
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                .body(new ErrorMessage("Invalid value for parameter '" + ex.getName() + "': " + ex.getValue()));
     }
 
     @ExceptionHandler(AccessDeniedException.class)

--- a/backend/src/main/java/com/senior/spm/config/SecurityConfig.java
+++ b/backend/src/main/java/com/senior/spm/config/SecurityConfig.java
@@ -65,6 +65,7 @@ public class SecurityConfig {
                                 .requestMatchers("/api/submissions/**").hasAnyRole("STUDENT", "PROFESSOR")
                                 .requestMatchers("/api/auth/**").permitAll()
                                 .requestMatchers("/v3/api-docs/**", "/swagger-ui/**", "/swagger-ui.html").permitAll()
+                                .requestMatchers(HttpMethod.GET, "/api/admin/audit-logs").hasAnyRole("COORDINATOR", "ADMIN")
                                 .requestMatchers("/api/admin/**").hasRole("ADMIN")
                                 .anyRequest().authenticated())
                 .exceptionHandling(

--- a/backend/src/main/java/com/senior/spm/controller/AdminController.java
+++ b/backend/src/main/java/com/senior/spm/controller/AdminController.java
@@ -1,7 +1,15 @@
 package com.senior.spm.controller;
 
+import java.time.LocalDateTime;
 import java.util.Map;
+import java.util.UUID;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -9,13 +17,18 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.senior.spm.controller.request.LlmConfigRequest;
 import com.senior.spm.controller.request.RegisterProfessorRequest;
+import com.senior.spm.controller.response.AuditLogResponse;
 import com.senior.spm.controller.response.ErrorMessage;
 import com.senior.spm.controller.response.LlmConfigResponse;
+import com.senior.spm.controller.response.PagedAuditLogResponse;
+import com.senior.spm.entity.AuditLog;
 import com.senior.spm.exception.AlreadyExistsException;
+import com.senior.spm.service.AuditLogService;
 import com.senior.spm.service.LlmConfigService;
 import com.senior.spm.service.StaffUserService;
 
@@ -27,11 +40,14 @@ public class AdminController {
 
     private final StaffUserService staffUserService;
     private final LlmConfigService llmConfigService;
+    private final AuditLogService auditLogService;
 
     public AdminController(StaffUserService staffUserService,
-                           LlmConfigService llmConfigService) {
+                           LlmConfigService llmConfigService,
+                           AuditLogService auditLogService) {
         this.staffUserService = staffUserService;
         this.llmConfigService = llmConfigService;
+        this.auditLogService = auditLogService;
     }
 
     @PostMapping("/register-professor")
@@ -56,5 +72,30 @@ public class AdminController {
     public ResponseEntity<Map<String, String>> updateLlmConfig(@Valid @RequestBody LlmConfigRequest request) {
         llmConfigService.updateLlmKey(request.getApiKey());
         return ResponseEntity.ok(Map.of("message", "LLM API key updated successfully"));
+    }
+
+    @GetMapping("/audit-logs")
+    public ResponseEntity<PagedAuditLogResponse> getAuditLogs(
+            @RequestParam(required = false) AuditLog.UserType userType,
+            @RequestParam(required = false) AuditLog.Category category,
+            @RequestParam(required = false) AuditLog.Outcome outcome,
+            @RequestParam(required = false) UUID userId,
+            @RequestParam(required = false)
+                @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime from,
+            @RequestParam(required = false)
+                @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime to,
+            @PageableDefault(size = 20, sort = "occurredAt", direction = Sort.Direction.DESC)
+                Pageable pageable) {
+
+        if (pageable.getPageSize() > 100) {
+            pageable = PageRequest.of(pageable.getPageNumber(), 100, pageable.getSort());
+        }
+
+        Page<AuditLogResponse> page = auditLogService.query(
+                userType, category, outcome, userId, from, to, pageable);
+
+        return ResponseEntity.ok(new PagedAuditLogResponse(
+                page.getContent(), page.getNumber(), page.getSize(),
+                page.getTotalElements(), page.getTotalPages()));
     }
 }

--- a/backend/src/test/java/com/senior/spm/controller/AuditLogControllerTest.java
+++ b/backend/src/test/java/com/senior/spm/controller/AuditLogControllerTest.java
@@ -1,0 +1,205 @@
+package com.senior.spm.controller;
+
+import static org.hamcrest.Matchers.everyItem;
+import static org.hamcrest.Matchers.is;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+
+import com.senior.spm.entity.AuditLog;
+import com.senior.spm.entity.AuditLog.Category;
+import com.senior.spm.entity.AuditLog.Outcome;
+import com.senior.spm.entity.AuditLog.UserType;
+import com.senior.spm.entity.StaffUser;
+import com.senior.spm.entity.StaffUser.Role;
+import com.senior.spm.entity.Student;
+import com.senior.spm.repository.AuditLogRepository;
+import com.senior.spm.repository.StaffUserRepository;
+import com.senior.spm.repository.StudentRepository;
+import com.senior.spm.service.JWTService;
+
+/**
+ * Integration tests for GET /api/admin/audit-logs (issue #302).
+ *
+ * Covers:
+ *   – Auth matrix: coordinator → 200, admin → 200, professor → 403, student → 403, no token → 401
+ *   – size=500 → capped to 100 in response
+ *   – ?outcome=FAILURE filter returns only FAILURE rows
+ *   – ?userId=not-a-uuid → 400
+ */
+@SpringBootTest
+@AutoConfigureMockMvc
+@TestPropertySource(locations = "classpath:test.properties")
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+class AuditLogControllerTest {
+
+    @Autowired MockMvc mockMvc;
+    @Autowired JWTService jwtService;
+
+    @Autowired AuditLogRepository auditLogRepository;
+    @Autowired StaffUserRepository staffUserRepository;
+    @Autowired StudentRepository studentRepository;
+
+    private String coordinatorToken;
+    private String adminToken;
+    private String professorToken;
+    private String studentToken;
+
+    @BeforeEach
+    void setUp() {
+        cleanAll();
+
+        StaffUser coordinator = staffUserRepository.save(makeStaff("coord@al-test.com", Role.Coordinator));
+        StaffUser admin       = staffUserRepository.save(makeStaff("admin@al-test.com", Role.Admin));
+        StaffUser professor   = staffUserRepository.save(makeStaff("prof@al-test.com",  Role.Professor));
+        Student   student     = studentRepository.save(makeStudent("44400000001"));
+
+        coordinatorToken = jwtService.issueToken(coordinator);
+        adminToken       = jwtService.issueToken(admin);
+        professorToken   = jwtService.issueToken(professor);
+        studentToken     = jwtService.issueToken(student);
+    }
+
+    @AfterEach
+    void tearDown() {
+        cleanAll();
+    }
+
+    // ═══════════════════════════════════════════════════════════════════
+    //  Auth matrix
+    // ═══════════════════════════════════════════════════════════════════
+
+    @Test
+    @DisplayName("Coordinator GET /audit-logs → 200")
+    void coordinator_returns200() throws Exception {
+        mockMvc.perform(get("/api/admin/audit-logs")
+                .header("Authorization", "Bearer " + coordinatorToken))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    @DisplayName("Admin GET /audit-logs → 200")
+    void admin_returns200() throws Exception {
+        mockMvc.perform(get("/api/admin/audit-logs")
+                .header("Authorization", "Bearer " + adminToken))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    @DisplayName("Professor GET /audit-logs → 403")
+    void professor_returns403() throws Exception {
+        mockMvc.perform(get("/api/admin/audit-logs")
+                .header("Authorization", "Bearer " + professorToken))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @DisplayName("Student GET /audit-logs → 403")
+    void student_returns403() throws Exception {
+        mockMvc.perform(get("/api/admin/audit-logs")
+                .header("Authorization", "Bearer " + studentToken))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @DisplayName("No token GET /audit-logs → 401")
+    void noToken_returns401() throws Exception {
+        mockMvc.perform(get("/api/admin/audit-logs"))
+                .andExpect(status().isUnauthorized());
+    }
+
+    // ═══════════════════════════════════════════════════════════════════
+    //  Page size cap
+    // ═══════════════════════════════════════════════════════════════════
+
+    @Test
+    @DisplayName("size=500 in request → size=100 in response (cap enforced)")
+    void pageSizeCap_500becomes100() throws Exception {
+        mockMvc.perform(get("/api/admin/audit-logs")
+                .header("Authorization", "Bearer " + coordinatorToken)
+                .param("size", "500"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.size").value(100));
+    }
+
+    // ═══════════════════════════════════════════════════════════════════
+    //  Outcome filter
+    // ═══════════════════════════════════════════════════════════════════
+
+    @Test
+    @DisplayName("?outcome=FAILURE returns only FAILURE rows")
+    void outcomeFilter_returnsOnlyFailureRows() throws Exception {
+        auditLogRepository.save(makeAuditLog("STAFF_LOGIN", Category.AUTH, Outcome.SUCCESS));
+        auditLogRepository.save(makeAuditLog("STAFF_LOGIN", Category.AUTH, Outcome.FAILURE));
+        auditLogRepository.save(makeAuditLog("STAFF_LOGIN", Category.AUTH, Outcome.FAILURE));
+
+        mockMvc.perform(get("/api/admin/audit-logs")
+                .header("Authorization", "Bearer " + coordinatorToken)
+                .param("outcome", "FAILURE"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.totalElements").value(2))
+                .andExpect(jsonPath("$.content[*].outcome", everyItem(is("FAILURE"))));
+    }
+
+    // ═══════════════════════════════════════════════════════════════════
+    //  Invalid UUID → 400
+    // ═══════════════════════════════════════════════════════════════════
+
+    @Test
+    @DisplayName("?userId=not-a-uuid → 400")
+    void invalidUuid_returns400() throws Exception {
+        mockMvc.perform(get("/api/admin/audit-logs")
+                .header("Authorization", "Bearer " + coordinatorToken)
+                .param("userId", "not-a-uuid"))
+                .andExpect(status().isBadRequest());
+    }
+
+    // ═══════════════════════════════════════════════════════════════════
+    //  Helpers
+    // ═══════════════════════════════════════════════════════════════════
+
+    private void cleanAll() {
+        auditLogRepository.deleteAll();
+        studentRepository.deleteAll();
+        staffUserRepository.deleteAll();
+    }
+
+    private StaffUser makeStaff(String mail, Role role) {
+        StaffUser u = new StaffUser();
+        u.setMail(mail);
+        u.setPasswordHash("$2a$10$dXJ3SW6G7P50lGmMkkmwe.20cQQubK3.HZWzG3YB1tlRy.fqvM/BG");
+        u.setRole(role);
+        u.setAdvisorCapacity(5);
+        return u;
+    }
+
+    private Student makeStudent(String studentId) {
+        Student s = new Student();
+        s.setStudentId(studentId);
+        return s;
+    }
+
+    private AuditLog makeAuditLog(String action, Category category, Outcome outcome) {
+        AuditLog log = new AuditLog();
+        log.setUserType(UserType.STAFF);
+        log.setAction(action);
+        log.setCategory(category);
+        log.setOutcome(outcome);
+        log.setOccurredAt(LocalDateTime.now(ZoneId.of("UTC")));
+        return log;
+    }
+}

--- a/backend/tests/postman/README.md
+++ b/backend/tests/postman/README.md
@@ -110,3 +110,24 @@ Run with Newman:
 ```
 newman run P5-SprintTracking_postman_collection.json -e SPM-Local.postman_environment.json
 ```
+
+---
+
+## Issue #306 — Audit Log Query API
+
+Collection: `audit-log-query.postman_collection.json`
+Environment template: `spm-test.env.json`
+
+18 test cases for `GET /api/admin/audit-logs` (TC-QUERY-01..13, TC-SEC-01..05).
+
+**Folders:**
+- `0. Setup — Get Tokens` — logs in as Coordinator / Admin / Professor and stores tokens into env vars
+- `1. Security (TC-SEC-01..05)` — auth matrix: Professor→403, Student→403, no token→401, malformed token→401, Coordinator→200
+- `2. Query (TC-QUERY-01..13)` — filter by outcome/userType/category, pagination (size cap at 100, page params), DESC sort, invalid UUID→400
+
+**Required env vars:** `baseUrl`, `coordinatorMail`, `coordinatorPassword`, `adminMail`, `adminPassword`, `professorMail`, `professorPassword`, `studentToken`
+
+Fill `spm-test.env.json` with your local credentials (never commit secrets), then run:
+```
+npx newman run audit-log-query.postman_collection.json --environment spm-test.env.json
+```

--- a/backend/tests/postman/audit-log-query.postman_collection.json
+++ b/backend/tests/postman/audit-log-query.postman_collection.json
@@ -1,0 +1,575 @@
+{
+  "info": {
+    "_postman_id": "c8f2e1a0-3b74-4d9e-8c56-f1a2b3c4d5e6",
+    "name": "Audit Log Query API — Issue #306",
+    "description": "18 test cases for GET /api/admin/audit-logs (TC-QUERY-01..13, TC-SEC-01..05).\n\nRun:\n  npx newman run audit-log-query.postman_collection.json --environment spm-test.env.json\n\nSetup folder must run first — it logs in and stores tokens into environment variables.",
+    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+  },
+  "item": [
+    {
+      "name": "0. Setup — Get Tokens",
+      "item": [
+        {
+          "name": "Login as Coordinator",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test(\"Coordinator login → 200\", () => pm.response.to.have.status(200));",
+                  "const body = pm.response.json();",
+                  "pm.environment.set(\"coordinatorToken\", body.token);"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [{ "key": "Content-Type", "value": "application/json" }],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"mail\": \"{{coordinatorMail}}\",\n  \"password\": \"{{coordinatorPassword}}\"\n}",
+              "options": { "raw": { "language": "json" } }
+            },
+            "url": "{{baseUrl}}/api/auth/login"
+          },
+          "response": []
+        },
+        {
+          "name": "Login as Admin",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test(\"Admin login → 200\", () => pm.response.to.have.status(200));",
+                  "const body = pm.response.json();",
+                  "pm.environment.set(\"adminToken\", body.token);"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [{ "key": "Content-Type", "value": "application/json" }],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"mail\": \"{{adminMail}}\",\n  \"password\": \"{{adminPassword}}\"\n}",
+              "options": { "raw": { "language": "json" } }
+            },
+            "url": "{{baseUrl}}/api/auth/login"
+          },
+          "response": []
+        },
+        {
+          "name": "Login as Professor",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test(\"Professor login → 200\", () => pm.response.to.have.status(200));",
+                  "const body = pm.response.json();",
+                  "pm.environment.set(\"professorToken\", body.token);"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [{ "key": "Content-Type", "value": "application/json" }],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"mail\": \"{{professorMail}}\",\n  \"password\": \"{{professorPassword}}\"\n}",
+              "options": { "raw": { "language": "json" } }
+            },
+            "url": "{{baseUrl}}/api/auth/login"
+          },
+          "response": []
+        }
+      ]
+    },
+    {
+      "name": "1. Security (TC-SEC-01..05)",
+      "item": [
+        {
+          "name": "TC-SEC-01 — Professor → 403",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test(\"TC-SEC-01: Professor receives 403 Forbidden\", () => {",
+                  "    pm.response.to.have.status(403);",
+                  "});"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ],
+          "request": {
+            "method": "GET",
+            "header": [
+              { "key": "Authorization", "value": "Bearer {{professorToken}}" }
+            ],
+            "url": "{{baseUrl}}/api/admin/audit-logs"
+          },
+          "response": []
+        },
+        {
+          "name": "TC-SEC-02 — Student → 403",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test(\"TC-SEC-02: Student receives 403 Forbidden\", () => {",
+                  "    pm.response.to.have.status(403);",
+                  "});"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ],
+          "request": {
+            "method": "GET",
+            "header": [
+              { "key": "Authorization", "value": "Bearer {{studentToken}}" }
+            ],
+            "url": "{{baseUrl}}/api/admin/audit-logs"
+          },
+          "response": []
+        },
+        {
+          "name": "TC-SEC-03 — No token → 401",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test(\"TC-SEC-03: Missing token receives 401 Unauthorized\", () => {",
+                  "    pm.response.to.have.status(401);",
+                  "});"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ],
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": "{{baseUrl}}/api/admin/audit-logs"
+          },
+          "response": []
+        },
+        {
+          "name": "TC-SEC-04 — Malformed token → 401",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test(\"TC-SEC-04: Malformed token receives 401 Unauthorized\", () => {",
+                  "    pm.response.to.have.status(401);",
+                  "});"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ],
+          "request": {
+            "method": "GET",
+            "header": [
+              { "key": "Authorization", "value": "Bearer not.a.valid.jwt.token" }
+            ],
+            "url": "{{baseUrl}}/api/admin/audit-logs"
+          },
+          "response": []
+        },
+        {
+          "name": "TC-SEC-05 — Coordinator → 200",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test(\"TC-SEC-05: Coordinator receives 200 OK\", () => {",
+                  "    pm.response.to.have.status(200);",
+                  "});"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ],
+          "request": {
+            "method": "GET",
+            "header": [
+              { "key": "Authorization", "value": "Bearer {{coordinatorToken}}" }
+            ],
+            "url": "{{baseUrl}}/api/admin/audit-logs"
+          },
+          "response": []
+        }
+      ]
+    },
+    {
+      "name": "2. Query (TC-QUERY-01..13)",
+      "item": [
+        {
+          "name": "TC-QUERY-01 — No filters: response schema valid",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test(\"TC-QUERY-01: status 200\", () => pm.response.to.have.status(200));",
+                  "pm.test(\"TC-QUERY-01: response has required pagination fields\", () => {",
+                  "    const body = pm.response.json();",
+                  "    pm.expect(body).to.have.property(\"content\").that.is.an(\"array\");",
+                  "    pm.expect(body).to.have.property(\"page\").that.is.a(\"number\");",
+                  "    pm.expect(body).to.have.property(\"size\").that.is.a(\"number\");",
+                  "    pm.expect(body).to.have.property(\"totalElements\").that.is.a(\"number\");",
+                  "    pm.expect(body).to.have.property(\"totalPages\").that.is.a(\"number\");",
+                  "});"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ],
+          "request": {
+            "method": "GET",
+            "header": [
+              { "key": "Authorization", "value": "Bearer {{adminToken}}" }
+            ],
+            "url": "{{baseUrl}}/api/admin/audit-logs"
+          },
+          "response": []
+        },
+        {
+          "name": "TC-QUERY-02 — ?outcome=FAILURE: every row outcome is FAILURE",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test(\"TC-QUERY-02: status 200\", () => pm.response.to.have.status(200));",
+                  "pm.test(\"TC-QUERY-02: every content[*].outcome equals FAILURE\", () => {",
+                  "    const rows = pm.response.json().content;",
+                  "    rows.forEach(row => pm.expect(row.outcome).to.eql(\"FAILURE\"));",
+                  "});"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ],
+          "request": {
+            "method": "GET",
+            "header": [
+              { "key": "Authorization", "value": "Bearer {{coordinatorToken}}" }
+            ],
+            "url": "{{baseUrl}}/api/admin/audit-logs?outcome=FAILURE"
+          },
+          "response": []
+        },
+        {
+          "name": "TC-QUERY-03 — ?outcome=SUCCESS: every row outcome is SUCCESS",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test(\"TC-QUERY-03: status 200\", () => pm.response.to.have.status(200));",
+                  "pm.test(\"TC-QUERY-03: every content[*].outcome equals SUCCESS\", () => {",
+                  "    const rows = pm.response.json().content;",
+                  "    rows.forEach(row => pm.expect(row.outcome).to.eql(\"SUCCESS\"));",
+                  "});"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ],
+          "request": {
+            "method": "GET",
+            "header": [
+              { "key": "Authorization", "value": "Bearer {{coordinatorToken}}" }
+            ],
+            "url": "{{baseUrl}}/api/admin/audit-logs?outcome=SUCCESS"
+          },
+          "response": []
+        },
+        {
+          "name": "TC-QUERY-04 — ?userType=STAFF: every row userType is STAFF",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test(\"TC-QUERY-04: status 200\", () => pm.response.to.have.status(200));",
+                  "pm.test(\"TC-QUERY-04: every content[*].userType equals STAFF\", () => {",
+                  "    const rows = pm.response.json().content;",
+                  "    rows.forEach(row => pm.expect(row.userType).to.eql(\"STAFF\"));",
+                  "});"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ],
+          "request": {
+            "method": "GET",
+            "header": [
+              { "key": "Authorization", "value": "Bearer {{coordinatorToken}}" }
+            ],
+            "url": "{{baseUrl}}/api/admin/audit-logs?userType=STAFF"
+          },
+          "response": []
+        },
+        {
+          "name": "TC-QUERY-05 — ?userType=STUDENT: every row userType is STUDENT",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test(\"TC-QUERY-05: status 200\", () => pm.response.to.have.status(200));",
+                  "pm.test(\"TC-QUERY-05: every content[*].userType equals STUDENT\", () => {",
+                  "    const rows = pm.response.json().content;",
+                  "    rows.forEach(row => pm.expect(row.userType).to.eql(\"STUDENT\"));",
+                  "});"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ],
+          "request": {
+            "method": "GET",
+            "header": [
+              { "key": "Authorization", "value": "Bearer {{coordinatorToken}}" }
+            ],
+            "url": "{{baseUrl}}/api/admin/audit-logs?userType=STUDENT"
+          },
+          "response": []
+        },
+        {
+          "name": "TC-QUERY-06 — ?category=AUTH: every row category is AUTH",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test(\"TC-QUERY-06: status 200\", () => pm.response.to.have.status(200));",
+                  "pm.test(\"TC-QUERY-06: every content[*].category equals AUTH\", () => {",
+                  "    const rows = pm.response.json().content;",
+                  "    rows.forEach(row => pm.expect(row.category).to.eql(\"AUTH\"));",
+                  "});"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ],
+          "request": {
+            "method": "GET",
+            "header": [
+              { "key": "Authorization", "value": "Bearer {{coordinatorToken}}" }
+            ],
+            "url": "{{baseUrl}}/api/admin/audit-logs?category=AUTH"
+          },
+          "response": []
+        },
+        {
+          "name": "TC-QUERY-07 — ?category=GROUP: every row category is GROUP",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test(\"TC-QUERY-07: status 200\", () => pm.response.to.have.status(200));",
+                  "pm.test(\"TC-QUERY-07: every content[*].category equals GROUP\", () => {",
+                  "    const rows = pm.response.json().content;",
+                  "    rows.forEach(row => pm.expect(row.category).to.eql(\"GROUP\"));",
+                  "});"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ],
+          "request": {
+            "method": "GET",
+            "header": [
+              { "key": "Authorization", "value": "Bearer {{coordinatorToken}}" }
+            ],
+            "url": "{{baseUrl}}/api/admin/audit-logs?category=GROUP"
+          },
+          "response": []
+        },
+        {
+          "name": "TC-QUERY-08 — ?category=ADVISOR: every row category is ADVISOR",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test(\"TC-QUERY-08: status 200\", () => pm.response.to.have.status(200));",
+                  "pm.test(\"TC-QUERY-08: every content[*].category equals ADVISOR\", () => {",
+                  "    const rows = pm.response.json().content;",
+                  "    rows.forEach(row => pm.expect(row.category).to.eql(\"ADVISOR\"));",
+                  "});"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ],
+          "request": {
+            "method": "GET",
+            "header": [
+              { "key": "Authorization", "value": "Bearer {{coordinatorToken}}" }
+            ],
+            "url": "{{baseUrl}}/api/admin/audit-logs?category=ADVISOR"
+          },
+          "response": []
+        },
+        {
+          "name": "TC-QUERY-09 — ?category=GRADING: every row category is GRADING",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test(\"TC-QUERY-09: status 200\", () => pm.response.to.have.status(200));",
+                  "pm.test(\"TC-QUERY-09: every content[*].category equals GRADING\", () => {",
+                  "    const rows = pm.response.json().content;",
+                  "    rows.forEach(row => pm.expect(row.category).to.eql(\"GRADING\"));",
+                  "});"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ],
+          "request": {
+            "method": "GET",
+            "header": [
+              { "key": "Authorization", "value": "Bearer {{coordinatorToken}}" }
+            ],
+            "url": "{{baseUrl}}/api/admin/audit-logs?category=GRADING"
+          },
+          "response": []
+        },
+        {
+          "name": "TC-QUERY-10 — ?size=500: response size capped at 100",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test(\"TC-QUERY-10: status 200\", () => pm.response.to.have.status(200));",
+                  "pm.test(\"TC-QUERY-10: response.size <= 100 when size=500 requested\", () => {",
+                  "    const body = pm.response.json();",
+                  "    pm.expect(body.size).to.be.at.most(100);",
+                  "});"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ],
+          "request": {
+            "method": "GET",
+            "header": [
+              { "key": "Authorization", "value": "Bearer {{coordinatorToken}}" }
+            ],
+            "url": "{{baseUrl}}/api/admin/audit-logs?size=500"
+          },
+          "response": []
+        },
+        {
+          "name": "TC-QUERY-11 — ?page=0&size=5: pagination params respected",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test(\"TC-QUERY-11: status 200\", () => pm.response.to.have.status(200));",
+                  "pm.test(\"TC-QUERY-11: response.page equals 0\", () => {",
+                  "    pm.expect(pm.response.json().page).to.eql(0);",
+                  "});",
+                  "pm.test(\"TC-QUERY-11: response.size <= 5\", () => {",
+                  "    pm.expect(pm.response.json().size).to.be.at.most(5);",
+                  "});",
+                  "pm.test(\"TC-QUERY-11: content length <= 5\", () => {",
+                  "    pm.expect(pm.response.json().content.length).to.be.at.most(5);",
+                  "});"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ],
+          "request": {
+            "method": "GET",
+            "header": [
+              { "key": "Authorization", "value": "Bearer {{coordinatorToken}}" }
+            ],
+            "url": "{{baseUrl}}/api/admin/audit-logs?page=0&size=5"
+          },
+          "response": []
+        },
+        {
+          "name": "TC-QUERY-12 — Default sort: content ordered DESC by occurredAt",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test(\"TC-QUERY-12: status 200\", () => pm.response.to.have.status(200));",
+                  "const rows = pm.response.json().content;",
+                  "if (rows && rows.length >= 2) {",
+                  "    pm.test(\"TC-QUERY-12: content[0].occurredAt >= content[1].occurredAt (DESC)\", () => {",
+                  "        const t0 = new Date(rows[0].occurredAt).getTime();",
+                  "        const t1 = new Date(rows[1].occurredAt).getTime();",
+                  "        pm.expect(t0).to.be.at.least(t1);",
+                  "    });",
+                  "} else {",
+                  "    pm.test(\"TC-QUERY-12: DESC sort (skipped — fewer than 2 rows in DB)\", () => true);",
+                  "}"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ],
+          "request": {
+            "method": "GET",
+            "header": [
+              { "key": "Authorization", "value": "Bearer {{coordinatorToken}}" }
+            ],
+            "url": "{{baseUrl}}/api/admin/audit-logs"
+          },
+          "response": []
+        },
+        {
+          "name": "TC-QUERY-13 — ?userId=not-a-uuid → 400",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test(\"TC-QUERY-13: malformed UUID in userId param returns 400\", () => {",
+                  "    pm.response.to.have.status(400);",
+                  "});"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ],
+          "request": {
+            "method": "GET",
+            "header": [
+              { "key": "Authorization", "value": "Bearer {{coordinatorToken}}" }
+            ],
+            "url": "{{baseUrl}}/api/admin/audit-logs?userId=not-a-uuid"
+          },
+          "response": []
+        }
+      ]
+    }
+  ]
+}

--- a/backend/tests/postman/spm-test.env.example.json
+++ b/backend/tests/postman/spm-test.env.example.json
@@ -1,0 +1,73 @@
+{
+  "_postman_variable_scope": "environment",
+  "name": "SPM Local — Issue #306",
+  "values": [
+    {
+      "key": "baseUrl",
+      "value": "http://localhost:8080",
+      "type": "default",
+      "enabled": true
+    },
+    {
+      "key": "coordinatorMail",
+      "value": "",
+      "type": "default",
+      "enabled": true
+    },
+    {
+      "key": "coordinatorPassword",
+      "value": "",
+      "type": "secret",
+      "enabled": true
+    },
+    {
+      "key": "coordinatorToken",
+      "value": "",
+      "type": "default",
+      "enabled": true
+    },
+    {
+      "key": "adminMail",
+      "value": "",
+      "type": "default",
+      "enabled": true
+    },
+    {
+      "key": "adminPassword",
+      "value": "",
+      "type": "secret",
+      "enabled": true
+    },
+    {
+      "key": "adminToken",
+      "value": "",
+      "type": "default",
+      "enabled": true
+    },
+    {
+      "key": "professorMail",
+      "value": "",
+      "type": "default",
+      "enabled": true
+    },
+    {
+      "key": "professorPassword",
+      "value": "",
+      "type": "secret",
+      "enabled": true
+    },
+    {
+      "key": "professorToken",
+      "value": "",
+      "type": "default",
+      "enabled": true
+    },
+    {
+      "key": "studentToken",
+      "value": "",
+      "type": "default",
+      "enabled": true,
+      "_comment": "GitHub OAuth token — obtain manually via POST /api/auth/github and paste here"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Add `audit-log-query.postman_collection.json` with 18 test cases for `GET /api/admin/audit-logs` (TC-QUERY-01..13, TC-SEC-01..05)
- Add `spm-test.env.json` environment template (no secrets — all values left blank)
- Update `tests/postman/README.md` with usage instructions

## Test Cases
| Group | TCs | What's covered |
|-------|-----|----------------|
| Security | TC-SEC-01..05 | Professor→403, Student→403, no token→401, malformed token→401, Coordinator→200 |
| Query | TC-QUERY-01..09 | Schema validation, outcome/userType/category filters |
| Pagination | TC-QUERY-10..12 | size=500 capped to 100, page params, DESC sort by occurredAt |
| Validation | TC-QUERY-13 | `?userId=not-a-uuid` → 400 |

## How to run
1. Fill `spm-test.env.json` with local credentials
2. `npx newman run audit-log-query.postman_collection.json --environment spm-test.env.json`

Closes #306

