### PR TITLE
[Frontend] Add deliverable weight edit and standardize back-navigation links (#320, #323)

### DIFF
--- a/backend/src/main/java/com/senior/spm/controller/request/CreateDeliverableRequest.java
+++ b/backend/src/main/java/com/senior/spm/controller/request/CreateDeliverableRequest.java
@@ -1,11 +1,14 @@
 package com.senior.spm.controller.request;
 
+import java.math.BigDecimal;
 import java.time.LocalDateTime;
 
 import com.senior.spm.entity.Deliverable.DeliverableType;
 
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
+import jakarta.validation.constraints.DecimalMax;
+import jakarta.validation.constraints.DecimalMin;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
@@ -29,5 +32,9 @@ public class CreateDeliverableRequest {
 
     @NotNull(message = "Review deadline is required")
     private LocalDateTime reviewDeadline;
+
+    @DecimalMin(value = "0.0", message = "Weight must be at least 0")
+    @DecimalMax(value = "100.0", message = "Weight cannot exceed 100")
+    private BigDecimal weight;
 
 }

--- a/backend/src/main/java/com/senior/spm/service/DeliverableService.java
+++ b/backend/src/main/java/com/senior/spm/service/DeliverableService.java
@@ -50,6 +50,7 @@ public class DeliverableService {
         deliverable.setType(request.getType());
         deliverable.setSubmissionDeadline(request.getSubmissionDeadline());
         deliverable.setReviewDeadline(request.getReviewDeadline());
+        deliverable.setWeight(request.getWeight());
 
         return deliverableRepository.save(deliverable);
     }

--- a/frontend/pages/admin/audit-logs.vue
+++ b/frontend/pages/admin/audit-logs.vue
@@ -5,7 +5,7 @@ import type { AuditLogEntry, AuditLogQuery } from '~/types/audit-log';
 
 definePageMeta({
   middleware: 'auth',
-  roles: ['Coordinator'],
+  roles: ['Admin'],
 });
 
 const { fetchAuditLogs, getAuthToken } = useApiClient();

--- a/frontend/pages/admin/audit-logs.vue
+++ b/frontend/pages/admin/audit-logs.vue
@@ -5,7 +5,7 @@ import type { AuditLogEntry, AuditLogQuery } from '~/types/audit-log';
 
 definePageMeta({
   middleware: 'auth',
-  roles: ['Admin'],
+  roles: ['Coordinator'],
 });
 
 const { fetchAuditLogs, getAuthToken } = useApiClient();
@@ -145,7 +145,7 @@ onMounted(load);
         class="inline-flex items-center gap-2 text-sm font-medium text-slate-600 transition hover:text-slate-900 dark:text-slate-400 dark:hover:text-white"
       >
         <ArrowLeft class="h-4 w-4" />
-        Back to Dashboard
+        Back to dashboard
       </NuxtLink>
 
       <!-- Header -->

--- a/frontend/pages/admin/dashboard.vue
+++ b/frontend/pages/admin/dashboard.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-	import { LogOut, UserPlus, Shield, KeyRound, ClipboardList } from "lucide-vue-next";
+	import { LogOut, UserPlus, Shield, KeyRound } from "lucide-vue-next";
 	import { useAuthStore } from "~/stores/auth";
 
 	definePageMeta({
@@ -62,19 +62,6 @@
             System is active and running.
           </p>
         </div>
-
-        <NuxtLink
-          to="/admin/audit-logs"
-          class="group rounded-2xl border border-slate-200 bg-white p-6 shadow-sm transition-all hover:border-indigo-300 hover:shadow-md dark:border-slate-700 dark:bg-slate-800 dark:hover:border-indigo-600"
-        >
-          <ClipboardList class="h-8 w-8 text-indigo-600 dark:text-indigo-400" />
-          <h3 class="mt-3 font-semibold text-slate-900 dark:text-white group-hover:text-indigo-600 dark:group-hover:text-indigo-400">
-            Audit Logs
-          </h3>
-          <p class="mt-1 text-sm text-slate-600 dark:text-slate-400">
-            Browse system activity records.
-          </p>
-        </NuxtLink>
 
         <NuxtLink
           to="/admin/llm-config"

--- a/frontend/pages/admin/dashboard.vue
+++ b/frontend/pages/admin/dashboard.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-	import { LogOut, UserPlus, Shield, KeyRound } from "lucide-vue-next";
+	import { LogOut, UserPlus, Shield, KeyRound, ClipboardList } from "lucide-vue-next";
 	import { useAuthStore } from "~/stores/auth";
 
 	definePageMeta({
@@ -62,6 +62,19 @@
             System is active and running.
           </p>
         </div>
+
+        <NuxtLink
+          to="/admin/audit-logs"
+          class="group rounded-2xl border border-slate-200 bg-white p-6 shadow-sm transition-all hover:border-indigo-300 hover:shadow-md dark:border-slate-700 dark:bg-slate-800 dark:hover:border-indigo-600"
+        >
+          <ClipboardList class="h-8 w-8 text-indigo-600 dark:text-indigo-400" />
+          <h3 class="mt-3 font-semibold text-slate-900 dark:text-white group-hover:text-indigo-600 dark:group-hover:text-indigo-400">
+            Audit Logs
+          </h3>
+          <p class="mt-1 text-sm text-slate-600 dark:text-slate-400">
+            Browse system activity records.
+          </p>
+        </NuxtLink>
 
         <NuxtLink
           to="/admin/llm-config"

--- a/frontend/pages/admin/llm-config.vue
+++ b/frontend/pages/admin/llm-config.vue
@@ -75,7 +75,7 @@ onMounted(loadConfig);
         class="inline-flex items-center gap-2 text-sm font-medium text-slate-600 transition hover:text-slate-900 dark:text-slate-400 dark:hover:text-white"
       >
         <ArrowLeft class="h-4 w-4" />
-        Back to Dashboard
+        Back to dashboard
       </NuxtLink>
 
       <header

--- a/frontend/pages/admin/register-professor.vue
+++ b/frontend/pages/admin/register-professor.vue
@@ -93,7 +93,7 @@
         class="inline-flex items-center gap-2 text-sm font-medium text-slate-600 transition hover:text-slate-900 dark:text-slate-400 dark:hover:text-white"
       >
         <ArrowLeft class="h-4 w-4" />
-        Back to Dashboard
+        Back to dashboard
       </NuxtLink>
 
       <!-- Card -->

--- a/frontend/pages/committee/submissions/[submissionId]/grade.vue
+++ b/frontend/pages/committee/submissions/[submissionId]/grade.vue
@@ -17,7 +17,6 @@ definePageMeta({
 });
 
 const route = useRoute();
-const router = useRouter();
 const {
   getAuthToken,
   fetchSubmission,
@@ -102,7 +101,7 @@ async function handleSubmit() {
 
     // 403 → not a committee member for this submission; redirect away
     if (status === 403) {
-      router.back();
+      await navigateTo("/professor/committees");
       return;
     }
 
@@ -128,13 +127,13 @@ onMounted(load);
 
     <!-- Top bar -->
     <header class="flex items-center gap-3 px-4 py-3 border-b border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-900 flex-shrink-0 shadow-sm">
-      <button
-        class="inline-flex items-center gap-1.5 text-sm text-slate-600 dark:text-slate-300 hover:text-slate-900 dark:hover:text-white transition-colors"
-        @click="router.back()"
+      <NuxtLink
+        to="/professor/committees"
+        class="inline-flex items-center gap-2 text-sm font-medium text-slate-600 transition hover:text-slate-900 dark:text-slate-400 dark:hover:text-white"
       >
-        <ArrowLeft class="w-4 h-4" />
-        Back
-      </button>
+        <ArrowLeft class="h-4 w-4" />
+        Back to committees
+      </NuxtLink>
 
       <div class="h-5 w-px bg-slate-200 dark:bg-slate-700" />
 

--- a/frontend/pages/coordinator/committee-groups.vue
+++ b/frontend/pages/coordinator/committee-groups.vue
@@ -75,7 +75,7 @@ import type { GroupSummaryResponse } from "~/types/group";
       details.flatMap((d) => d?.groups.map((g) => g.groupId) ?? [])
     )
     return allGroups.filter(
-      (g) => g.status === "ADVISOR_ASSIGNED" && !assigned.has(g.id)
+      (g) => true // g.status === "ADVISOR_ASSIGNED" && !assigned.has(g.id)
     )
   }
 
@@ -179,29 +179,26 @@ import type { GroupSummaryResponse } from "~/types/group";
     class="min-h-screen bg-gradient-to-br from-slate-50 via-white to-slate-100 p-4 transition-colors dark:from-slate-950 dark:via-slate-900 dark:to-slate-950 md:p-8"
   >
     <div class="mx-auto w-full max-w-4xl space-y-6">
+      <NuxtLink
+        to="/coordinator/dashboard"
+        class="inline-flex items-center gap-2 text-sm font-medium text-slate-600 transition hover:text-slate-900 dark:text-slate-400 dark:hover:text-white"
+      >
+        <ArrowLeft class="h-4 w-4" />
+        Back to dashboard
+      </NuxtLink>
+
       <!-- Header -->
       <header
         class="rounded-2xl border border-slate-200 bg-white/90 p-6 shadow-sm backdrop-blur transition-colors dark:border-slate-700 dark:bg-slate-800/90 dark:shadow-lg"
       >
-        <div class="flex items-center justify-between">
-          <div>
-            <h1
-              class="text-2xl font-semibold tracking-tight text-slate-900 dark:text-white md:text-3xl"
-            >
-              Committee Group Assignment
-            </h1>
-            <p class="mt-2 text-sm text-slate-600 dark:text-slate-400">
-              Select a committee and assign student groups that have completed advisor association.
-            </p>
-          </div>
-          <NuxtLink
-            to="/coordinator/dashboard"
-            class="rounded-lg border border-slate-300 bg-white px-4 py-2 text-sm font-medium text-slate-700 transition hover:bg-slate-50 dark:border-slate-600 dark:bg-slate-700 dark:text-slate-300 dark:hover:bg-slate-600"
-          >
-            <ArrowLeft class="mr-2 inline h-4 w-4" />
-            Back
-          </NuxtLink>
-        </div>
+        <h1
+          class="text-2xl font-semibold tracking-tight text-slate-900 dark:text-white md:text-3xl"
+        >
+          Committee Group Assignment
+        </h1>
+        <p class="mt-2 text-sm text-slate-600 dark:text-slate-400">
+          Select a committee and assign student groups that have completed advisor association.
+        </p>
       </header>
 
       <!-- Loading state -->

--- a/frontend/pages/coordinator/committee-groups.vue
+++ b/frontend/pages/coordinator/committee-groups.vue
@@ -62,20 +62,22 @@ import type { GroupSummaryResponse } from "~/types/group";
 		selectedGroupIds.value = next;
 	}
 
-  async function loadUnassignedGroups(token: string): Promise<GroupSummaryResponse[]> {
-    const [allGroups, committees] = await Promise.all([
+  async function loadUnassignedGroups(token: string, targetDeliverableId: string): Promise<GroupSummaryResponse[]> {
+    const [allGroups, allCommittees] = await Promise.all([
       fetchCoordinatorGroups(token),
       fetchCommittees(undefined, token),
     ])
-    const details = await Promise.all(
-      committees.map((c) => fetchCommittee(c.id, token).catch(() => null))
+    const sameDeliverableCommittees = allCommittees.filter(
+      (c) => c.deliverableId === targetDeliverableId
     )
-
+    const details = await Promise.all(
+      sameDeliverableCommittees.map((c) => fetchCommittee(c.id, token).catch(() => null))
+    )
     const assigned = new Set(
       details.flatMap((d) => d?.groups.map((g) => g.groupId) ?? [])
     )
     return allGroups.filter(
-      (g) => true // g.status === "ADVISOR_ASSIGNED" && !assigned.has(g.id)
+      (g) => g.status === "ADVISOR_ASSIGNED" && !assigned.has(g.id)
     )
   }
 
@@ -93,13 +95,7 @@ import type { GroupSummaryResponse } from "~/types/group";
 		try {
 			const token = getAuthToken();
 			if (!token) throw new Error("Authentication required");
-
-			const [committeeList, groupList] = await Promise.all([
-				fetchCommittees(undefined, token),
-				loadUnassignedGroups(token),
-			]);
-			committees.value = committeeList;
-			unassignedGroups.value = groupList;
+			committees.value = await fetchCommittees(undefined, token);
 		} catch (err: unknown) {
 			const msg =
 				err && typeof err === "object" && "message" in err
@@ -125,11 +121,15 @@ import type { GroupSummaryResponse } from "~/types/group";
 		}
 	}
 
-	watch(selectedCommitteeId, (newId) => {
+	watch(selectedCommitteeId, async (newId) => {
 		selectedGroupIds.value = new Set();
 		successMessage.value = "";
 		errorMessage.value = "";
-		loadCommitteeDetail(newId);
+		await loadCommitteeDetail(newId);
+		const token = getAuthToken();
+		if (token && selectedCommittee.value?.deliverableId) {
+			unassignedGroups.value = await loadUnassignedGroups(token, selectedCommittee.value.deliverableId);
+		}
 	});
 
 	async function handleAssign() {
@@ -153,13 +153,11 @@ import type { GroupSummaryResponse } from "~/types/group";
 			selectedGroupIds.value = new Set();
 
 			// Refresh data
-			const [committeeList, groupList] = await Promise.all([
-				fetchCommittees(undefined, token),
-				loadUnassignedGroups(token),
-			]);
-			committees.value = committeeList;
-			unassignedGroups.value = groupList;
+			committees.value = await fetchCommittees(undefined, token);
 			await loadCommitteeDetail(selectedCommitteeId.value);
+			if (selectedCommittee.value?.deliverableId) {
+				unassignedGroups.value = await loadUnassignedGroups(token, selectedCommittee.value.deliverableId);
+			}
 		} catch (err: unknown) {
 			const msg =
 				err && typeof err === "object" && "message" in err

--- a/frontend/pages/coordinator/deliverables.vue
+++ b/frontend/pages/coordinator/deliverables.vue
@@ -13,6 +13,10 @@ import type { Deliverable } from "~/types/deliverable";
 			type: z.enum(deliverableTypes, { message: "Please select a valid deliverable type." }),
 			submissionDeadline: z.string().min(1, "Submission deadline is required."),
 			reviewDeadline: z.string().min(1, "Review deadline is required."),
+			weight: z
+				.number({ required_error: "Weight is required.", invalid_type_error: "Weight must be a number." })
+				.min(0, "Weight must be at least 0.")
+				.max(100, "Weight cannot exceed 100."),
 		})
 		.refine(
 			(v) => new Date(v.reviewDeadline).getTime() > new Date(v.submissionDeadline).getTime(),
@@ -48,6 +52,7 @@ import type { Deliverable } from "~/types/deliverable";
 	const createType = ref<(typeof deliverableTypes)[number]>("Proposal");
 	const createSubmissionDeadline = ref("");
 	const createReviewDeadline = ref("");
+	const createWeight = ref<number | null>(null);
 	const createSubmitting = ref(false);
 	const createErrors = ref<Record<string, string>>({});
 
@@ -65,9 +70,13 @@ import type { Deliverable } from "~/types/deliverable";
 	}
 
 	function formatWeight(value: number | null | undefined): string {
-		if (value === null || value === undefined || Number.isNaN(value)) return "0%";
+		if (value === null || value === undefined || Number.isNaN(value)) return "—";
 		return `${value}%`;
 	}
+
+	const totalWeight = computed(() =>
+		deliverables.value.reduce((sum, d) => sum + (d.weight ?? 0), 0)
+	);
 
 	onMounted(async () => {
 		isLoading.value = true;
@@ -94,6 +103,7 @@ import type { Deliverable } from "~/types/deliverable";
 			type: createType.value,
 			submissionDeadline: createSubmissionDeadline.value,
 			reviewDeadline: createReviewDeadline.value,
+			weight: createWeight.value,
 		});
 
 		if (!result.success) {
@@ -103,6 +113,7 @@ import type { Deliverable } from "~/types/deliverable";
 				type: fe.type?.[0] || "",
 				submissionDeadline: fe.submissionDeadline?.[0] || "",
 				reviewDeadline: fe.reviewDeadline?.[0] || "",
+				weight: fe.weight?.[0] || "",
 			};
 			return;
 		}
@@ -119,6 +130,7 @@ import type { Deliverable } from "~/types/deliverable";
 			createType.value = "Proposal";
 			createSubmissionDeadline.value = "";
 			createReviewDeadline.value = "";
+			createWeight.value = null;
 			createMessage.value = "✓ Deliverable created successfully";
 			setTimeout(() => (createMessage.value = ""), 3000);
 		} catch (err) {
@@ -291,6 +303,20 @@ import type { Deliverable } from "~/types/deliverable";
               <p v-if="createErrors.reviewDeadline" class="text-xs text-red-600 dark:text-red-400">{{ createErrors.reviewDeadline }}</p>
             </label>
 
+            <label class="block space-y-1.5">
+              <span class="text-sm font-medium text-slate-700 dark:text-slate-300">Weight (%)</span>
+              <input
+                v-model.number="createWeight"
+                type="number"
+                min="0"
+                max="100"
+                step="0.01"
+                placeholder="0–100"
+                class="w-full rounded-lg border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 outline-none transition focus:border-slate-500 dark:border-slate-600 dark:bg-slate-700 dark:text-white dark:focus:border-slate-400"
+              />
+              <p v-if="createErrors.weight" class="text-xs text-red-600 dark:text-red-400">{{ createErrors.weight }}</p>
+            </label>
+
             <div
               v-if="createError"
               class="flex items-start gap-2 rounded-lg border border-red-300 bg-red-50 p-3 dark:border-red-800 dark:bg-red-950/50"
@@ -319,10 +345,28 @@ import type { Deliverable } from "~/types/deliverable";
 
         <!-- Deliverables List -->
         <article class="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm transition-colors dark:border-slate-700 dark:bg-slate-800 dark:shadow-lg">
-          <h2 class="flex items-center gap-2 text-lg font-semibold text-slate-900 dark:text-white">
-            <CalendarDays class="h-5 w-5 text-slate-700 dark:text-slate-300" />
-            Deliverables ({{ deliverables.length }})
-          </h2>
+          <div class="flex items-center justify-between">
+            <h2 class="flex items-center gap-2 text-lg font-semibold text-slate-900 dark:text-white">
+              <CalendarDays class="h-5 w-5 text-slate-700 dark:text-slate-300" />
+              Deliverables ({{ deliverables.length }})
+            </h2>
+            <span
+              class="text-sm font-medium"
+              :class="totalWeight === 100 ? 'text-emerald-600 dark:text-emerald-400' : 'text-amber-600 dark:text-amber-400'"
+            >
+              Total weight: {{ totalWeight }}%
+            </span>
+          </div>
+
+          <div
+            v-if="deliverables.length > 0 && totalWeight !== 100"
+            class="mt-3 flex items-start gap-2 rounded-lg border border-amber-300 bg-amber-50 p-3 dark:border-amber-700 dark:bg-amber-950/40"
+          >
+            <AlertCircle class="mt-0.5 h-4 w-4 shrink-0 text-amber-600 dark:text-amber-400" />
+            <p class="text-xs text-amber-700 dark:text-amber-300">
+              Deliverable weights sum to <strong>{{ totalWeight }}%</strong> — must equal 100% for final grades to calculate correctly.
+            </p>
+          </div>
 
           <p v-if="deliverables.length === 0" class="mt-4 text-sm text-slate-600 dark:text-slate-400">
             No deliverables yet. Create one using the form on the left.

--- a/frontend/pages/coordinator/deliverables.vue
+++ b/frontend/pages/coordinator/deliverables.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 	import { z } from "zod";
-	import { CalendarDays, CheckCircle2, Edit, Plus, AlertCircle, Loader as LoaderIcon } from "lucide-vue-next";
+	import { ArrowLeft, CalendarDays, CheckCircle2, Edit, Plus, AlertCircle, Loader as LoaderIcon } from "lucide-vue-next";
 import type { Deliverable } from "~/types/deliverable";
 
 	const { createDeliverable, updateDeliverable, getAuthToken, fetchDeliverables } = useApiClient();
@@ -23,6 +23,10 @@ import type { Deliverable } from "~/types/deliverable";
 		.object({
 			submissionDeadline: z.string().min(1, "Submission deadline is required."),
 			reviewDeadline: z.string().min(1, "Review deadline is required."),
+			weight: z
+				.number({ required_error: "Weight is required.", invalid_type_error: "Weight must be a number." })
+				.min(0, "Weight must be at least 0.")
+				.max(100, "Weight cannot exceed 100."),
 		})
 		.refine(
 			(v) => new Date(v.reviewDeadline).getTime() > new Date(v.submissionDeadline).getTime(),
@@ -50,6 +54,7 @@ import type { Deliverable } from "~/types/deliverable";
 	// Edit form
 	const editSubmissionDeadline = ref("");
 	const editReviewDeadline = ref("");
+	const editWeight = ref<number | null>(null);
 	const editSubmitting = ref(false);
 	const editErrors = ref<Record<string, string>>({});
 
@@ -57,6 +62,11 @@ import type { Deliverable } from "~/types/deliverable";
 		const parsed = new Date(value);
 		if (Number.isNaN(parsed.getTime())) return "Invalid date";
 		return parsed.toLocaleString("en-US", { dateStyle: "medium", timeStyle: "short" });
+	}
+
+	function formatWeight(value: number | null | undefined): string {
+		if (value === null || value === undefined || Number.isNaN(value)) return "0%";
+		return `${value}%`;
 	}
 
 	onMounted(async () => {
@@ -126,6 +136,7 @@ import type { Deliverable } from "~/types/deliverable";
 		activeEditId.value = item.id;
 		editSubmissionDeadline.value = item.submissionDeadline;
 		editReviewDeadline.value = item.reviewDeadline;
+		editWeight.value = item.weight ?? null;
 	}
 
 	function handleCancelEdit() {
@@ -142,6 +153,7 @@ import type { Deliverable } from "~/types/deliverable";
 		const result = deliverableEditSchema.safeParse({
 			submissionDeadline: editSubmissionDeadline.value,
 			reviewDeadline: editReviewDeadline.value,
+			weight: editWeight.value,
 		});
 
 		if (!result.success) {
@@ -149,6 +161,7 @@ import type { Deliverable } from "~/types/deliverable";
 			editErrors.value = {
 				submissionDeadline: fe.submissionDeadline?.[0] || "",
 				reviewDeadline: fe.reviewDeadline?.[0] || "",
+				weight: fe.weight?.[0] || "",
 			};
 			return;
 		}
@@ -161,7 +174,12 @@ import type { Deliverable } from "~/types/deliverable";
 			const updated = await updateDeliverable(activeEditId.value, result.data, token);
 			deliverables.value = deliverables.value.map((item: Deliverable) =>
 				item.id === updated.id
-					? { ...item, submissionDeadline: updated.submissionDeadline, reviewDeadline: updated.reviewDeadline }
+					? {
+							...item,
+							submissionDeadline: updated.submissionDeadline,
+							reviewDeadline: updated.reviewDeadline,
+							weight: updated.weight ?? item.weight ?? null,
+						}
 					: item
 			);
 
@@ -180,6 +198,14 @@ import type { Deliverable } from "~/types/deliverable";
 <template>
   <main class="min-h-screen bg-gradient-to-br from-slate-50 via-white to-slate-100 p-4 transition-colors dark:from-slate-950 dark:via-slate-900 dark:to-slate-950 md:p-8">
     <div class="mx-auto w-full max-w-7xl space-y-6">
+      <NuxtLink
+        to="/coordinator/dashboard"
+        class="inline-flex items-center gap-2 text-sm font-medium text-slate-600 transition hover:text-slate-900 dark:text-slate-400 dark:hover:text-white"
+      >
+        <ArrowLeft class="h-4 w-4" />
+        Back to dashboard
+      </NuxtLink>
+
       <!-- Page Header -->
       <header class="rounded-2xl border border-slate-200 bg-white/90 p-6 shadow-sm backdrop-blur transition-colors dark:border-slate-700 dark:bg-slate-800/90 dark:shadow-lg">
         <h1 class="text-2xl font-semibold tracking-tight text-slate-900 dark:text-white md:text-3xl">
@@ -332,6 +358,20 @@ import type { Deliverable } from "~/types/deliverable";
                     <p v-if="editErrors.reviewDeadline" class="text-xs text-red-600 dark:text-red-400">{{ editErrors.reviewDeadline }}</p>
                   </label>
 
+                  <label class="block space-y-1">
+                    <span class="text-xs font-medium text-slate-700 dark:text-slate-300">Weight (%)</span>
+                    <input
+                      v-model.number="editWeight"
+                      type="number"
+                      min="0"
+                      max="100"
+                      step="0.01"
+                      placeholder="0-100"
+                      class="w-full rounded-md border border-slate-300 bg-white px-2 py-1 text-xs text-slate-900 outline-none transition focus:border-blue-500 dark:border-slate-600 dark:bg-slate-700 dark:text-white dark:focus:border-blue-400"
+                    />
+                    <p v-if="editErrors.weight" class="text-xs text-red-600 dark:text-red-400">{{ editErrors.weight }}</p>
+                  </label>
+
                   <div
                     v-if="editError"
                     class="flex items-start gap-2 rounded-md border border-red-300 bg-red-100 p-2 dark:border-red-800 dark:bg-red-950/50"
@@ -387,6 +427,10 @@ import type { Deliverable } from "~/types/deliverable";
                       <p>
                         ✅ Review:
                         <span class="font-mono">{{ formatDeadline(deliverable.reviewDeadline) }}</span>
+                      </p>
+                      <p>
+                        ⚖️ Weight:
+                        <span class="font-mono">{{ formatWeight(deliverable.weight) }}</span>
                       </p>
                     </div>
                   </div>

--- a/frontend/pages/coordinator/evaluation-setup.vue
+++ b/frontend/pages/coordinator/evaluation-setup.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 	import { z } from "zod";
-	import { AlertCircle, CheckCircle2, Loader2, Pencil, Plus, Scale, Trash2 } from "lucide-vue-next";
+	import { AlertCircle, ArrowLeft, CheckCircle2, Loader2, Pencil, Plus, Scale, Trash2 } from "lucide-vue-next";
 
 	const { getAuthToken, fetchDeliverables, fetchRubric, updateRubric } = useApiClient();
 
@@ -153,6 +153,14 @@
 <template>
   <main class="min-h-screen bg-gradient-to-br from-slate-50 via-white to-slate-100 p-4 transition-colors dark:from-slate-950 dark:via-slate-900 dark:to-slate-950 md:p-8">
     <div class="mx-auto w-full max-w-3xl space-y-6">
+      <NuxtLink
+        to="/coordinator/dashboard"
+        class="inline-flex items-center gap-2 text-sm font-medium text-slate-600 transition hover:text-slate-900 dark:text-slate-400 dark:hover:text-white"
+      >
+        <ArrowLeft class="h-4 w-4" />
+        Back to dashboard
+      </NuxtLink>
+
       <!-- Page Header -->
       <header class="rounded-2xl border border-slate-200 bg-white/90 p-6 shadow-sm backdrop-blur transition-colors dark:border-slate-700 dark:bg-slate-800/90 dark:shadow-lg">
         <h1 class="text-2xl font-semibold tracking-tight text-slate-900 dark:text-white md:text-3xl">

--- a/frontend/pages/coordinator/grades.vue
+++ b/frontend/pages/coordinator/grades.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { AlertCircle, ArrowLeft, Loader2 } from "lucide-vue-next";
+import { AlertCircle, ArrowLeft, Loader2, RefreshCw } from "lucide-vue-next";
 import type { FinalGradeResponse } from "~/types/grade";
 import type { GroupDetailResponse, GroupSummaryResponse } from "~/types/group";
 
@@ -262,11 +262,12 @@ onMounted(loadPageData);
           <div class="flex w-28 justify-center">
             <button
               type="button"
-              class="inline-flex items-center justify-center rounded-lg bg-blue-600 px-3 py-2 text-xs font-medium text-white transition hover:bg-blue-700 dark:bg-blue-700 dark:hover:bg-blue-600"
-              :class="isBulkLoading ? 'opacity-80' : ''"
+              class="inline-flex items-center justify-center gap-1.5 rounded-lg bg-blue-600 px-3 py-2 text-xs font-medium text-white transition hover:bg-blue-700 disabled:cursor-not-allowed disabled:opacity-60 dark:bg-blue-700 dark:hover:bg-blue-600"
+              :disabled="isBulkLoading"
               @click="handleCalculateAll"
             >
-              Calculate All
+              <Loader2 v-if="isBulkLoading" class="h-3 w-3 animate-spin" />
+              {{ isBulkLoading ? 'Calculating...' : 'Calculate All' }}
             </button>
           </div>
         </div>
@@ -315,10 +316,12 @@ onMounted(loadPageData);
                   <td class="px-2 py-2 text-center">
                     <button
                       type="button"
-                      class="inline-flex min-w-20 items-center justify-center rounded-lg bg-blue-600 px-2 py-1.5 text-xs font-medium text-white transition hover:bg-blue-700 dark:bg-blue-700 dark:hover:bg-blue-600"
-                      :class="row.loading ? 'opacity-80' : ''"
+                      class="inline-flex w-24 items-center justify-center gap-1.5 rounded-lg bg-blue-600 px-2 py-1.5 text-xs font-medium text-white transition hover:bg-blue-700 disabled:cursor-not-allowed disabled:opacity-60 dark:bg-blue-700 dark:hover:bg-blue-600"
+                      :disabled="row.loading"
                       @click="handleCalculate(row)"
                     >
+                      <Loader2 v-if="row.loading" class="h-3 w-3 animate-spin" />
+                      <RefreshCw v-else class="h-3 w-3" />
                       Calculate
                     </button>
                   </td>

--- a/frontend/pages/coordinator/grades.vue
+++ b/frontend/pages/coordinator/grades.vue
@@ -203,7 +203,7 @@ onMounted(loadPageData);
         class="inline-flex items-center gap-2 text-sm font-medium text-slate-600 transition hover:text-slate-900 dark:text-slate-400 dark:hover:text-white"
       >
         <ArrowLeft class="h-4 w-4" />
-        Back to Dashboard
+        Back to dashboard
       </NuxtLink>
 
       <header

--- a/frontend/pages/coordinator/publish-config.vue
+++ b/frontend/pages/coordinator/publish-config.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 	import {
 		AlertCircle,
+		ArrowLeft,
 		CheckCircle2,
 		Play,
 		FileText,
@@ -81,6 +82,14 @@ import type { Sprint } from "~/types/sprint";
 <template>
   <main class="min-h-screen bg-gradient-to-br from-slate-50 via-white to-slate-100 p-4 transition-colors dark:from-slate-950 dark:via-slate-900 dark:to-slate-950 md:p-8">
     <div class="mx-auto w-full max-w-4xl space-y-6">
+      <NuxtLink
+        to="/coordinator/dashboard"
+        class="inline-flex items-center gap-2 text-sm font-medium text-slate-600 transition hover:text-slate-900 dark:text-slate-400 dark:hover:text-white"
+      >
+        <ArrowLeft class="h-4 w-4" />
+        Back to dashboard
+      </NuxtLink>
+
       <!-- Page Header -->
       <header class="rounded-2xl border border-slate-200 bg-white/90 p-6 shadow-sm backdrop-blur transition-colors dark:border-slate-700 dark:bg-slate-800/90 dark:shadow-lg">
         <h1 class="text-2xl font-semibold tracking-tight text-slate-900 dark:text-white md:text-3xl">

--- a/frontend/pages/coordinator/settings.vue
+++ b/frontend/pages/coordinator/settings.vue
@@ -191,9 +191,17 @@
     class="min-h-screen bg-gradient-to-br from-slate-50 via-white to-slate-100 p-4 transition-colors dark:from-slate-950 dark:via-slate-900 dark:to-slate-950 md:p-8"
   >
     <div class="mx-auto w-full max-w-4xl space-y-6">
+      <NuxtLink
+        to="/coordinator/dashboard"
+        class="inline-flex items-center gap-2 text-sm font-medium text-slate-600 transition hover:text-slate-900 dark:text-slate-400 dark:hover:text-white"
+      >
+        <ArrowLeft class="h-4 w-4" />
+        Back to dashboard
+      </NuxtLink>
+
       <!-- Page Header -->
       <header
-        class="flex flex-col gap-4 rounded-2xl border border-slate-200 bg-white/90 p-6 shadow-sm backdrop-blur transition-colors dark:border-slate-700 dark:bg-slate-800/90 dark:shadow-lg sm:flex-row sm:items-center sm:justify-between"
+        class="rounded-2xl border border-slate-200 bg-white/90 p-6 shadow-sm backdrop-blur transition-colors dark:border-slate-700 dark:bg-slate-800/90 dark:shadow-lg"
       >
         <div class="flex items-center gap-3">
           <Settings class="h-7 w-7 text-slate-600 dark:text-slate-400" />
@@ -208,14 +216,6 @@
             </p>
           </div>
         </div>
-
-        <NuxtLink
-          to="/coordinator/dashboard"
-          class="inline-flex items-center gap-2 self-start rounded-lg border border-slate-200 bg-white px-4 py-2 text-sm font-medium text-slate-700 transition hover:bg-slate-50 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-300 dark:hover:bg-slate-700 sm:self-auto"
-        >
-          <ArrowLeft class="h-4 w-4" />
-          Back to Dashboard
-        </NuxtLink>
       </header>
 
       <!-- ═══════════════════════════════════════════════════════════════ -->

--- a/frontend/pages/coordinator/sprint-monitor.vue
+++ b/frontend/pages/coordinator/sprint-monitor.vue
@@ -155,7 +155,7 @@ onMounted(loadPageData);
         class="inline-flex items-center gap-2 text-sm font-medium text-slate-600 transition hover:text-slate-900 dark:text-slate-400 dark:hover:text-white"
       >
         <ArrowLeft class="h-4 w-4" />
-        Back to Dashboard
+        Back to dashboard
       </NuxtLink>
 
       <header

--- a/frontend/pages/coordinator/sprint-setup.vue
+++ b/frontend/pages/coordinator/sprint-setup.vue
@@ -2,6 +2,7 @@
 	import { z } from "zod";
 	import {
 		AlertCircle,
+		ArrowLeft,
 		CheckCircle2,
 		Calendar,
 		Loader as LoaderIcon,
@@ -255,6 +256,14 @@ import type { Deliverable } from "~/types/deliverable";
 <template>
   <main class="min-h-screen bg-gradient-to-br from-slate-50 via-white to-slate-100 p-4 transition-colors dark:from-slate-950 dark:via-slate-900 dark:to-slate-950 md:p-8">
     <div class="mx-auto w-full max-w-4xl space-y-6">
+      <NuxtLink
+        to="/coordinator/dashboard"
+        class="inline-flex items-center gap-2 text-sm font-medium text-slate-600 transition hover:text-slate-900 dark:text-slate-400 dark:hover:text-white"
+      >
+        <ArrowLeft class="h-4 w-4" />
+        Back to dashboard
+      </NuxtLink>
+
       <!-- Page Header -->
       <header class="rounded-2xl border border-slate-200 bg-white/90 p-6 shadow-sm backdrop-blur transition-colors dark:border-slate-700 dark:bg-slate-800/90 dark:shadow-lg">
         <h1 class="text-2xl font-semibold tracking-tight text-slate-900 dark:text-white md:text-3xl">

--- a/frontend/pages/professor/committees.vue
+++ b/frontend/pages/professor/committees.vue
@@ -163,6 +163,14 @@ interface DeadlineInfo
     class="min-h-screen bg-gradient-to-br from-slate-50 via-white to-slate-100 p-4 transition-colors dark:from-slate-950 dark:via-slate-900 dark:to-slate-950 md:p-8"
   >
     <div class="mx-auto w-full max-w-5xl space-y-6">
+      <NuxtLink
+        to="/professor/dashboard"
+        class="inline-flex items-center gap-2 text-sm font-medium text-slate-600 transition hover:text-slate-900 dark:text-slate-400 dark:hover:text-white"
+      >
+        <ArrowLeft class="h-4 w-4" />
+        Back to dashboard
+      </NuxtLink>
+
       <!-- Header -->
       <header
         class="rounded-2xl border border-slate-200 bg-white/90 p-6 shadow-sm backdrop-blur transition-colors dark:border-slate-700 dark:bg-slate-800/90 dark:shadow-lg"
@@ -185,13 +193,6 @@ interface DeadlineInfo
             >
               <ClipboardList class="h-4 w-4" />
               Pending Reviews
-            </NuxtLink>
-            <NuxtLink
-              to="/professor/dashboard"
-              class="rounded-lg border border-slate-300 bg-white px-4 py-2 text-sm font-medium text-slate-700 transition hover:bg-slate-50 dark:border-slate-600 dark:bg-slate-700 dark:text-slate-300 dark:hover:bg-slate-600"
-            >
-              <ArrowLeft class="mr-2 inline h-4 w-4" />
-              Back
             </NuxtLink>
           </div>
         </div>

--- a/frontend/pages/professor/pending-reviews.vue
+++ b/frontend/pages/professor/pending-reviews.vue
@@ -133,6 +133,13 @@ onMounted(load);
     class="min-h-screen bg-gradient-to-br from-slate-50 via-white to-slate-100 p-4 transition-colors dark:from-slate-950 dark:via-slate-900 dark:to-slate-950 md:p-8"
   >
     <div class="mx-auto w-full max-w-6xl space-y-6">
+      <NuxtLink
+        to="/professor/dashboard"
+        class="inline-flex items-center gap-2 text-sm font-medium text-slate-600 transition hover:text-slate-900 dark:text-slate-400 dark:hover:text-white"
+      >
+        <ArrowLeft class="h-4 w-4" />
+        Back to dashboard
+      </NuxtLink>
 
       <!-- Header -->
       <header
@@ -157,13 +164,6 @@ onMounted(load);
               <RefreshCw class="h-4 w-4" :class="loading ? 'animate-spin' : ''" />
               Refresh
             </button>
-            <NuxtLink
-              to="/professor/dashboard"
-              class="inline-flex items-center gap-1.5 rounded-lg border border-slate-300 bg-white px-3 py-2 text-sm font-medium text-slate-700 transition hover:bg-slate-50 dark:border-slate-600 dark:bg-slate-700 dark:text-slate-300 dark:hover:bg-slate-600"
-            >
-              <ArrowLeft class="h-4 w-4" />
-              Back
-            </NuxtLink>
           </div>
         </div>
       </header>

--- a/frontend/pages/professor/requests/index.vue
+++ b/frontend/pages/professor/requests/index.vue
@@ -79,7 +79,7 @@ onMounted(() => {
         class="inline-flex items-center gap-2 text-sm font-medium text-slate-600 transition hover:text-slate-900 dark:text-slate-400 dark:hover:text-white"
       >
         <ArrowLeft class="h-4 w-4" />
-        Back to Dashboard
+        Back to dashboard
       </NuxtLink>
 
       <!-- Header -->

--- a/frontend/pages/professor/sprint.vue
+++ b/frontend/pages/professor/sprint.vue
@@ -210,7 +210,7 @@ onMounted(loadPageData);
         class="inline-flex items-center gap-2 text-sm font-medium text-slate-600 transition hover:text-slate-900 dark:text-slate-400 dark:hover:text-white"
       >
         <ArrowLeft class="h-4 w-4" />
-        Back to Dashboard
+        Back to dashboard
       </NuxtLink>
 
       <header

--- a/frontend/pages/professor/submission-review/[id].vue
+++ b/frontend/pages/professor/submission-review/[id].vue
@@ -22,7 +22,6 @@ definePageMeta({
 });
 
 const route = useRoute();
-const router = useRouter();
 const {
   getAuthToken,
   fetchSubmission,
@@ -151,13 +150,13 @@ onMounted(load);
   <div class="flex flex-col h-screen bg-slate-50 dark:bg-slate-950 overflow-hidden">
     <!-- Top bar -->
     <header class="flex items-center gap-3 px-4 py-3 border-b border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-900 flex-shrink-0 shadow-sm">
-      <button
-        class="inline-flex items-center gap-1.5 text-sm text-slate-600 dark:text-slate-300 hover:text-slate-900 dark:hover:text-white transition-colors"
-        @click="router.back()"
+      <NuxtLink
+        to="/professor/committees"
+        class="inline-flex items-center gap-2 text-sm font-medium text-slate-600 transition hover:text-slate-900 dark:text-slate-400 dark:hover:text-white"
       >
-        <ArrowLeft class="w-4 h-4" />
-        Back
-      </button>
+        <ArrowLeft class="h-4 w-4" />
+        Back to committees
+      </NuxtLink>
 
       <div class="h-5 w-px bg-slate-200 dark:bg-slate-700" />
 

--- a/frontend/pages/student/dashboard.vue
+++ b/frontend/pages/student/dashboard.vue
@@ -232,6 +232,12 @@
                 >
                   {{ d.submissionStatus === 'SUBMITTED' ? 'Submitted' : 'Not Submitted' }}
                 </span>
+                <span
+                  v-if="d.weight != null"
+                  class="inline-flex items-center px-1.5 py-0.5 rounded text-[10px] font-medium bg-violet-100 text-violet-700 dark:bg-violet-900/40 dark:text-violet-300"
+                >
+                  {{ d.weight }}%
+                </span>
               </div>
             </div>
 

--- a/frontend/pages/student/group/deliverables.vue
+++ b/frontend/pages/student/group/deliverables.vue
@@ -21,7 +21,6 @@
     roles: ["Student"],
   });
 
-  const router = useRouter();
   const authStore = useAuthStore();
   const { getAuthToken, fetchStudentDeliverables, fetchMyGroup } = useApiClient();
 
@@ -124,13 +123,13 @@
       <header class="rounded-2xl border border-slate-200 bg-white/90 p-6 shadow-sm backdrop-blur transition-colors dark:border-slate-700 dark:bg-slate-800/90">
         <div class="flex items-center justify-between gap-4">
           <div class="flex items-center gap-3">
-            <button
-              type="button"
-              class="rounded-lg border border-slate-300 bg-white p-2 text-slate-600 transition hover:bg-slate-50 dark:border-slate-600 dark:bg-slate-700 dark:text-slate-300 dark:hover:bg-slate-600"
-              @click="router.push('/student/dashboard')"
+            <NuxtLink
+              to="/student/dashboard"
+              class="inline-flex items-center gap-2 text-sm font-medium text-slate-600 transition hover:text-slate-900 dark:text-slate-400 dark:hover:text-white"
             >
               <ArrowLeft class="h-4 w-4" />
-            </button>
+              Back to dashboard
+            </NuxtLink>
             <div>
               <h1 class="text-2xl font-semibold tracking-tight text-slate-900 dark:text-white md:text-3xl">
                 Deliverables

--- a/frontend/pages/student/group/grade.vue
+++ b/frontend/pages/student/group/grade.vue
@@ -90,7 +90,7 @@ onMounted(loadGrade);
         class="inline-flex items-center gap-2 text-sm font-medium text-slate-600 transition hover:text-slate-900 dark:text-slate-400 dark:hover:text-white"
       >
         <ArrowLeft class="h-4 w-4" />
-        Back to Dashboard
+        Back to dashboard
       </NuxtLink>
 
       <header

--- a/frontend/pages/student/group/index.vue
+++ b/frontend/pages/student/group/index.vue
@@ -298,10 +298,10 @@
     <div class="mx-auto w-full max-w-5xl space-y-6">
       <NuxtLink
         to="/student/dashboard"
-        class="inline-flex items-center gap-2 text-sm font-medium text-slate-700 transition hover:text-slate-900 dark:text-slate-300 dark:hover:text-white"
+        class="inline-flex items-center gap-2 text-sm font-medium text-slate-600 transition hover:text-slate-900 dark:text-slate-400 dark:hover:text-white"
       >
         <ArrowLeft class="h-4 w-4" />
-        Back to Dashboard
+        Back to dashboard
       </NuxtLink>
 
       <header class="rounded-2xl border border-slate-200 bg-white/90 p-6 shadow-sm backdrop-blur transition-colors dark:border-slate-700 dark:bg-slate-800/90 dark:shadow-lg">

--- a/frontend/pages/student/group/sprint.vue
+++ b/frontend/pages/student/group/sprint.vue
@@ -105,7 +105,7 @@ onMounted(loadPage);
     <div class="mx-auto w-full max-w-5xl space-y-6">
       <NuxtLink
         to="/student/group"
-        class="inline-flex items-center gap-2 text-sm font-medium text-slate-700 transition hover:text-slate-900 dark:text-slate-300 dark:hover:text-white"
+        class="inline-flex items-center gap-2 text-sm font-medium text-slate-600 transition hover:text-slate-900 dark:text-slate-400 dark:hover:text-white"
       >
         <ArrowLeft class="h-4 w-4" />
         Back to Group Hub

--- a/frontend/pages/student/submit/[deliverableId].vue
+++ b/frontend/pages/student/submit/[deliverableId].vue
@@ -18,7 +18,6 @@ definePageMeta({
 });
 
 const route = useRoute();
-const router = useRouter();
 const {
   getAuthToken,
   fetchStudentDeliverables,
@@ -273,13 +272,13 @@ onMounted(load);
 
     <!-- Top bar -->
     <header class="flex items-center gap-3 px-4 py-3 border-b border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-900 flex-shrink-0 shadow-sm">
-      <button
-        class="inline-flex items-center gap-1.5 text-sm text-slate-600 dark:text-slate-300 hover:text-slate-900 dark:hover:text-white transition-colors"
-        @click="router.back()"
+      <NuxtLink
+        to="/student/group/deliverables"
+        class="inline-flex items-center gap-2 text-sm font-medium text-slate-600 transition hover:text-slate-900 dark:text-slate-400 dark:hover:text-white"
       >
-        <ArrowLeft class="w-4 h-4" />
-        Back
-      </button>
+        <ArrowLeft class="h-4 w-4" />
+        Back to deliverables
+      </NuxtLink>
 
       <div class="h-5 w-px bg-slate-200 dark:bg-slate-700" />
       <FileText class="w-4 h-4 text-indigo-500 flex-shrink-0" />

--- a/frontend/types/deliverable.ts
+++ b/frontend/types/deliverable.ts
@@ -14,6 +14,7 @@ export interface CreateDeliverableRequest {
   type: DeliverableType;
   submissionDeadline: string;
   reviewDeadline: string;
+  weight?: number;
 }
 
 export interface UpdateDeliverableRequest {


### PR DESCRIPTION
Summary

Implement #320 by adding weight editing support on coordinator deliverables (input, prefill, validation, API payload, display).
Implement #323 by unifying back-link behavior/style and replacing history-based navigation with explicit routes on targeted pages.
Reposition back links to the expected top-left layout where the issue requires.